### PR TITLE
feat(kubelet): Adds ability to configure nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,10 +268,28 @@ version = "2.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.11.0",
  "atty",
  "bitflags",
  "strsim 0.8.0",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.0.0-beta.1"
+source = "git+https://github.com/clap-rs/clap#19c20f7c00310900ce6667baedfe1190e20eeeab"
+dependencies = [
+ "ansi_term 0.12.1",
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "strsim 0.9.3",
+ "term_size 1.0.0-beta1",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -278,6 +305,18 @@ dependencies = [
  "failure",
  "log",
  "structopt 0.2.18",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.0-beta.1"
+source = "git+https://github.com/clap-rs/clap#19c20f7c00310900ce6667baedfe1190e20eeeab"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.16",
 ]
 
 [[package]]
@@ -306,9 +345,9 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "core-foundation"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
+checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -316,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
+checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "cpu-time"
@@ -1110,6 +1149,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "http"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1334,8 +1384,10 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "clap 3.0.0-beta.1",
  "failure",
  "futures",
+ "hostname",
  "hyper",
  "k8s-openapi",
  "kube",
@@ -1398,6 +1450,12 @@ checksum = "86dd2487cdfea56def77b88438a2c915fb45113c5319bfe7e14306ca4cd0b0e1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matches"
@@ -1490,9 +1548,9 @@ checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
 
 [[package]]
 name = "native-tls"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e"
+checksum = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
 dependencies = [
  "lazy_static",
  "libc",
@@ -2307,23 +2365,24 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ef2429d7cefe5fd28bd1d2ed41c944547d4ff84776f5935b456da44593a16df"
+checksum = "97bbedbe81904398b6ebb054b3e912f99d55807125790f3198ac990d98def5b0"
 dependencies = [
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
- "libc",
  "security-framework-sys",
 ]
 
 [[package]]
 name = "security-framework-sys"
-version = "0.3.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31493fc37615debb8c5090a7aeb4a9730bc61e77ab10b9af59f1a202284f895"
+checksum = "06fd2f23e31ef68dd2328cc383bd493142e46107a3a0e24f7d734e3f3b80fe4c"
 dependencies = [
  "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2503,7 +2562,7 @@ version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16c2cdbf9cc375f15d1b4141bc48aeef444806655cd0e904207edc8d68d86ed7"
 dependencies = [
- "clap",
+ "clap 2.33.0",
  "structopt-derive 0.2.18",
 ]
 
@@ -2513,7 +2572,7 @@ version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fe43617218c0805c6eb37160119dc3c548110a67786da7218d1c6555212f073"
 dependencies = [
- "clap",
+ "clap 2.33.0",
  "lazy_static",
  "structopt-derive 0.4.4",
 ]
@@ -2624,6 +2683,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "term_size"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327"
+dependencies = [
+ "kernel32-sys",
+ "libc",
+ "winapi 0.2.8",
+]
+
+[[package]]
+name = "term_size"
+version = "1.0.0-beta1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a17d8699e154863becdf18e4fd28bd0be27ca72856f54daf75c00f2566898f"
+dependencies = [
+ "kernel32-sys",
+ "libc",
+ "winapi 0.2.8",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2638,6 +2719,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
+ "term_size 0.3.1",
  "unicode-width",
 ]
 
@@ -2937,9 +3019,9 @@ dependencies = [
 
 [[package]]
 name = "wascap"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f016dc358574d9a7b0b64eaebf83dcca2d7d294642873c4e8be391aaa1cda9b5"
+checksum = "3839a08f49ae5be43fd695089262f75b156d5d37c26f31ab19f1089abf1a1770"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ tokio = { version = "0.2.13", features = ["macros"] }
 kube = "0.28.0"
 env_logger = "0.7.1"
 failure = "0.1"
-kubelet = { path = "./crates/kubelet", version = "0.1.0" }
+kubelet = { path = "./crates/kubelet", version = "0.1.0", features = ["cli"] }
 wascc-provider = { path = "./crates/wascc-provider", version = "0.1.0" }
 wasi-provider = { path = "./crates/wasi-provider", version = "0.1.0" }
 

--- a/crates/kubelet/Cargo.toml
+++ b/crates/kubelet/Cargo.toml
@@ -26,5 +26,9 @@ tokio  = { version = "0.2.13" }
 kube = { version = "0.28.0"  }
 k8s-openapi = { version = "0.7.1", default-features = false, features = ["v1_17"] }
 chrono = { version = "0.4", features = ["serde"] }
-clap = { git = "https://github.com/clap-rs/clap", features = ["wrap_help"] }
+clap = { git = "https://github.com/clap-rs/clap", features = ["wrap_help"], optional = true }
 hostname = "^0.3"
+
+[features]
+default = []
+cli = ["clap"]

--- a/crates/kubelet/Cargo.toml
+++ b/crates/kubelet/Cargo.toml
@@ -26,3 +26,5 @@ tokio  = { version = "0.2.13" }
 kube = { version = "0.28.0"  }
 k8s-openapi = { version = "0.7.1", default-features = false, features = ["v1_17"] }
 chrono = { version = "0.4", features = ["serde"] }
+clap = { git = "https://github.com/clap-rs/clap", features = ["wrap_help"] }
+hostname = "^0.3"

--- a/crates/kubelet/src/config.rs
+++ b/crates/kubelet/src/config.rs
@@ -1,12 +1,15 @@
-use clap::derive::Clap;
+#[cfg(feature = "cli")]
+use clap::derive::{FromArgMatches, IntoApp};
 use std::net::IpAddr;
 use std::net::ToSocketAddrs;
 
+const DEFAULT_PORT: u16 = 3000;
+
 /// The configuration needed for a kubelet to run properly. This can be
 /// configured manually in your code or if you are exposing a CLI, use the
-/// [get_from_flags method](get_from_flags). Use
-/// [default_config](Config::default_config) to generate a config with all of
-/// the default values set.
+/// [get_from_flags method](get_from_flags) (this requires the `cli` feature to
+/// be enabled). Use [default_config](Config::default_config) to generate a
+/// config with all of the default values set.
 #[derive(Clone)]
 pub struct Config {
     pub addr: IpAddr,
@@ -35,17 +38,51 @@ impl Config {
                 IpAddr::V4(_) => "0.0.0.0".parse().unwrap(),
                 IpAddr::V6(_) => "::".parse().unwrap(),
             },
-            port: 3000,
-            node_ip: default_node_ip(&hostname, preferred_ip_family)?,
+            port: DEFAULT_PORT,
+            node_ip: default_node_ip(&mut hostname.clone(), preferred_ip_family)?,
             node_name: sanitize_hostname(&hostname),
             hostname,
             arch: String::default(),
         })
     }
+    /// Parses all command line flags and sets the proper defaults. The version
+    /// of your application should be passed to set the proper version for the
+    /// CLI
+    #[cfg(feature = "cli")]
+    pub fn new_from_flags(version: &str) -> Self {
+        // TODO: Support config files too. config-rs and clap don't just work
+        // together, so there is no easy way to merge together everything right
+        // now. This function is here so we can do that data massaging and
+        // merging down the road
+        let app = Opts::into_app().version(version);
+        let opts = Opts::from_arg_matches(&app.get_matches());
+        // Copy the addr to avoid a partial move when computing node_ip
+        let addr = opts.addr;
+        let hostname = opts
+            .hostname
+            .unwrap_or_else(|| default_hostname().expect("unable to get default hostname"));
+        let node_ip = opts.node_ip.unwrap_or_else(|| {
+            default_node_ip(&mut hostname.clone(), &addr)
+                .expect("unable to get default node IP address")
+        });
+        Config {
+            addr,
+            port: 3000,
+            node_ip,
+            node_name: sanitize_hostname(&hostname),
+            hostname,
+            arch: String::default(),
+        }
+    }
 }
 
 // Opts contains the values that can be configured for kubelet
 #[derive(clap::Clap, Clone, Debug)]
+#[cfg(feature = "cli")]
+#[clap(
+    name = "krustlet",
+    about = "A kubelet for running WebAssembly workloads"
+)]
 pub struct Opts {
     #[clap(
         short = "a",
@@ -69,7 +106,7 @@ pub struct Opts {
         short = "n",
         long = "node-ip",
         env = "KRUSTLET_NODE_IP",
-        help = "The IP address of the node registered with the Kubernetes master. Defaults to the IP address of the node name in DNS and then IP address of the network interface used as the default gateway"
+        help = "The IP address of the node registered with the Kubernetes master. Defaults to the IP address of the node name in DNS as a best effort try at a default"
     )]
     node_ip: Option<IpAddr>,
 
