### PR TITLE
feat(kubelet): Fully glues together logs logic

### DIFF
--- a/crates/kubelet/src/kubelet.rs
+++ b/crates/kubelet/src/kubelet.rs
@@ -214,7 +214,7 @@ pub trait Provider {
         _namespace: String,
         _pod: String,
         _container: String,
-    ) -> Result<Vec<String>, failure::Error> {
+    ) -> Result<Vec<u8>, failure::Error> {
         Err(NotImplementedError {}.into())
     }
 

--- a/crates/kubelet/src/server.rs
+++ b/crates/kubelet/src/server.rs
@@ -74,25 +74,26 @@ async fn get_container_logs<T: Provider + Sync>(
     let path: Vec<&str> = req.uri().path().split('/').collect();
     // Because of the leading slash, index 0 is an empty string. Index 1 is the
     // container logs path
-    if path.len() != 5 {
-        let mut res = Response::new(Body::from(format!(
-            "Resource {} not found",
-            req.uri().path()
-        )));
-        *res.status_mut() = StatusCode::NOT_FOUND;
-        return res;
-    }
-
-    let namespace = path[2];
-    let pod = path[3];
-    let container = path[4];
+    let (namespace, pod, container) = match path.as_slice() {
+        [_, _, namespace, pod, container] => (*namespace, *pod, *container),
+        _ => {
+            return Response::builder()
+                .status(StatusCode::NOT_FOUND)
+                .body(Body::from(format!(
+                    "Resource {} not found",
+                    req.uri().path()
+                )))
+                .unwrap()
+        }
+    };
     if namespace.is_empty() || pod.is_empty() || container.is_empty() {
-        let mut res = Response::new(Body::from(format!(
-            "Resource {} not found",
-            req.uri().path()
-        )));
-        *res.status_mut() = StatusCode::NOT_FOUND;
-        return res;
+        return Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(Body::from(format!(
+                "Resource {} not found",
+                req.uri().path()
+            )))
+            .unwrap();
     }
 
     // END validation

--- a/crates/wasi-provider/Cargo.toml
+++ b/crates/wasi-provider/Cargo.toml
@@ -25,7 +25,7 @@ serde = "1.0"
 serde_json = "1.0"
 kubelet = { path = "../kubelet", version = "0.1.0" }
 wat = "1.0"
-tokio = { version = "0.2.13", features = ["fs", "stream", "macros"] }
+tokio = { version = "0.2.13", features = ["fs", "stream", "macros", "io-util"] }
 
 [dev-dependencies]
 k8s-openapi = { version = "0.7.1", features = ["v1_17"] }

--- a/crates/wasi-provider/src/lib.rs
+++ b/crates/wasi-provider/src/lib.rs
@@ -187,7 +187,7 @@ impl Provider for WasiProvider {
                 pod_name,
                 container_name,
             })?;
-        let mut output = Vec::default();
+        let mut output = Vec::new();
         (&mut handle.0).read_to_end(&mut output).await?;
         // Reset the seek location for the next call to read from the file
         // NOTE: This is a little janky, but the Tokio BufReader does not


### PR DESCRIPTION
As part of this, I changed the provider trait to instead return a vec
of bytes instead of worrying about all the allocations of copying each
line into a string. Instead the raw data is just passed back as part of
the HTTP response body.

I also found that the wasi logs implementation needed to reset the seek
pointer to the beginning of the file for future reads, so that has now
been fixed

NOTE: This is not currently tested with a running master because we do
not have HTTPS set up yet. It has been tested with manual calls to the
endpoint

Closes #33