### PR TITLE
initial add of OCI Distribution crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,12 +50,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c"
 
 [[package]]
-name = "arc-swap"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b8a9123b8027467bce0099fe556c628a53c8d83df0507084c31e9ba2e39aff"
-
-[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1584,33 +1578,10 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log",
- "miow 0.2.1",
+ "miow",
  "net2",
  "slab",
  "winapi 0.2.8",
-]
-
-[[package]]
-name = "mio-named-pipes"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e374eff525ce1c5b7687c4cef63943e7686524a387933ad27ca7ec43779cb3"
-dependencies = [
- "log",
- "mio",
- "miow 0.3.3",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "mio-uds"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
-dependencies = [
- "iovec",
- "libc",
- "mio",
 ]
 
 [[package]]
@@ -1623,16 +1594,6 @@ dependencies = [
  "net2",
  "winapi 0.2.8",
  "ws2_32-sys",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226"
-dependencies = [
- "socket2",
- "winapi 0.3.8",
 ]
 
 [[package]]
@@ -2593,16 +2554,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
-dependencies = [
- "arc-swap",
- "libc",
-]
-
-[[package]]
 name = "signatory"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2647,18 +2598,6 @@ name = "smallvec"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
-
-[[package]]
-name = "socket2"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "winapi 0.3.8",
-]
 
 [[package]]
 name = "spin"
@@ -2945,17 +2884,11 @@ dependencies = [
  "futures-core",
  "iovec",
  "lazy_static",
- "libc",
  "memchr",
  "mio",
- "mio-named-pipes",
- "mio-uds",
- "num_cpus",
  "pin-project-lite",
- "signal-hook-registry",
  "slab",
  "tokio-macros",
- "winapi 0.3.8",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,11 +73,27 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d37ca0ddff0c8afe8307cd4cc3636c19f0fa09ecfc642344b1597d08a19d1a2"
 dependencies = [
- "bytes",
+ "bytes 0.5.4",
  "flate2",
  "futures-core",
  "memchr",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-oauth2"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "303a7b3d526142ef2bec43912e257c57e4254e34493ae0c4056a18a568a9e0bb"
+dependencies = [
+ "base64 0.11.0",
+ "rand 0.7.3",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror",
+ "url 2.1.1",
 ]
 
 [[package]]
@@ -134,6 +150,15 @@ checksum = "e17b52e737c40a7d75abca20b29a19a0eb7ba9fc72c5a72dd282a0a3c2c0dc35"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "base64"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -216,6 +241,16 @@ name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+
+[[package]]
+name = "bytes"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
+dependencies = [
+ "byteorder",
+ "iovec",
+]
 
 [[package]]
 name = "bytes"
@@ -1114,12 +1149,12 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5c295d1c0c68e4e42003d75f908f5e16a1edd1cbe0b0d02e4dc2006a384f47"
 dependencies = [
- "bytes",
+ "bytes 0.5.4",
  "fnv",
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.0",
  "indexmap",
  "log",
  "slab",
@@ -1158,11 +1193,22 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6ccf5ede3a895d8856620237b2f02972c1bbc78d2965ad7fe8838d4a0ed41f0"
+dependencies = [
+ "bytes 0.4.12",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b708cc7f06493459026f53b9a61a7a121a5d1ec6238dee58ea4941132b30156b"
 dependencies = [
- "bytes",
+ "bytes 0.5.4",
  "fnv",
  "itoa",
 ]
@@ -1173,8 +1219,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes",
- "http",
+ "bytes 0.5.4",
+ "http 0.2.0",
 ]
 
 [[package]]
@@ -1198,12 +1244,12 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7b15203263d1faa615f9337d79c1d37959439dc46c2b4faab33286fadc2a1c5"
 dependencies = [
- "bytes",
+ "bytes 0.5.4",
  "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.0",
  "http-body",
  "httparse",
  "itoa",
@@ -1222,7 +1268,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3adcd308402b9553630734e9c36b77a7e48b3821251ca2493e8cd596763aafaa"
 dependencies = [
- "bytes",
+ "bytes 0.5.4",
  "hyper",
  "native-tls",
  "tokio",
@@ -1230,10 +1276,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyperx"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a94cbc2c6f63028e5736ca4e811ae36d3990059c384cbe68298c66728a9776"
+dependencies = [
+ "base64 0.10.1",
+ "bytes 0.4.12",
+ "http 0.1.21",
+ "httparse",
+ "language-tags",
+ "log",
+ "mime",
+ "percent-encoding 1.0.1",
+ "time 0.1.42",
+ "unicase 2.6.0",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "idna"
@@ -1312,15 +1387,15 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96affb18356fc998baa692c2185d198095ffdf6e6fff3bc9efb4927952f86851"
 dependencies = [
- "base64",
- "bytes",
+ "base64 0.11.0",
+ "bytes 0.5.4",
  "chrono",
- "http",
- "percent-encoding",
+ "http 0.2.0",
+ "percent-encoding 2.1.0",
  "serde",
  "serde-value",
  "serde_json",
- "url",
+ "url 2.1.1",
 ]
 
 [[package]]
@@ -1353,15 +1428,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d128769b413d409e02a7cf65e7c78ba12939d31c817b87809f6f335a667b4d63"
 dependencies = [
  "Inflector",
- "base64",
- "bytes",
+ "base64 0.11.0",
+ "bytes 0.5.4",
  "chrono",
  "dirs",
  "either",
  "futures",
  "futures-timer",
  "futures-util",
- "http",
+ "http 0.2.0",
  "k8s-openapi",
  "log",
  "openssl",
@@ -1372,7 +1447,7 @@ dependencies = [
  "serde_yaml",
  "thiserror",
  "time 0.2.7",
- "url",
+ "url 2.1.1",
 ]
 
 [[package]]
@@ -1395,6 +1470,12 @@ dependencies = [
  "serde_json",
  "tokio",
 ]
+
+[[package]]
+name = "language-tags"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 
 [[package]]
 name = "lazy_static"
@@ -1494,7 +1575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
 dependencies = [
  "mime",
- "unicase",
+ "unicase 2.6.0",
 ]
 
 [[package]]
@@ -1623,7 +1704,7 @@ dependencies = [
  "nuid",
  "rand 0.7.3",
  "regex",
- "url",
+ "url 2.1.1",
 ]
 
 [[package]]
@@ -1765,10 +1846,14 @@ name = "oci-distribution"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-oauth2",
+ "hyperx",
  "reqwest",
  "serde",
  "serde_json",
  "tokio",
+ "url 2.1.1",
+ "www-authenticate",
 ]
 
 [[package]]
@@ -1824,6 +1909,12 @@ name = "parity-wasm"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
+
+[[package]]
+name = "percent-encoding"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
 name = "percent-encoding"
@@ -2249,12 +2340,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b81e49ddec5109a9dcfc5f2a317ff53377c915e9ae9d4f2fb50914b85614e2"
 dependencies = [
  "async-compression",
- "base64",
- "bytes",
+ "base64 0.11.0",
+ "bytes 0.5.4",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "http",
+ "http 0.2.0",
  "http-body",
  "hyper",
  "hyper-tls",
@@ -2264,7 +2355,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "native-tls",
- "percent-encoding",
+ "percent-encoding 2.1.0",
  "pin-project-lite",
  "serde",
  "serde_json",
@@ -2272,7 +2363,7 @@ dependencies = [
  "time 0.1.42",
  "tokio",
  "tokio-tls",
- "url",
+ "url 2.1.1",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -2321,7 +2412,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
 dependencies = [
- "base64",
+ "base64 0.11.0",
  "blake2b_simd",
  "constant_time_eq",
  "crossbeam-utils",
@@ -2491,7 +2582,7 @@ dependencies = [
  "dtoa",
  "itoa",
  "serde",
- "url",
+ "url 2.1.1",
 ]
 
 [[package]]
@@ -2866,7 +2957,7 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa5e81d6bc4e67fe889d5783bd2a128ab2e0cfa487e0be16b6a8d177b101616"
 dependencies = [
- "bytes",
+ "bytes 0.5.4",
  "fnv",
  "futures-core",
  "iovec",
@@ -2911,7 +3002,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
 dependencies = [
- "bytes",
+ "bytes 0.5.4",
  "futures-core",
  "futures-sink",
  "log",
@@ -2945,6 +3036,15 @@ name = "typenum"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
+
+[[package]]
+name = "unicase"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
+dependencies = [
+ "version_check 0.1.5",
+]
 
 [[package]]
 name = "unicase"
@@ -3005,13 +3105,24 @@ checksum = "60369ef7a31de49bcb3f6ca728d4ba7300d9a1658f94c727d4cab8c8d9f4aece"
 
 [[package]]
 name = "url"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
+dependencies = [
+ "idna 0.1.5",
+ "matches",
+ "percent-encoding 1.0.1",
+]
+
+[[package]]
+name = "url"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
 dependencies = [
- "idna",
+ "idna 0.2.0",
  "matches",
- "percent-encoding",
+ "percent-encoding 2.1.0",
 ]
 
 [[package]]
@@ -3093,7 +3204,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3839a08f49ae5be43fd695089262f75b156d5d37c26f31ab19f1089abf1a1770"
 dependencies = [
- "base64",
+ "base64 0.11.0",
  "chrono",
  "chrono-humanize",
  "data-encoding",
@@ -3332,7 +3443,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80f3dea0e60c076dd0da27fa10c821323903c9554c617ed32eaab8e7a7e36c89"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.11.0",
  "bincode",
  "cranelift-codegen",
  "cranelift-entity",
@@ -3563,6 +3674,17 @@ checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "www-authenticate"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c62efb8259cda4e4c732287397701237b78daa4c43edcf3e613c8503a6c07dd"
+dependencies = [
+ "hyperx",
+ "unicase 1.4.2",
+ "url 1.7.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,22 +81,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-oauth2"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "303a7b3d526142ef2bec43912e257c57e4254e34493ae0c4056a18a568a9e0bb"
-dependencies = [
- "base64 0.11.0",
- "rand 0.7.3",
- "reqwest",
- "serde",
- "serde_json",
- "sha2",
- "thiserror",
- "url 2.1.1",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1846,13 +1830,12 @@ name = "oci-distribution"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-oauth2",
+ "chrono",
  "hyperx",
  "reqwest",
  "serde",
  "serde_json",
  "tokio",
- "url 2.1.1",
  "www-authenticate",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,9 +18,9 @@ checksum = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5e63fd144e18ba274ae7095c0197a870a7b9468abc801dd62f190d80817d2ec"
+checksum = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
 dependencies = [
  "memchr",
 ]
@@ -48,6 +48,12 @@ name = "anyhow"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c"
+
+[[package]]
+name = "arc-swap"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7b8a9123b8027467bce0099fe556c628a53c8d83df0507084c31e9ba2e39aff"
 
 [[package]]
 name = "arrayref"
@@ -218,15 +224,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
 
 [[package]]
-name = "c2-chacha"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
-dependencies = [
- "ppv-lite86",
-]
-
-[[package]]
 name = "cc"
 version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,9 +240,9 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chrono"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31850b4a4d6bae316f7a09e691c944c28299298837edc0a03f755618c23cbc01"
+checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -280,7 +277,7 @@ dependencies = [
 [[package]]
 name = "clap"
 version = "3.0.0-beta.1"
-source = "git+https://github.com/clap-rs/clap#19c20f7c00310900ce6667baedfe1190e20eeeab"
+source = "git+https://github.com/clap-rs/clap#bc738e12c223666ac84fe29c74c21b4e276c5e59"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -310,7 +307,7 @@ dependencies = [
 [[package]]
 name = "clap_derive"
 version = "3.0.0-beta.1"
-source = "git+https://github.com/clap-rs/clap#19c20f7c00310900ce6667baedfe1190e20eeeab"
+source = "git+https://github.com/clap-rs/clap#bc738e12c223666ac84fe29c74c21b4e276c5e59"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -677,9 +674,9 @@ checksum = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
 
 [[package]]
 name = "ed25519"
-version = "1.0.0-pre.1"
+version = "1.0.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28f2b738e873c40ce7339dfb8c5a48c936084b4540127e86c47a0fddcaa8624"
+checksum = "80408ec92c1f70ba4f77797b5602961c252a60ec89eb15a4b7ecb83a7859bfa6"
 dependencies = [
  "signature",
 ]
@@ -1351,9 +1348,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63c3b22cfdec7ba3b3100006f32e2c03235b476cc5573b66b69e7cc2b80d8d5"
+checksum = "d128769b413d409e02a7cf65e7c78ba12939d31c817b87809f6f335a667b4d63"
 dependencies = [
  "Inflector",
  "base64",
@@ -1522,10 +1519,33 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log",
- "miow",
+ "miow 0.2.1",
  "net2",
  "slab",
  "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio-named-pipes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e374eff525ce1c5b7687c4cef63943e7686524a387933ad27ca7ec43779cb3"
+dependencies = [
+ "log",
+ "mio",
+ "miow 0.3.3",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "mio-uds"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
+dependencies = [
+ "iovec",
+ "libc",
+ "mio",
 ]
 
 [[package]]
@@ -1538,6 +1558,16 @@ dependencies = [
  "net2",
  "winapi 0.2.8",
  "ws2_32-sys",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226"
+dependencies = [
+ "socket2",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -1728,6 +1758,17 @@ dependencies = [
  "scroll",
  "target-lexicon",
  "uuid",
+]
+
+[[package]]
+name = "oci-distribution"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -1981,7 +2022,7 @@ checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom",
  "libc",
- "rand_chacha 0.2.1",
+ "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
 ]
@@ -1998,11 +2039,11 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
- "c2-chacha",
+ "ppv-lite86",
  "rand_core 0.5.1",
 ]
 
@@ -2478,6 +2519,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
+dependencies = [
+ "arc-swap",
+ "libc",
+]
+
+[[package]]
 name = "signatory"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2504,9 +2555,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.0.0-pre.1"
+version = "1.0.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0cfcdc45066661979294e965c21b60355da35eb5d638af8143e5aa83fdfce53"
+checksum = "561619c00cf6a187ebfc21e46bc4c0ce4e4d5f67cd640e7b1c58d9c3754b38aa"
 dependencies = [
  "digest",
 ]
@@ -2522,6 +2573,18 @@ name = "smallvec"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
+
+[[package]]
+name = "socket2"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi 0.3.8",
+]
 
 [[package]]
 name = "spin"
@@ -2808,11 +2871,17 @@ dependencies = [
  "futures-core",
  "iovec",
  "lazy_static",
+ "libc",
  "memchr",
  "mio",
+ "mio-named-pipes",
+ "mio-uds",
+ "num_cpus",
  "pin-project-lite",
+ "signal-hook-registry",
  "slab",
  "tokio-macros",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -3370,12 +3439,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "wat"
-version = "1.0.10"
+name = "wast"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56173f7f4fb59aebe35a7e71423845e1c6c7144bfb56362d497931b6b3bed0f6"
+checksum = "4efb62ecebf5cc9dbf2954309a20d816289c6550c0597a138b9e811cefc05007"
 dependencies = [
- "wast",
+ "leb128",
+]
+
+[[package]]
+name = "wat"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdea5e25273cc3a62f3ae3a1a4c7d7996625875b50c0b4475fee6698c2b069c"
+dependencies = [
+ "wast 10.0.0",
 ]
 
 [[package]]
@@ -3474,7 +3552,7 @@ dependencies = [
  "pretty_env_logger",
  "structopt 0.3.11",
  "thiserror",
- "wast",
+ "wast 9.0.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1829,8 +1829,8 @@ dependencies = [
 name = "oci-distribution"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "chrono",
+ "failure",
  "hyperx",
  "reqwest",
  "serde",

--- a/crates/oci-distribution/Cargo.toml
+++ b/crates/oci-distribution/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "oci-distribution"
+version = "0.1.0"
+authors = [
+    "Matt Butcher <matt.butcher@microsoft.com>",
+    "Matthew Fisher <matt.fisher@microsoft.com>",
+    "Radu Matei <radu.matei@microsoft.com>",
+    "Taylor Thomas <taylor.thomas@microsoft.com>",
+    "Brian Ketelsen <Brian.Ketelsen@microsoft.com>",
+    "Brian Hardock <Brian.Hardock@microsoft.com>",
+    "Ryan Levick <rylevick@microsoft.com>",
+]
+edition = "2018"
+
+[dependencies]
+reqwest = { version = "0.10", features = ["json"] }
+anyhow = "1.0.25"
+tokio = { version = "0.2", features = ["full"] }
+serde = "1.0"
+serde_json = "1.0"

--- a/crates/oci-distribution/Cargo.toml
+++ b/crates/oci-distribution/Cargo.toml
@@ -13,9 +13,9 @@ authors = [
 edition = "2018"
 
 [dependencies]
-reqwest = { version = "0.10", features = ["json"] }
+reqwest = { version = "0.10.4", features = ["json"] }
 failure = "0.1"
-tokio = { version = "0.2", features = ["full"] }
+tokio = "0.2.13"
 serde = "1.0"
 serde_json = "1.0"
 www-authenticate = "0.3.0"

--- a/crates/oci-distribution/Cargo.toml
+++ b/crates/oci-distribution/Cargo.toml
@@ -18,7 +18,6 @@ anyhow = "1.0.25"
 tokio = { version = "0.2", features = ["full"] }
 serde = "1.0"
 serde_json = "1.0"
-async-oauth2 = "0.1.1"
 www-authenticate = "0.3.0"
-url = "2.1.1"
 hyperx = "0.13"
+chrono = { version = "0.4", features = ["serde"] }

--- a/crates/oci-distribution/Cargo.toml
+++ b/crates/oci-distribution/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [dependencies]
 reqwest = { version = "0.10", features = ["json"] }
-anyhow = "1.0.25"
+failure = "0.1"
 tokio = { version = "0.2", features = ["full"] }
 serde = "1.0"
 serde_json = "1.0"

--- a/crates/oci-distribution/Cargo.toml
+++ b/crates/oci-distribution/Cargo.toml
@@ -18,3 +18,7 @@ anyhow = "1.0.25"
 tokio = { version = "0.2", features = ["full"] }
 serde = "1.0"
 serde_json = "1.0"
+async-oauth2 = "0.1.1"
+www-authenticate = "0.3.0"
+url = "2.1.1"
+hyperx = "0.13"

--- a/crates/oci-distribution/README.md
+++ b/crates/oci-distribution/README.md
@@ -1,0 +1,5 @@
+# OCI Distribution
+
+This Rust library implements the [OCI Distribution specification](https://github.com/opencontainers/distribution-spec/blob/master/spec.md), which is the protocol that Docker Hub and other container registries use.
+
+The immediate goal of this crate is to provide a way to pull WASM modules from a Docker registry. However, our broader goal is to implement the spec in its entirety.

--- a/crates/oci-distribution/src/errors.rs
+++ b/crates/oci-distribution/src/errors.rs
@@ -2,7 +2,7 @@
 ///
 /// This struct represents that error format, which is formally described here:
 /// https://github.com/opencontainers/distribution-spec/blob/master/spec.md#errors-2
-#[derive(Deserialize, Debug)]
+#[derive(serde::Deserialize, Debug)]
 pub struct OciError {
     pub code: OciErrorCode,
     pub message: String,
@@ -20,12 +20,12 @@ impl std::fmt::Display for OciError {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(serde::Deserialize)]
 pub struct OciEnvelope {
     pub errors: Vec<OciError>,
 }
 
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(serde::Deserialize, Debug, PartialEq)]
 pub enum OciErrorCode {
     /// Blob unknown to registry
     ///

--- a/crates/oci-distribution/src/errors.rs
+++ b/crates/oci-distribution/src/errors.rs
@@ -26,65 +26,66 @@ pub struct OciEnvelope {
 }
 
 #[derive(serde::Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum OciErrorCode {
     /// Blob unknown to registry
     ///
     /// This error MAY be returned when a blob is unknown to the registry in a specified
     /// repository. This can be returned with a standard get or if a manifest
     /// references an unknown layer during upload.
-    BLOB_UNKNOWN,
+    BlobUnknown,
     /// Blob upload is invalid
     ///
     /// The blob upload encountered an error and can no longer proceed.
-    BLOB_UPLOAD_INVALID,
+    BlobUploadInvalid,
     /// Blob upload is unknown to registry
-    BLOB_UPLOAD_UNKNOWN,
+    BlobUploadUnknown,
     /// Provided digest did not match uploaded content.
-    DIGEST_INVALID,
+    DigestInvalid,
     /// Blob is unknown to registry
-    MANIFEST_BLOB_UNKNOWN,
+    ManifestBlobUnknown,
     /// Manifest is invalid
     ///
     /// During upload, manifests undergo several checks ensuring validity. If
     /// those checks fail, this error MAY be returned, unless a more specific
     /// error is included. The detail will contain information the failed
     /// validation.
-    MANIFEST_INVALID,
+    ManifestInvalid,
     /// Manifest unknown
     ///
     /// This error is returned when the manifest, identified by name and tag is unknown to the repository.
-    MANIFEST_UNKNOWN,
+    ManifestUnknown,
     /// Manifest failed signature validation
-    MANIFEST_UNVERIFIED,
+    ManifestUnverified,
     /// Invalid repository name
-    NAME_INVALID,
+    NameInvalid,
     /// Repository name is not known
-    NAME_UNKNOWN,
+    NameUnknown,
     // Provided length did not match content length
-    SIZE_INVALID,
+    SizeInvalid,
     /// Manifest tag did not match URI
-    TAG_INVALID,
+    TagInvalid,
     /// Authentication required.
-    UNAUTHORIZED,
+    Unauthorized,
     // Requested access to the resource is denied
-    DENIED,
+    Denied,
     /// This operation is unsupported
-    UNSUPPORTED,
+    Unsupported,
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
 
-    const example_error: &str = r#"
+    const EXAMPLE_ERROR: &str = r#"
       {"errors":[{"code":"UNAUTHORIZED","message":"authentication required","detail":[{"Type":"repository","Name":"hello-wasm","Action":"pull"}]}]}
       "#;
     #[test]
     fn test_deserialize() {
         let envelope: OciEnvelope =
-            serde_json::from_str(example_error).expect("parse example error");
+            serde_json::from_str(EXAMPLE_ERROR).expect("parse example error");
         let e = &envelope.errors[0];
-        assert_eq!(OciErrorCode::UNAUTHORIZED, e.code);
+        assert_eq!(OciErrorCode::Unauthorized, e.code);
         assert_eq!("authentication required", e.message);
     }
 }

--- a/crates/oci-distribution/src/errors.rs
+++ b/crates/oci-distribution/src/errors.rs
@@ -1,0 +1,83 @@
+/// The OCI specification defines a specific error format.
+///
+/// This struct represents that error format, which is formally described here:
+/// https://github.com/opencontainers/distribution-spec/blob/master/spec.md#errors-2
+#[derive(Deserialize, Debug)]
+pub struct OciError {
+    pub code: OciErrorCode,
+    pub message: String,
+    pub detail: serde_json::Value,
+}
+
+impl std::error::Error for OciError {
+    fn description(&self) -> &str {
+        self.message.as_str()
+    }
+}
+impl std::fmt::Display for OciError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "OCI API error: {}", self.message.as_str())
+    }
+}
+
+#[derive(Deserialize)]
+pub struct OciEnvelope {
+    pub errors: Vec<OciError>,
+}
+
+#[derive(Deserialize, Debug, PartialEq)]
+pub enum OciErrorCode {
+    /// Blob unknown to registry
+    ///
+    /// This error MAY be returned when a blob is unknown to the registry in a specified
+    /// repository. This can be returned with a standard get or if a manifest
+    /// references an unknown layer during upload.
+    BLOB_UNKNOWN,
+    /// Blob upload is invalid
+    ///
+    /// The blob upload encountered an error and can no longer proceed.
+    BLOB_UPLOAD_INVALID,
+    /// Blob upload is unknown to registry
+    BLOB_UPLOAD_UNKNOWN,
+    /// Provided digest did not match uploaded content.
+    DIGEST_INVALID,
+    /// Blob is unknown to registry
+    MANIFEST_BLOB_UNKNOWN,
+    /// Manifest is invalid
+    MANIFEST_INVALID,
+    /// Manifest unknown
+    MANIFEST_UNKNOWN,
+    /// Manifest failed signature validation
+    MANIFEST_UNVERIFIED,
+    /// Invalid repository name
+    NAME_INVALID,
+    /// Repository name is not known
+    NAME_UNKNOWN,
+    // Provided length did not match content length
+    SIZE_INVALID,
+    /// Manifest tag did not match URI
+    TAG_INVALID,
+    /// Authentication required.
+    UNAUTHORIZED,
+    // Requested access to the resource is denied
+    DENIED,
+    /// This operation is unsupported
+    UNSUPPORTED,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    const example_error: &str = r#"
+      {"errors":[{"code":"UNAUTHORIZED","message":"authentication required","detail":[{"Type":"repository","Name":"hello-wasm","Action":"pull"}]}]}
+      "#;
+    #[test]
+    fn test_deserialize() {
+        let envelope: OciEnvelope =
+            serde_json::from_str(example_error).expect("parse example error");
+        let e = &envelope.errors[0];
+        assert_eq!(OciErrorCode::UNAUTHORIZED, e.code);
+        assert_eq!("authentication required", e.message);
+    }
+}

--- a/crates/oci-distribution/src/errors.rs
+++ b/crates/oci-distribution/src/errors.rs
@@ -44,8 +44,15 @@ pub enum OciErrorCode {
     /// Blob is unknown to registry
     MANIFEST_BLOB_UNKNOWN,
     /// Manifest is invalid
+    ///
+    /// During upload, manifests undergo several checks ensuring validity. If
+    /// those checks fail, this error MAY be returned, unless a more specific
+    /// error is included. The detail will contain information the failed
+    /// validation.
     MANIFEST_INVALID,
     /// Manifest unknown
+    ///
+    /// This error is returned when the manifest, identified by name and tag is unknown to the repository.
     MANIFEST_UNKNOWN,
     /// Manifest failed signature validation
     MANIFEST_UNVERIFIED,

--- a/crates/oci-distribution/src/lib.rs
+++ b/crates/oci-distribution/src/lib.rs
@@ -31,7 +31,7 @@ type OciResult<T> = Result<T, failure::Error>;
 /// For true anonymous access, you can skip `auth()`. This is not recommended
 /// unless you are sure that the remote registry does not require Oauth2.
 struct Client {
-    token: Option<DockerToken>,
+    token: Option<RegistryToken>,
 }
 
 impl Default for Client {
@@ -98,7 +98,7 @@ impl Client {
 
         match auth_res.status() {
             reqwest::StatusCode::OK => {
-                let docker_token: DockerToken = auth_res.json().await?;
+                let docker_token: RegistryToken = auth_res.json().await?;
                 self.token = Some(docker_token);
                 Ok(())
             }
@@ -143,21 +143,21 @@ impl Client {
 }
 
 #[derive(serde::Deserialize)]
-struct DockerToken {
+struct RegistryToken {
     access_token: String,
     expires_in: Option<u32>,
     issued_at: Option<DateTime<Utc>>,
 }
 
-impl DockerToken {
+impl RegistryToken {
     fn bearer_token(&self) -> String {
         format!("Bearer {}", self.access_token)
     }
 }
 
-impl Default for DockerToken {
+impl Default for RegistryToken {
     fn default() -> Self {
-        DockerToken {
+        RegistryToken {
             access_token: "".to_owned(),
             expires_in: None,
             issued_at: None, // We could do Utc::now() if we really need.

--- a/crates/oci-distribution/src/lib.rs
+++ b/crates/oci-distribution/src/lib.rs
@@ -1,16 +1,16 @@
 #[macro_use]
 extern crate serde;
 
+use hyperx::header::Header;
+use oauth2::{Client as OauthClient, StandardToken};
 use serde::Deserialize;
 use std::convert::TryFrom;
+use url::Url;
+use www_authenticate::{Challenge, ChallengeFields, RawChallenge, WwwAuthenticate};
 
 use crate::errors::*;
 use crate::reference::Reference;
 
-/// The OCI Distribution specification version 2.
-///
-/// This marker is used in URLs for accessing OCI Distributiion endpoints.
-const OCI_VERSION_2: &str = "v2";
 const OCI_VERSION_KEY: &str = "Docker-Distribution-Api-Version";
 
 pub mod errors;
@@ -18,24 +18,74 @@ pub mod reference;
 
 type OciResult<T> = Result<T, anyhow::Error>;
 
-struct Client {}
+struct Client {
+    token: Option<StandardToken>,
+}
 
 impl Default for Client {
     fn default() -> Self {
-        Client {}
+        Client { token: None }
     }
 }
 
 impl Client {
+    /// According to the v2 specification, 200 and 401 error codes MUST return the
+    /// version. It appears that any other response code should be deemed non-v2.
+    ///
+    /// For this implementation, it will return v2 or an error result. If the error is a
+    /// `reqwest` error, the request itself failed. All other error messages mean that
+    /// v2 is not supported.
     pub async fn version(&self, host: String) -> OciResult<String> {
-        let url = format!("https://{}/{}/", host, OCI_VERSION_2);
+        let url = format!("https://{}/v2/", host);
         let res = reqwest::get(&url).await?;
         let disthdr = res.headers().get(OCI_VERSION_KEY);
         let version = disthdr
-            .ok_or_else(|| anyhow::format_err!("no header {} found", OCI_VERSION_KEY))?
+            .ok_or_else(|| anyhow::format_err!("no header v2 found"))?
             .to_str()?
             .to_owned();
         Ok(version)
+    }
+
+    /// Perform an OAuth v2 auth request if necessary.
+    ///
+    /// This performs authorization and then stores the token internally to be used
+    /// on other requests.
+    pub async fn auth(&mut self, host: String, secret: Option<String>) -> OciResult<()> {
+        let cli = reqwest::Client::new();
+        // The version request will tell us where to go.
+        let url = format!("https://{}/v2/", host);
+        let res = cli.get(&url).send().await?;
+        let disthdr = res.headers().get(reqwest::header::WWW_AUTHENTICATE);
+        if disthdr.is_none() {
+            // The Authenticate header can be set to empty string.
+            return Ok(());
+        }
+        // FIXME: There must be a more elegant way of passing a header from hyper into WwwAuthenticate.
+        let auth = WwwAuthenticate::parse_header(&disthdr.unwrap().to_str()?.to_string().into())?;
+        let challenge_opt = auth.get::<BearerChallenge>();
+        if challenge_opt.is_none() {
+            return Ok(());
+        }
+
+        let challenge = challenge_opt.as_ref().unwrap()[0].clone();
+        let realm = challenge.realm.unwrap();
+        let mut oauth = OauthClient::new(
+            "krustlet",
+            Url::parse(realm.as_str())?,
+            Url::parse(realm.as_str())?,
+        );
+        oauth.add_scope(challenge.scope.unwrap().as_str());
+        oauth.set_client_secret(secret.unwrap_or_else(|| "".to_owned()));
+
+        let token = oauth
+            .exchange_client_credentials()
+            .with_client(&cli)
+            .execute::<StandardToken>()
+            .await?;
+
+        self.token = Some(token);
+
+        Ok(())
     }
 
     pub async fn pull_manifest(&self, image_name: String) -> OciResult<String> {
@@ -57,6 +107,41 @@ impl Client {
     }
 }
 
+#[derive(Clone)]
+struct BearerChallenge {
+    pub realm: Option<String>,
+    pub service: Option<String>,
+    pub scope: Option<String>,
+}
+
+impl Challenge for BearerChallenge {
+    fn challenge_name() -> &'static str {
+        "Bearer"
+    }
+    fn from_raw(raw: RawChallenge) -> Option<Self> {
+        match raw {
+            RawChallenge::Token68(_) => None,
+            RawChallenge::Fields(mut map) => Some(BearerChallenge {
+                // NB (mpb): This follows the `remove` pattern from the existing
+                // implementations. Not sure why they do this, though.
+                realm: map.remove("realm"),
+                scope: map.remove("scope"),
+                service: map.remove("service"),
+            }),
+        }
+    }
+    fn into_raw(self) -> RawChallenge {
+        let mut map = ChallengeFields::new();
+        self.realm
+            .and_then(|realm| map.insert_static_quoting("realm", realm));
+        self.scope
+            .and_then(|item| map.insert_static_quoting("scope", item));
+        self.service
+            .and_then(|item| map.insert_static_quoting("service", item));
+        RawChallenge::Fields(map)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -71,11 +156,18 @@ mod test {
     }
 
     #[tokio::test]
+    async fn test_auth() {
+        let mut c = Client::default();
+        c.auth("webassembly.azurecr.io".to_owned(), None)
+            .await
+            .expect("result from version request");
+    }
+
+    #[tokio::test]
     async fn test_pull_manifest() {
         // Currently, pull_manifest does not perform Authz, so this will fail.
         let c = Client::default();
-        let res = c
-            .pull_manifest("webassembly.azurecr.io/hello:v1".to_owned())
+        c.pull_manifest("webassembly.azurecr.io/hello:v1".to_owned())
             .await
             .expect_err("pull manifest should fail");
     }

--- a/crates/oci-distribution/src/lib.rs
+++ b/crates/oci-distribution/src/lib.rs
@@ -1,0 +1,82 @@
+#[macro_use]
+extern crate serde;
+
+use serde::Deserialize;
+use std::convert::TryFrom;
+
+use crate::errors::*;
+use crate::reference::Reference;
+
+/// The OCI Distribution specification version 2.
+///
+/// This marker is used in URLs for accessing OCI Distributiion endpoints.
+const OCI_VERSION_2: &str = "v2";
+const OCI_VERSION_KEY: &str = "Docker-Distribution-Api-Version";
+
+pub mod errors;
+pub mod reference;
+
+type OciResult<T> = Result<T, anyhow::Error>;
+
+struct Client {}
+
+impl Default for Client {
+    fn default() -> Self {
+        Client {}
+    }
+}
+
+impl Client {
+    pub async fn version(&self, host: String) -> OciResult<String> {
+        let url = format!("https://{}/{}/", host, OCI_VERSION_2);
+        let res = reqwest::get(&url).await?;
+        let disthdr = res.headers().get(OCI_VERSION_KEY);
+        let version = disthdr
+            .ok_or_else(|| anyhow::format_err!("no header {} found", OCI_VERSION_KEY))?
+            .to_str()?
+            .to_owned();
+        Ok(version)
+    }
+
+    pub async fn pull_manifest(&self, image_name: String) -> OciResult<String> {
+        // We unwrap right now because this try_from literally cannot fail.
+        let reference = Reference::try_from(image_name).unwrap();
+        let url = reference.to_v2_manifest_url();
+        let res = reqwest::get(&url).await?;
+        let status = res.status();
+        if res.status().is_client_error() {
+            // According to the OCI spec, we should see an error in the message body.
+            let err = res.json::<OciEnvelope>().await?;
+            // FIXME: This should not have to wrap the error.
+            return Err(anyhow::format_err!("{}", err.errors[0]));
+        } else if status.is_server_error() {
+            return Err(anyhow::format_err!("Server error at {}", url));
+        }
+        let text = res.text().await?;
+        Ok(text)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[tokio::test]
+    async fn test_version() {
+        let c = Client::default();
+        let ver = c
+            .version("webassembly.azurecr.io".to_owned())
+            .await
+            .expect("result from version request");
+        assert_eq!("registry/2.0".to_owned(), ver);
+    }
+
+    #[tokio::test]
+    async fn test_pull_manifest() {
+        // Currently, pull_manifest does not perform Authz, so this will fail.
+        let c = Client::default();
+        let res = c
+            .pull_manifest("webassembly.azurecr.io/hello:v1".to_owned())
+            .await
+            .expect_err("pull manifest should fail");
+    }
+}

--- a/crates/oci-distribution/src/manifest.rs
+++ b/crates/oci-distribution/src/manifest.rs
@@ -1,0 +1,182 @@
+use std::collections::HashMap;
+
+/// The mediatype for WASM layers.
+pub const WASM_LAYER_MEDIA_TYPE: &str = "application/vnd.wasm.content.layer.v1+wasm";
+/// The mediatype for an OCI manifest.
+pub const IMAGE_MANIFEST_MEDIA_TYPE: &str = "application/vnd.docker.distribution.manifest.v2+json";
+/// The mediatype for an image config (manifest).
+pub const IMAGE_CONFIG_MEDIA_TYPE: &str = "application/vnd.oci.image.config.v1+json";
+/// The mediatype that Docker uses for image configs.
+pub const IMAGE_DOCKER_CONFIG_MEDIA_TYPE: &str = "application/vnd.docker.container.image.v1+json";
+/// The mediatype for a layer.
+pub const IMAGE_LAYER_MEDIA_TYPE: &str = "application/vnd.oci.image.layer.v1.tar";
+/// The mediatype for a layer that is gzipped.
+pub const IMAGE_LAYER_GZIP_MEDIA_TYPE: &str = "application/vnd.oci.image.layer.v1.tar+gzip";
+/// The mediatype for a layer that is nondistributable.
+pub const IMAGE_LAYER_NONDISTRIBUTABLE_MEDIA_TYPE: &str =
+    "application/vnd.oci.image.layer.nondistributable.v1.tar";
+/// The mediatype for a layer that is nondistributable and gzipped.
+pub const IMAGE_LAYER_NONDISTRIBUTABLE_GZIP_MEDIA_TYPE: &str =
+    "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip";
+
+// TODO: Annotation key constants. https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys
+
+/// The OCI manifest describes an OCI image.
+///
+/// It is part of the OCI specification, and is defined here:
+/// https://github.com/opencontainers/image-spec/blob/master/manifest.md
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OciManifest {
+    /// This is a schema version.
+    ///
+    /// The specification does not specify the width of this integer.
+    /// However, the only version allowed by the specification is `2`.
+    /// So we have made this a u8.
+    pub schema_version: u8,
+
+    /// This is an optional media type describing this manifest.
+    ///
+    /// It is reserved for compatibility, but the specification does not seem
+    /// to recommend setting it.
+    pub media_type: Option<String>,
+
+    /// The image configuration.
+    ///
+    /// This object is required.
+    pub config: OciDescriptor,
+
+    /// The OCI image layers
+    ///
+    /// The specification is unclear whether this is required. We have left it
+    /// required, assuming an empty vector can be used if necessary.
+    pub layers: Vec<OciDescriptor>,
+
+    /// The annotations for this manifest
+    ///
+    /// The specification says "If there are no annotations then this property
+    /// MUST either be absent or be an empty map."
+    /// TO accomodate either, this is optional.
+    pub annotations: Option<HashMap<String, String>>,
+}
+
+impl Default for OciManifest {
+    fn default() -> Self {
+        OciManifest {
+            schema_version: 2,
+            media_type: None,
+            config: OciDescriptor::default(),
+            layers: vec![],
+            annotations: None,
+        }
+    }
+}
+
+/// The OCI descriptor is a generic object used to describe other objects.
+///
+/// It is defined in the OCI Image Specification:
+/// https://github.com/opencontainers/image-spec/blob/master/descriptor.md#properties
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OciDescriptor {
+    /// The media type of this descriptor.
+    ///
+    /// Layers, config, and manifests may all have descriptors. Each
+    /// is differentiated by its mediaType.
+    ///
+    /// This REQUIRED property contains the media type of the referenced
+    /// content. Values MUST comply with RFC 6838, including the naming
+    /// requirements in its section 4.2.
+    pub media_type: String,
+    /// The SHA 256 or 512 digest of the object this describes.
+    ///
+    /// This REQUIRED property is the digest of the targeted content, conforming
+    /// to the requirements outlined in Digests. Retrieved content SHOULD be
+    /// verified against this digest when consumed via untrusted sources.
+    pub digest: String,
+    /// The size, in bytes, of the object this describes.
+    ///
+    /// This REQUIRED property specifies the size, in bytes, of the raw
+    /// content. This property exists so that a client will have an expected
+    /// size for the content before processing. If the length of the retrieved
+    /// content does not match the specified length, the content SHOULD NOT be
+    /// trusted.
+    pub size: i64,
+    /// This OPTIONAL property specifies a list of URIs from which this
+    /// object MAY be downloaded. Each entry MUST conform to RFC 3986.
+    /// Entries SHOULD use the http and https schemes, as defined in RFC 7230.
+    pub urls: Option<Vec<String>>,
+
+    /// This OPTIONAL property contains arbitrary metadata for this descriptor.
+    /// This OPTIONAL property MUST use the annotation rules.
+    /// https://github.com/opencontainers/image-spec/blob/master/annotations.md#rules
+    pub annotations: Option<HashMap<String, String>>,
+}
+
+impl Default for OciDescriptor {
+    fn default() -> Self {
+        OciDescriptor {
+            media_type: IMAGE_CONFIG_MEDIA_TYPE.to_owned(),
+            digest: "".to_owned(),
+            size: 0,
+            urls: None,
+            annotations: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    const TEST_MANIFEST: &str = r#"{
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+        "config": {
+            "mediaType": "application/vnd.docker.container.image.v1+json",
+            "size": 2,
+            "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+        },
+        "layers": [
+            {
+                "mediaType": "application/vnd.wasm.content.layer.v1+wasm",
+                "size": 1615998,
+                "digest": "sha256:f9c91f4c280ab92aff9eb03b279c4774a80b84428741ab20855d32004b2b983f",
+                "annotations": {
+                    "org.opencontainers.image.title": "module.wasm"
+                }
+            }
+        ]
+    }
+    "#;
+
+    #[test]
+    fn test_manifest() {
+        let manifest: OciManifest = serde_json::from_str(TEST_MANIFEST).expect("parsed manifest");
+        assert_eq!(2, manifest.schema_version);
+        assert_eq!(
+            Some(IMAGE_MANIFEST_MEDIA_TYPE.to_owned()),
+            manifest.media_type
+        );
+        let config = manifest.config;
+        // Note that this is the Docker config media type, not the OCI one.
+        assert_eq!(IMAGE_DOCKER_CONFIG_MEDIA_TYPE.to_owned(), config.media_type);
+        assert_eq!(2, config.size);
+        assert_eq!(
+            "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a".to_owned(),
+            config.digest
+        );
+
+        assert_eq!(1, manifest.layers.len());
+        let wasm_layer = &manifest.layers[0];
+        assert_eq!(1_615_998, wasm_layer.size);
+        assert_eq!(WASM_LAYER_MEDIA_TYPE.to_owned(), wasm_layer.media_type);
+        assert_eq!(
+            1,
+            wasm_layer
+                .annotations
+                .as_ref()
+                .expect("annotations map")
+                .len()
+        );
+    }
+}

--- a/crates/oci-distribution/src/reference.rs
+++ b/crates/oci-distribution/src/reference.rs
@@ -1,0 +1,82 @@
+use std::convert::{Into, TryFrom};
+
+// currently, the library only accepts modules tagged in the following structure:
+// <registry>/<repository>:<tag>
+// for example: webassembly.azurecr.io/hello:v1
+#[derive(Clone)]
+pub struct Reference {
+    whole: String,
+    slash: usize,
+    colon: usize,
+}
+
+impl Reference {
+    pub fn whole(&self) -> &str {
+        &self.whole
+    }
+
+    pub fn registry(&self) -> &str {
+        &self.whole[..self.slash]
+    }
+
+    pub fn repository(&self) -> &str {
+        &self.whole[self.slash + 1..self.colon]
+    }
+
+    pub fn tag(&self) -> &str {
+        &self.whole[self.colon + 1..]
+    }
+
+    pub fn to_v2_manifest_url(&self) -> String {
+        format!(
+            "https://{}/v2/{}/manifests/{}",
+            self.registry(),
+            self.repository(),
+            self.tag()
+        )
+    }
+}
+
+impl TryFrom<String> for Reference {
+    type Error = ();
+    fn try_from(string: String) -> Result<Self, Self::Error> {
+        let slash = string.find('/').ok_or(())?;
+        let colon = string[slash + 1..].find(':').ok_or(())?;
+        Ok(Reference {
+            whole: string,
+            slash,
+            colon: slash + 1 + colon,
+        })
+    }
+}
+
+impl Into<String> for Reference {
+    fn into(self) -> String {
+        self.whole
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn correctly_parses_string() {
+        let reference = Reference::try_from("webassembly.azurecr.io/hello:v1".to_owned())
+            .expect("Could not parse reference");
+
+        assert_eq!(reference.registry(), "webassembly.azurecr.io");
+        assert_eq!(reference.repository(), "hello");
+        assert_eq!(reference.tag(), "v1");
+    }
+
+    #[test]
+    fn test_to_v2_manifest() {
+        let reference = Reference::try_from("webassembly.azurecr.io/hello:v1".to_owned())
+            .expect("Could not parse reference");
+        assert_eq!(
+            "https://webassembly.azurecr.io/v2/hello/manifests/v1",
+            reference.to_v2_manifest_url()
+        );
+    }
+}


### PR DESCRIPTION
This PR adds a crate for OCI Distribution. It has a working `version` call, and a `pull_manifest` call that hits the correct endpoint. But we need AuthZ implemented before that one will work. I have begun working on that.

We can either merge this now so that others can help, or I can keep pushing it along for a while until we get to something that meets our requirement for viability.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>