@@ -88,35 +125,10 @@ pub struct Opts {
     node_name: Option<String>,
 }
 
-/// Parses all command line flags and sets the proper defaults
-pub fn get_from_flags() -> Config {
-    // TODO: Support config files too. config-rs and clap don't just work
-    // together, so there is no easy way to merge together everything right
-    // now. This function is here so we can do that data massaging and
-    // merging down the road
-    let opts = Opts::parse();
-    // Copy the addr to avoid a partial move when computing node_ip
-    let addr = opts.addr;
-    let hostname = opts
-        .hostname
-        .unwrap_or_else(|| default_hostname().expect("unable to get default hostname"));
-    let node_ip = opts.node_ip.unwrap_or_else(|| {
-        default_node_ip(&hostname, &addr).expect("unable to get default node IP address")
-    });
-    Config {
-        addr,
-        port: 3000,
-        node_ip,
-        node_name: sanitize_hostname(&hostname),
-        hostname,
-        arch: String::default(),
-    }
-}
-
 fn default_hostname() -> Result<String, failure::Error> {
     Ok(hostname::get()?
         .into_string()
-        .map_err(|_| format_err!("invalid hostname string"))?)
+        .map_err(|_| format_err!("invalid utf-8 hostname string"))?)
 }
 
 // Some hostnames (particularly local ones) can have uppercase letters, which is
