### PR TITLE
fix the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,19 @@
 FROM rust:1.38
 WORKDIR /usr/src/krustlet
 
+RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+
 COPY Cargo.toml .
 COPY Cargo.lock .
+COPY justfile .
+COPY crates ./crates
 
 # Layer hack: Build an empty program to compile dependencies and place on their own layer.
 # This cuts down build time
 RUN mkdir -p ./src/ && \
     echo 'fn main() {}' > ./src/main.rs && \
     echo '' > ./src/lib.rs
-RUN cargo fetch
+RUN just prefetch
 RUN cargo build --release && \
     rm -rf ./target/release/.fingerprint/krustlet-*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.38
+FROM rust:1.41
 WORKDIR /usr/src/krustlet
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
@@ -10,14 +10,15 @@ COPY crates ./crates
 
 # Layer hack: Build an empty program to compile dependencies and place on their own layer.
 # This cuts down build time
-RUN mkdir -p ./src/ && \
-    echo 'fn main() {}' > ./src/main.rs && \
-    echo '' > ./src/lib.rs
+RUN mkdir -p ./examples/ && \
+    echo 'fn main() {}' > ./examples/empty.rs
 RUN just prefetch
-RUN cargo build --release && \
+RUN cargo build --example empty --release && \
     rm -rf ./target/release/.fingerprint/krustlet-*
 
 # Build real binaries now
+RUN rm ./src/main.rs ./src/lib.rs
 COPY ./src ./src
+
 RUN cargo build --release
 CMD ["/usr/src/krustlet/target/release/krustlet"]

--- a/justfile
+++ b/justfile
@@ -5,6 +5,9 @@ run: run-wascc
 build:
     cargo build
 
+prefetch:
+    cargo fetch --manifest-path ./Cargo.toml
+
 test:
     cargo fmt --all -- --check
     cargo clippy --workspace


### PR DESCRIPTION
In previous versions of the Dockerfile, we had some cool layer cache hacks to prevent the main dependency list from having to rebuild every time. I managed to partially reproduce, but not as effectively before.

What this version does is prefetch the packages (thus making a layer with the downloads already done) and then attempt to build the main libraries with an empty example (on a new layer), then building the final binaries on a last layer. This will speed up a little bit, but not as much as before.