### PR TITLE
Update build action to build and test on macOS and Ubuntu

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,13 +4,21 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - {os: "ubuntu-latest", url: "https://github.com/casey/just/releases/download/v0.5.8/just-v0.5.8-x86_64-unknown-linux-musl.tar.gz", name: "just", pathInArchive: "just" }
+        - {os: "macos-latest", url: "https://github.com/casey/just/releases/download/v0.5.8/just-v0.5.8-x86_64-apple-darwin.tar.gz", name: "just", pathInArchive: "just" }
     steps:
       - uses: actions/checkout@v1
+      - uses: engineerd/configurator@v0.0.1
+        with:
+          name: ${{ matrix.config.name }}
+          url: ${{ matrix.config.url }}
+          pathInArchive: ${{ matrix.config.pathInArchive }}
       - name: Build
         run: |
-          wget https://github.com/casey/just/releases/download/v0.5.8/just-v0.5.8-x86_64-unknown-linux-musl.tar.gz
-          tar -xzf just-v0.5.8-x86_64-unknown-linux-musl.tar.gz -C /tmp
-          /tmp/just build
-          /tmp/just test
+          just build
+          just test


### PR DESCRIPTION
This PR updates our build action to also build for macOS.

It uses a simple matrix config for the operating system, and introduces a dependency on [this GitHub Action](https://github.com/marketplace/actions/engineerd-configurator) to simplify the download of `just`.

Note that testing on macOS is still failing:

```
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: Error(HostCallFailure(DecodeError { description: "buffer underflow", stack: [] }))', src/libcore/result.rs:1188:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
test test::test_wascc_run ... FAILED

failures:

---- test::test_wascc_run stdout ----
thread 'test::test_wascc_run' panicked at 'called `Result::unwrap()` on an `Err` value: RecvError', src/libcore/result.rs:1188:5


failures:
    test::test_wascc_run

test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
```