@@ -124,7 +136,7 @@ fn default_hostname() -> Result<String, failure::Error> {
 // names
 fn sanitize_hostname(hostname: &str) -> String {
     // TODO: Are there other sanitation steps we should do here?
-    hostname.to_owned().to_lowercase()
+    hostname.to_lowercase()
 }
 
 // Attempt to get the node IP address in the following order (this follows the
@@ -132,17 +144,24 @@ fn sanitize_hostname(hostname: &str) -> String {
 // 1. Lookup the IP from node name by DNS
 // 2. Try to get the IP from the network interface used as default gateway
 //    (unimplemented for now because it doesn't work across platforms)
-fn default_node_ip(hostname: &str, preferred_ip_family: &IpAddr) -> Result<IpAddr, failure::Error> {
+fn default_node_ip(
+    hostname: &mut String,
+    preferred_ip_family: &IpAddr,
+) -> Result<IpAddr, failure::Error> {
     // NOTE: As of right now, we don't have cloud providers. In the future if
     // that is the case, we will need to add logic for looking up the IP and
     // hostname using the cloud provider as they do in the kubelet
     // To use the local resolver, we need to add a port to the hostname. Doesn't
     // matter which one, it just needs to be a valid socket address
-    let mut with_port = hostname.to_owned();
-    with_port.push_str(":80");
-    Ok(with_port
+    hostname.push_str(":80");
+    Ok(hostname
         .to_socket_addrs()?
-        .find(|i| !&i.ip().is_loopback() && is_same_ip_family(&i.ip(), preferred_ip_family))
+        .find(|i| {
+            !i.ip().is_loopback()
+                && !i.ip().is_multicast()
+                && !i.ip().is_unspecified()
+                && is_same_ip_family(&i.ip(), preferred_ip_family)
+        })
         .ok_or_else(|| {
             format_err!(
                 "unable to find default IP address for node. Please specify a node IP manually"

--- a/crates/kubelet/src/config.rs
+++ b/crates/kubelet/src/config.rs
@@ -1,0 +1,159 @@
+use clap::derive::Clap;
+use std::net::IpAddr;
+use std::net::ToSocketAddrs;
+
+/// The configuration needed for a kubelet to run properly. This can be
+/// configured manually in your code or if you are exposing a CLI, use the
+/// [get_from_flags method](get_from_flags). Use
+/// [default_config](Config::default_config) to generate a config with all of
+/// the default values set.
+#[derive(Clone)]
+pub struct Config {
+    pub addr: IpAddr,
+
+    pub port: u16,
+
+    pub node_ip: IpAddr,
+    pub hostname: String,
+
+    pub node_name: String,
+
+    pub(crate) arch: String,
+}
+
+impl Config {
+    /// Returns a Config object set with all of the defaults. Useful for cases
+    /// when you don't want to set most of the values yourself. The
+    /// preferred_ip_family argument takes an IpAddr that is either V4 or V6 to
+    /// indicate the preferred IP family to use for defaults
+    pub fn default_config(preferred_ip_family: &IpAddr) -> Result<Self, failure::Error> {
+        let hostname = default_hostname()?;
+        Ok(Config {
+            addr: match preferred_ip_family {
+                // Just unwrap these because they are programmer error if they
+                // don't parse
+                IpAddr::V4(_) => "0.0.0.0".parse().unwrap(),
+                IpAddr::V6(_) => "::".parse().unwrap(),
+            },
+            port: 3000,
+            node_ip: default_node_ip(&hostname, preferred_ip_family)?,
+            node_name: sanitize_hostname(&hostname),
+            hostname,
+            arch: String::default(),
+        })
+    }
+}
+
+// Opts contains the values that can be configured for kubelet
+#[derive(clap::Clap, Clone, Debug)]
+pub struct Opts {
+    #[clap(
+        short = "a",
+        long = "addr",
+        default_value = "0.0.0.0",
+        env = "KRUSTLET_ADDRESS",
+        help = "The address krustlet should listen on"
+    )]
+    addr: IpAddr,
+
+    #[clap(
+        short = "p",
+        long = "port",
+        default_value = "3000",
+        env = "KRUSTLET_PORT",
+        help = "The port krustlet should listen on"
+    )]
+    port: u16,
+
+    #[clap(
+        short = "n",
+        long = "node-ip",
+        env = "KRUSTLET_NODE_IP",
+        help = "The IP address of the node registered with the Kubernetes master. Defaults to the IP address of the node name in DNS and then IP address of the network interface used as the default gateway"
+    )]
+    node_ip: Option<IpAddr>,
+
+    #[clap(
+        long = "hostname",
+        env = "KRUSTLET_HOSTNAME",
+        help = "The hostname for this node, defaults to the hostname of this machine"
+    )]
+    hostname: Option<String>,
+
+    #[clap(
+        long = "node-name",
+        env = "KRUSTLET_NODE_NAME",
+        help = "The name for this node in Kubernetes, defaults to the hostname of this machine"
+    )]
+    node_name: Option<String>,
+}
+
+/// Parses all command line flags and sets the proper defaults
+pub fn get_from_flags() -> Config {
+    // TODO: Support config files too. config-rs and clap don't just work
+    // together, so there is no easy way to merge together everything right
+    // now. This function is here so we can do that data massaging and
+    // merging down the road
+    let opts = Opts::parse();
+    // Copy the addr to avoid a partial move when computing node_ip
+    let addr = opts.addr;
+    let hostname = opts
+        .hostname
+        .unwrap_or_else(|| default_hostname().expect("unable to get default hostname"));
+    let node_ip = opts.node_ip.unwrap_or_else(|| {
+        default_node_ip(&hostname, &addr).expect("unable to get default node IP address")
+    });
+    Config {
+        addr,
+        port: 3000,
+        node_ip,
+        node_name: sanitize_hostname(&hostname),
+        hostname,
+        arch: String::default(),
+    }
+}
+
+fn default_hostname() -> Result<String, failure::Error> {
+    Ok(hostname::get()?
+        .into_string()
+        .map_err(|_| format_err!("invalid hostname string"))?)
+}
+
+// Some hostnames (particularly local ones) can have uppercase letters, which is
+// disallowed by the DNS spec used in kubernetes naming. This sanitizes those
+// names
+fn sanitize_hostname(hostname: &str) -> String {
+    // TODO: Are there other sanitation steps we should do here?
+    hostname.to_owned().to_lowercase()
+}
+
+// Attempt to get the node IP address in the following order (this follows the
+// same pattern as the Kubernetes kubelet):
+// 1. Lookup the IP from node name by DNS
+// 2. Try to get the IP from the network interface used as default gateway
+//    (unimplemented for now because it doesn't work across platforms)
+fn default_node_ip(hostname: &str, preferred_ip_family: &IpAddr) -> Result<IpAddr, failure::Error> {
+    // NOTE: As of right now, we don't have cloud providers. In the future if
+    // that is the case, we will need to add logic for looking up the IP and
+    // hostname using the cloud provider as they do in the kubelet
+    // To use the local resolver, we need to add a port to the hostname. Doesn't
+    // matter which one, it just needs to be a valid socket address
+    let mut with_port = hostname.to_owned();
+    with_port.push_str(":80");
+    Ok(with_port
+        .to_socket_addrs()?
+        .find(|i| !&i.ip().is_loopback() && is_same_ip_family(&i.ip(), preferred_ip_family))
+        .ok_or_else(|| {
+            format_err!(
+                "unable to find default IP address for node. Please specify a node IP manually"
+            )
+        })?
+        .ip())
+}
+
+fn is_same_ip_family(first: &IpAddr, second: &IpAddr) -> bool {
+    match first {
+        IpAddr::V4(_) => second.is_ipv4(),
+        IpAddr::V6(_) => second.is_ipv6(),
+    }
+}

--- a/crates/kubelet/src/config.rs
+++ b/crates/kubelet/src/config.rs
@@ -20,8 +20,6 @@ pub struct Config {
     pub hostname: String,
 
     pub node_name: String,
-
-    pub(crate) arch: String,
 }
 
 impl Config {
@@ -42,7 +40,6 @@ impl Config {
             node_ip: default_node_ip(&mut hostname.clone(), preferred_ip_family)?,
             node_name: sanitize_hostname(&hostname),
             hostname,
-            arch: String::default(),
         })
     }
     /// Parses all command line flags and sets the proper defaults. The version
@@ -71,7 +68,6 @@ impl Config {
             node_ip,
             node_name: sanitize_hostname(&hostname),
             hostname,
-            arch: String::default(),
         }
     }
 }

--- a/crates/kubelet/src/kubelet.rs
+++ b/crates/kubelet/src/kubelet.rs
@@ -12,7 +12,6 @@ use k8s_openapi::api::core::v1::{ConfigMap, Container, EnvVar, Secret};
 use kube::{
     api::{Api, ListParams, WatchEvent},
     client::APIClient,
-    config::Configuration,
     runtime::Informer,
     Resource,
 };
@@ -67,13 +66,13 @@ pub struct Status {
 #[derive(Clone)]
 pub struct Kubelet<P: 'static + Provider + Clone + Send + Sync> {
     provider: Arc<Mutex<P>>,
-    kubeconfig: Configuration,
+    kubeconfig: kube::config::Configuration,
     config: Config,
 }
 
 impl<T: 'static + Provider + Sync + Send + Clone> Kubelet<T> {
     /// Create a new Kubelet with a provider, a KubeConfig, and a namespace.
-    pub fn new(provider: T, kubeconfig: Configuration, config: Config) -> Self {
+    pub fn new(provider: T, kubeconfig: kube::config::Configuration, config: Config) -> Self {
         Kubelet {
             provider: Arc::new(Mutex::new(provider)),
             kubeconfig,
@@ -239,7 +238,7 @@ pub trait Provider {
     async fn handle_event(
         &self,
         event: WatchEvent<Pod>,
-        config: Configuration,
+        config: kube::config::Configuration,
     ) -> Result<(), failure::Error> {
         // TODO: Is there value in keeping one client and cloning it?
         let client = APIClient::new(config);
@@ -465,7 +464,7 @@ mod test {
     use std::collections::BTreeMap;
 
     fn mock_client() -> APIClient {
-        APIClient::new(Configuration {
+        APIClient::new(kube::config::Configuration {
             base_path: ".".to_string(),
             client: reqwest::Client::new(),
             default_ns: " ".to_string(),

--- a/crates/kubelet/src/kubelet.rs
+++ b/crates/kubelet/src/kubelet.rs
@@ -88,11 +88,11 @@ impl<T: 'static + Provider + Sync + Send + Clone> Kubelet<T> {
         self.provider.lock().await.init().await?;
         let client = APIClient::new(self.kubeconfig.clone());
         // Create the node. If it already exists, "adopt" the node definition
-        let mut conf = self.config.clone();
-        conf.arch = self.provider.lock().await.arch();
+        let conf = self.config.clone();
+        let arch = self.provider.lock().await.arch();
         // Get the node name for use in the update loop
         let node_name = conf.node_name.clone();
-        create_node(&client, conf).await;
+        create_node(&client, conf, &arch).await;
 
         // Start updating the node lease periodically
         let update_client = client.clone();

--- a/crates/kubelet/src/lib.rs
+++ b/crates/kubelet/src/lib.rs
@@ -6,7 +6,7 @@ extern crate failure;
 
 pub mod config;
 mod kubelet;
-pub mod node;
+mod node;
 pub mod pod;
 mod server;
 

--- a/crates/kubelet/src/lib.rs
+++ b/crates/kubelet/src/lib.rs
@@ -4,6 +4,7 @@ extern crate serde_json;
 #[macro_use]
 extern crate failure;
 
+pub mod config;
 mod kubelet;
 pub mod node;
 pub mod pod;

--- a/crates/kubelet/src/node.rs
+++ b/crates/kubelet/src/node.rs
@@ -18,10 +18,10 @@ use log::{debug, error, info};
 /// A node comes with a lease, and we maintain the lease to tell Kubernetes that the
 /// node remains alive and functional. Note that this will not work in
 /// versions of Kubernetes prior to 1.14.
-pub async fn create_node(client: &APIClient, config: Config) {
+pub async fn create_node(client: &APIClient, config: Config, arch: &str) {
     let node_client: Api<Node> = Api::all(client.clone());
     let node_name = config.node_name.clone();
-    let node = node_definition(config);
+    let node = node_definition(config, arch);
 
     match node_client
         .create(
@@ -125,7 +125,7 @@ async fn update_lease(node_uid: &str, node_name: &str, client: &APIClient) {
 /// the OS field. I have seen 'emscripten' used for this field, but in our case
 /// the runtime is not emscripten, and besides... specifying which runtime we
 /// use seems like a misstep. Ideally, we'll be able to support multiple runtimes.
-fn node_definition(config: Config) -> serde_json::Value {
+fn node_definition(config: Config, arch: &str) -> serde_json::Value {
     let ts = Time(Utc::now());
     json!({
         "apiVersion": "v1",
@@ -133,9 +133,9 @@ fn node_definition(config: Config) -> serde_json::Value {
         "metadata": {
             "name": config.node_name,
             "labels": {
-                "beta.kubernetes.io/arch": config.arch.clone(),
+                "beta.kubernetes.io/arch": arch,
                 "beta.kubernetes.io/os": "linux",
-                "kubernetes.io/arch": config.arch,
+                "kubernetes.io/arch": arch,
                 "kubernetes.io/os": "linux",
                 "kubernetes.io/hostname": config.hostname.clone(),
                 "kubernetes.io/role":     "agent",

--- a/crates/kubelet/src/node.rs
+++ b/crates/kubelet/src/node.rs
@@ -125,9 +125,6 @@ async fn update_lease(node_uid: &str, node_name: &str, client: &APIClient) {
 /// the OS field. I have seen 'emscripten' used for this field, but in our case
 /// the runtime is not emscripten, and besides... specifying which runtime we
 /// use seems like a misstep. Ideally, we'll be able to support multiple runtimes.
-///
-/// TODO: A lot of the values here are faked, and should be replaced by real
-/// numbers post-POC.
 fn node_definition(config: Config) -> serde_json::Value {
     let ts = Time(Utc::now());
     json!({

--- a/crates/kubelet/src/node.rs
+++ b/crates/kubelet/src/node.rs
@@ -1,3 +1,4 @@
+use crate::config::Config;
 use chrono::prelude::*;
 use k8s_openapi::api::coordination::v1::Lease;
 use k8s_openapi::api::core::v1::Node;
@@ -8,11 +9,6 @@ use kube::{
 };
 use log::{debug, error, info};
 
-/// The default node name.
-const NODE_NAME: &str = "krustlet";
-
-//type KubeNode = Object<NodeSpec, NodeStatus>;
-
 /// Create a node
 ///
 /// This creates a Kubernetes Node that describes our Kubelet, failing with a log message
@@ -22,9 +18,10 @@ const NODE_NAME: &str = "krustlet";
 /// A node comes with a lease, and we maintain the lease to tell Kubernetes that the
 /// node remains alive and functional. Note that this will not work in
 /// versions of Kubernetes prior to 1.14.
-pub async fn create_node(client: &APIClient, arch: &str) {
+pub async fn create_node(client: &APIClient, config: Config) {
     let node_client: Api<Node> = Api::all(client.clone());
-    let node = node_definition(arch);
+    let node_name = config.node_name.clone();
+    let node = node_definition(config);
 
     match node_client
         .create(
@@ -36,15 +33,15 @@ pub async fn create_node(client: &APIClient, arch: &str) {
         Ok(node) => {
             info!("created node just fine");
             let node_uid = node.metadata.unwrap_or_default().uid.unwrap_or_default();
-            create_lease(&node_uid, &client).await
+            create_lease(&node_uid, &node_name, &client).await
         }
         Err(e) => {
             error!("Error creating node: {}", e);
             info!("Looking up node to see if it exists already");
-            match node_client.get(NODE_NAME).await {
+            match node_client.get(&node_name).await {
                 Ok(node) => {
                     let node_uid = node.metadata.unwrap_or_default().uid.unwrap_or_default();
-                    create_lease(&node_uid, &client).await
+                    create_lease(&node_uid, &node_name, &client).await
                 }
                 Err(e) => error!("Error fetching node after failed create: {}", e),
             }
@@ -59,19 +56,18 @@ pub async fn create_node(client: &APIClient, arch: &str) {
 /// We trap errors because... well... quite frankly there is nothing useful
 /// to do if the Kubernetes API is unavailable, and we can merrily continue
 /// doing our processing of the pod queue.
-pub async fn update_node(client: &APIClient) {
+pub async fn update_node(client: &APIClient, node_name: &str) {
     let node_client: Api<Node> = Api::all(client.clone());
     // Get me a node
-    let node_res = node_client.get(NODE_NAME).await;
+    let node_res = node_client.get(node_name).await;
     match node_res {
         Err(e) => {
             error!("Failed to get node: {:?}", e);
-            return;
         }
         Ok(node) => {
-            debug!("no error");
+            debug!("node update complete, beginning lease update");
             let uid = node.metadata.unwrap_or_default().uid.unwrap_or_default();
-            update_lease(&uid, client).await;
+            update_lease(&uid, node_name, client).await;
         }
     }
 }
@@ -79,15 +75,15 @@ pub async fn update_node(client: &APIClient) {
 /// Create a node lease
 ///
 /// These creates a new node lease and claims the node for a set
-/// preiod of time. Leases work by creating a new Lease object
+/// period of time. Leases work by creating a new Lease object
 /// and then using an ownerReference to tie it to a particular node.
 ///
 /// As far as I can tell, leases ALWAYS go in the 'kube-node-lease'
 /// namespace, no exceptions.
-async fn create_lease(node_uid: &str, client: &APIClient) {
+async fn create_lease(node_uid: &str, node_name: &str, client: &APIClient) {
     let leases: Api<Lease> = Api::namespaced(client.clone(), "kube-node-lease");
 
-    let lease = lease_definition(node_uid);
+    let lease = lease_definition(node_uid, node_name);
     let lease_data =
         serde_json::to_vec(&lease).expect("Lease should always be serializable to JSON");
     debug!("{}", serde_json::to_string_pretty(&lease).unwrap());
@@ -104,17 +100,17 @@ async fn create_lease(node_uid: &str, client: &APIClient) {
 ///
 /// TODO: Our patch is overzealous right now. We just need to update the
 /// timestamp.
-async fn update_lease(node_uid: &str, client: &APIClient) {
+async fn update_lease(node_uid: &str, node_name: &str, client: &APIClient) {
     let leases: Api<Lease> = Api::namespaced(client.clone(), "kube-node-lease");
 
-    let lease = lease_definition(node_uid);
+    let lease = lease_definition(node_uid, node_name);
     let pp = PatchParams::default();
     let lease_data =
         serde_json::to_vec(&lease).expect("Lease should always be serializable to JSON");
     // TODO: either wrap this in a conditional or remove
     debug!("{}", serde_json::to_string_pretty(&lease).unwrap());
 
-    let resp = leases.patch(NODE_NAME, &pp, lease_data).await;
+    let resp = leases.patch(node_name, &pp, lease_data).await;
     match resp {
         Ok(_) => info!("Created lease"),
         Err(e) => error!("Failed to create lease: {}", e),
@@ -132,21 +128,19 @@ async fn update_lease(node_uid: &str, client: &APIClient) {
 ///
 /// TODO: A lot of the values here are faked, and should be replaced by real
 /// numbers post-POC.
-fn node_definition(arch: &str) -> serde_json::Value {
-    let pod_ip = "10.21.77.2";
-    let port = 3000;
+fn node_definition(config: Config) -> serde_json::Value {
     let ts = Time(Utc::now());
     json!({
         "apiVersion": "v1",
         "kind": "Node",
         "metadata": {
-            "name": NODE_NAME,
+            "name": config.node_name,
             "labels": {
-                "beta.kubernetes.io/arch": arch,
+                "beta.kubernetes.io/arch": config.arch.clone(),
                 "beta.kubernetes.io/os": "linux",
-                "kubernetes.io/arch": arch,
+                "kubernetes.io/arch": config.arch,
                 "kubernetes.io/os": "linux",
-                "kubernetes.io/hostname": "krustlet",
+                "kubernetes.io/hostname": config.hostname.clone(),
                 "kubernetes.io/role":     "agent",
                 "type": "krustlet"
             },
@@ -201,16 +195,16 @@ fn node_definition(arch: &str) -> serde_json::Value {
             "addresses": [
                 {
                     "type": "InternalIP",
-                    "address": pod_ip
+                    "address": config.node_ip
                 },
                 {
                     "type": "Hostname",
-                    "address": "krustlet"
+                    "address": config.hostname
                 }
             ],
             "daemonEndpoints": {
                 "kubeletEndpoint": {
-                    "Port": port
+                    "Port": config.port
                 }
             }
         }
@@ -222,23 +216,23 @@ fn node_definition(arch: &str) -> serde_json::Value {
 /// The lease tells Kubernetes that we want to claim the node for a while
 /// longer. And then tells Kubernetes how long it should wait before
 /// expecting a new lease.
-fn lease_definition(node_uid: &str) -> serde_json::Value {
+fn lease_definition(node_uid: &str, node_name: &str) -> serde_json::Value {
     json!(
         {
             "apiVersion": "coordination.k8s.io/v1",
             "kind": "Lease",
             "metadata": {
-                "name": NODE_NAME,
+                "name": node_name,
                 "ownerReferences": [
                     {
                         "apiVersion": "v1",
                         "kind": "Node",
-                        "name": NODE_NAME,
+                        "name": node_name,
                         "uid": node_uid
                     }
                 ]
             },
-            "spec": lease_spec_definition()
+            "spec": lease_spec_definition(node_name)
         }
     )
 }
@@ -246,14 +240,14 @@ fn lease_definition(node_uid: &str) -> serde_json::Value {
 /// Defines a new coordiation lease for Kubernetes
 ///
 /// We set the lease times, the lease duration, and the node name.
-fn lease_spec_definition() -> serde_json::Value {
+fn lease_spec_definition(node_name: &str) -> serde_json::Value {
     // Workaround for https://github.com/deislabs/krustlet/issues/5
     // In the future, use LeaseSpec rather than a JSON value
     let now = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
 
     json!(
         {
-            "holderIdentity": NODE_NAME,
+            "holderIdentity": node_name,
             "acquireTime": now,
             "renewTime": now,
             "leaseDurationSeconds": 300

--- a/docs/community/developers.md
+++ b/docs/community/developers.md
@@ -46,10 +46,20 @@ To run Krustlet locally, you can run
 $ just run-wasi
 ```
 
-Before startup, this command will delete any nodes in your Kubernetes cluster named "krustlet", so make sure you're
-running this in a test environment.
+Before startup, this command will delete any nodes in your Kubernetes cluster
+named with your hostname, so make sure you're running this in a test
+environment.
 
-Note that if you are running krustlet locally, calls to `kubectl log` and `kubectl exec` will result in errors.
+If you want to interact with the kubelet (for things like `kubectl logs` and
+`kubectl exec`), you'll likely need to set a specific NODE_IP that krustlet will
+be available at. Otherwise, calls to the kubelet will result in errors. This may
+differ from machine to machine. For example, with Minikube on a Mac, you'll have
+an interface called `bridge0` which the cluster can talk to. So your node IP
+should be that IP address. To set the node IP, run:
+
+```console
+export KRUSTLET_NODE_IP=<the ip address>
+```
 
 ## Creating your own Kubelets with Krustlet
 

--- a/justfile
+++ b/justfile
@@ -34,7 +34,7 @@ itest:
     for i in 1 2 3 4 5; do sleep 3 && kubectl get po greet; done
 
 _cleanup_kube:
-    kubectl delete no krustlet || true
+    kubectl delete no $(hostname | tr '[:upper:]' '[:lower:]') || true
     kubectl delete po greet || true
 
 testfor:

--- a/src/krustlet-wascc.rs
+++ b/src/krustlet-wascc.rs
@@ -1,4 +1,5 @@
 use kube::config;
+use kubelet::config::get_from_flags;
 use kubelet::Kubelet;
 use wascc_provider::WasccProvider;
 
@@ -10,9 +11,6 @@ async fn main() -> Result<(), failure::Error> {
         .await
         .or_else(|_| config::incluster_config())
         .expect("kubeconfig failed to load");
-    let address = std::env::var("POD_IP")
-        .unwrap_or_else(|_| "0.0.0.0:3000".to_string())
-        .parse()?;
 
     // Initialize the logger
     env_logger::init();
@@ -20,6 +18,6 @@ async fn main() -> Result<(), failure::Error> {
     // The provider is responsible for all the "back end" logic. If you are creating
     // a new Kubelet, all you need to implement is a provider.
     let provider = WasccProvider {};
-    let kubelet = Kubelet::new(provider, kubeconfig);
-    kubelet.start(address).await
+    let kubelet = Kubelet::new(provider, kubeconfig, get_from_flags());
+    kubelet.start().await
 }

--- a/src/krustlet-wascc.rs
+++ b/src/krustlet-wascc.rs
@@ -1,5 +1,5 @@
 use kube::config;
-use kubelet::config::get_from_flags;
+use kubelet::config::Config;
 use kubelet::Kubelet;
 use wascc_provider::WasccProvider;
 
@@ -18,6 +18,10 @@ async fn main() -> Result<(), failure::Error> {
     // The provider is responsible for all the "back end" logic. If you are creating
     // a new Kubelet, all you need to implement is a provider.
     let provider = WasccProvider {};
-    let kubelet = Kubelet::new(provider, kubeconfig, get_from_flags());
+    let kubelet = Kubelet::new(
+        provider,
+        kubeconfig,
+        Config::new_from_flags(env!("CARGO_PKG_VERSION")),
+    );
     kubelet.start().await
 }

--- a/src/krustlet-wasi.rs
+++ b/src/krustlet-wasi.rs
@@ -1,5 +1,5 @@
 use kube::config;
-use kubelet::config::get_from_flags;
+use kubelet::config::Config;
 use kubelet::Kubelet;
 use wasi_provider::WasiProvider;
 
@@ -18,6 +18,10 @@ async fn main() -> Result<(), failure::Error> {
     // The provider is responsible for all the "back end" logic. If you are creating
     // a new Kubelet, all you need to implement is a provider.
     let provider = WasiProvider::default();
-    let kubelet = Kubelet::new(provider, kubeconfig, get_from_flags());
+    let kubelet = Kubelet::new(
+        provider,
+        kubeconfig,
+        Config::new_from_flags(env!("CARGO_PKG_VERSION")),
+    );
     kubelet.start().await
 }

--- a/src/krustlet-wasi.rs
+++ b/src/krustlet-wasi.rs
@@ -1,4 +1,5 @@
 use kube::config;
+use kubelet::config::get_from_flags;
 use kubelet::Kubelet;
 use wasi_provider::WasiProvider;
 
@@ -10,9 +11,6 @@ async fn main() -> Result<(), failure::Error> {
         .await
         .or_else(|_| config::incluster_config())
         .expect("kubeconfig failed to load");
-    let address = std::env::var("POD_IP")
-        .unwrap_or_else(|_| "0.0.0.0:3000".to_string())
-        .parse()?;
 
     // Initialize the logger
     env_logger::init();
@@ -20,6 +18,6 @@ async fn main() -> Result<(), failure::Error> {
     // The provider is responsible for all the "back end" logic. If you are creating
     // a new Kubelet, all you need to implement is a provider.
     let provider = WasiProvider::default();
-    let kubelet = Kubelet::new(provider, kubeconfig);
-    kubelet.start(address).await
+    let kubelet = Kubelet::new(provider, kubeconfig, get_from_flags());
+    kubelet.start().await
 }


### PR DESCRIPTION
This follows similar defaulting methodology as to what is found in the
normal Kubernetes kubelet. Currently we only support command line flags
and environment variables but it allows a user to configure various parts
of the kubelet

Closes #34