### PR TITLE
feat(wasi): Adds runtime handle wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3224,6 +3224,7 @@ name = "wasi-provider"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "chrono",
  "failure",
  "k8s-openapi",
  "kube",

--- a/crates/wascc-provider/src/lib.rs
+++ b/crates/wascc-provider/src/lib.rs
@@ -180,6 +180,7 @@ impl Provider for WasccProvider {
             None => Ok(Status {
                 phase: Phase::Unknown,
                 message: None,
+                container_statuses: Vec::new(),
             }),
             Some(pk) => {
                 let pk = pk.clone();
@@ -190,11 +191,13 @@ impl Provider for WasccProvider {
                         Ok(Status {
                             phase: Phase::Succeeded,
                             message: None,
+                            container_statuses: Vec::new(),
                         })
                     }
                     Some(_) => Ok(Status {
                         phase: Phase::Running,
                         message: None,
+                        container_statuses: Vec::new(),
                     }),
                 }
             }

--- a/crates/wasi-provider/Cargo.toml
+++ b/crates/wasi-provider/Cargo.toml
@@ -25,7 +25,9 @@ serde = "1.0"
 serde_json = "1.0"
 kubelet = { path = "../kubelet", version = "0.1.0" }
 wat = "1.0"
-tokio = { version = "0.2.13", features = ["fs", "stream", "macros", "io-util"] }
+tokio = { version = "0.2.13", features = ["fs", "stream", "macros", "io-util", "sync"] }
+k8s-openapi = { version = "0.7.1", default-features = false, features = ["v1_17"] }
+chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
 k8s-openapi = { version = "0.7.1", features = ["v1_17"] }

--- a/crates/wasi-provider/src/handle.rs
+++ b/crates/wasi-provider/src/handle.rs
@@ -1,0 +1,70 @@
+use std::io::SeekFrom;
+
+use tokio::io::{AsyncReadExt, AsyncSeekExt, BufReader};
+use tokio::sync::watch::Receiver;
+use tokio::task::JoinHandle;
+
+use kubelet::ContainerStatus;
+
+/// Represents a handle to a running WASI instance. Right now, this is
+/// experimental and just for use with the [crate::WasiProvider]. If we like
+/// this pattern, we will expose it as part of the kubelet crate
+pub struct RuntimeHandle<R: AsyncReadExt + AsyncSeekExt + Unpin> {
+    output: BufReader<R>,
+    handle: JoinHandle<Result<(), failure::Error>>,
+    status_channel: Receiver<ContainerStatus>,
+}
+
+impl<R: AsyncReadExt + AsyncSeekExt + Unpin> RuntimeHandle<R> {
+    /// Create a new handle with the given reader for log output and a handle to
+    /// the running tokio task. The sender part of the channel should be given
+    /// to the running process and the receiver half passed to this constructor
+    /// to be used for reporting current status
+    pub fn new(
+        output: R,
+        handle: JoinHandle<Result<(), failure::Error>>,
+        status_channel: Receiver<ContainerStatus>,
+    ) -> Self {
+        RuntimeHandle {
+            output: BufReader::new(output),
+            handle,
+            status_channel,
+        }
+    }
+
+    /// Write all of the output from the running process into the given buffer.
+    /// Returns the number of bytes written to the buffer
+    pub async fn output(&mut self, buf: &mut Vec<u8>) -> Result<usize, failure::Error> {
+        let bytes_written = self.output.read_to_end(buf).await?;
+        // Reset the seek location for the next call to read from the file
+        // NOTE: This is a little janky, but the Tokio BufReader does not
+        // implement the AsyncSeek trait
+        self.output.get_mut().seek(SeekFrom::Start(0)).await?;
+        Ok(bytes_written)
+    }
+
+    /// Signal the running instance to stop and wait for it to complete. As of
+    /// right now, there is not a way to do this in wasmtime, so this does
+    /// nothing
+    pub async fn stop(&mut self) -> Result<(), failure::Error> {
+        // TODO: Send an actual stop signal once there is support in wasmtime
+        self.wait().await?;
+        unimplemented!("There is currently no way to stop a running wasmtime instance")
+    }
+
+    /// Returns the current status of the process
+    pub async fn status(&self) -> Result<ContainerStatus, failure::Error> {
+        // NOTE: For those who modify this in the future, borrow must be as
+        // short lived as possible as it can block the send half. We do not use
+        // the recv method because it uses the value each time and then waits
+        // for a new value on the next call, whereas we want to return the last
+        // sent value until updated
+        Ok(self.status_channel.borrow().clone())
+    }
+
+    // For now this is private (for use in testing and in stop). If we find a
+    // need to expose it, we can do that later
+    pub(crate) async fn wait(&mut self) -> Result<(), failure::Error> {
+        (&mut self.handle).await.unwrap()
+    }
+}

--- a/crates/wasi-provider/src/handle.rs
+++ b/crates/wasi-provider/src/handle.rs
@@ -37,8 +37,8 @@ impl<R: AsyncReadExt + AsyncSeekExt + Unpin> RuntimeHandle<R> {
     pub async fn output(&mut self, buf: &mut Vec<u8>) -> Result<usize, failure::Error> {
         let bytes_written = self.output.read_to_end(buf).await?;
         // Reset the seek location for the next call to read from the file
-        // NOTE: This is a little janky, but the Tokio BufReader does not
-        // implement the AsyncSeek trait
+        // NOTE: The Tokio BufReader does not implement seek, so we need to get
+        // a mutable ref to the inner file and perform the seek
         self.output.get_mut().seek(SeekFrom::Start(0)).await?;
         Ok(bytes_written)
     }

--- a/crates/wasi-provider/src/lib.rs
+++ b/crates/wasi-provider/src/lib.rs
@@ -1,3 +1,4 @@
+mod handle;
 mod wasi_runtime;
 
 use std::collections::HashMap;
@@ -11,7 +12,8 @@ use log::{debug, info};
 use tokio::fs::File;
 use tokio::sync::RwLock;
 
-use wasi_runtime::{RuntimeHandle, WasiRuntime};
+use handle::RuntimeHandle;
+use wasi_runtime::WasiRuntime;
 
 const TARGET_WASM32_WASI: &str = "wasm32-wasi";
 
@@ -97,7 +99,7 @@ impl Provider for WasiProvider {
                 )?;
 
                 debug!("Starting container {} on thread", container.name);
-                let handle = runtime.run().await?;
+                let handle = runtime.start().await?;
                 entry.insert(container.name.clone(), handle);
             }
         }
@@ -174,7 +176,8 @@ impl Provider for WasiProvider {
                 pod_name,
                 container_name,
             })?;
-        let output = handle.output().await?;
+        let mut output = Vec::new();
+        handle.output(&mut output).await?;
         Ok(output)
     }
 }

--- a/crates/wasi-provider/src/lib.rs
+++ b/crates/wasi-provider/src/lib.rs
@@ -96,7 +96,8 @@ impl Provider for WasiProvider {
                     HashMap::default(),
                     // TODO: Actual log path configuration
                     std::env::current_dir()?,
-                )?;
+                )
+                .await?;
 
                 debug!("Starting container {} on thread", container.name);
                 let handle = runtime.start().await?;

--- a/crates/wasi-provider/src/wasi_runtime.rs
+++ b/crates/wasi-provider/src/wasi_runtime.rs
@@ -1,9 +1,17 @@
 use std::collections::HashMap;
-use std::fs::File;
+use std::io::SeekFrom;
 use std::path::Path;
 
 use failure::{bail, format_err};
-use log::info;
+use k8s_openapi::api::core::v1::{
+    ContainerState, ContainerStateRunning, ContainerStateTerminated, ContainerStateWaiting,
+};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::Time;
+use log::{error, info};
+use tempfile::NamedTempFile;
+use tokio::io::{AsyncReadExt, AsyncSeekExt, BufReader};
+use tokio::sync::watch::{self, Receiver};
+use tokio::task::JoinHandle;
 use wasi_common::preopen_dir;
 use wasmtime_wasi::old::snapshot_0::Wasi as WasiUnstable;
 use wasmtime_wasi::{Wasi, WasiCtxBuilder};
@@ -21,6 +29,9 @@ pub struct WasiRuntime {
     /// (e.g. /tmp/foo/myfile -> /app/config). If the optional value is not given,
     /// the same path will be allowed in the runtime
     dirs: HashMap<String, Option<String>>,
+
+    /// The tempfile that output from the wasmtime process writes to
+    output: NamedTempFile,
 }
 
 impl WasiRuntime {
@@ -34,27 +45,33 @@ impl WasiRuntime {
     /// * `dirs` - a map of local file system paths to optional path names in the runtime
     ///     (e.g. /tmp/foo/myfile -> /app/config). If the optional value is not given,
     ///     the same path will be allowed in the runtime
-    /// * `log_file_location` - location for storing logs
-    pub fn new<M: AsRef<Path>>(
+    /// * `log_dir` - location for storing logs
+    pub fn new<M: AsRef<Path>, L: AsRef<Path>>(
         module_path: M,
         env: HashMap<String, String>,
         args: Vec<String>,
         dirs: HashMap<String, Option<String>>,
+        log_dir: L,
     ) -> Result<Self, failure::Error> {
         let module_data = wat::parse_file(module_path)?;
 
+        // We need to use named temp file because we need multiple file handles
+        // and if we are running in the temp dir, we run the possibility of the
+        // temp file getting cleaned out from underneath us while running. If we
+        // think it necessary, we can make these permanent files with a cleanup
+        // loop that runs elsewhere. These will get deleted when the reference
+        // is dropped
         Ok(WasiRuntime {
             module_data,
             env,
             args,
             dirs,
+            output: NamedTempFile::new_in(log_dir)?,
         })
     }
 
-    pub fn run(&self, output: File) -> Result<(), failure::Error> {
-        let engine = wasmtime::Engine::default();
-        let store = wasmtime::Store::new(&engine);
-
+    pub async fn run(&self) -> Result<RuntimeHandle<tokio::fs::File>, failure::Error> {
+        let output = self.output.reopen()?;
         // Build the WASI instance and then generate a list of WASI modules
         let mut ctx_builder_snapshot = WasiCtxBuilder::new();
         // For some reason if I didn't split these out, the compiler got mad
@@ -71,64 +88,246 @@ impl WasiRuntime {
 
         for (key, value) in self.dirs.iter() {
             let guest_dir = value.as_ref().unwrap_or(key);
-            // Try and preopen the directory and then try to clone it. This step adds the directory to the context
             ctx_builder_snapshot = ctx_builder_snapshot.preopened_dir(preopen_dir(key)?, guest_dir);
             ctx_builder_unstable = ctx_builder_unstable.preopened_dir(preopen_dir(key)?, guest_dir);
         }
         let wasi_ctx_snapshot = ctx_builder_snapshot.build()?;
         let wasi_ctx_unstable = ctx_builder_unstable.build()?;
 
-        let wasi_snapshot = Wasi::new(&store, wasi_ctx_snapshot);
-        let wasi_unstable = WasiUnstable::new(&store, wasi_ctx_unstable);
-        let module = wasmtime::Module::new(&store, &self.module_data)
-            .map_err(|e| format_err!("unable to load module data {}", e))?;
-        // Iterate through the module includes and resolve imports
-        let imports = module
-            .imports()
-            .iter()
-            .map(|i| {
-                // This is super funky logic, but it matches what is in 0.11.0
-                let export = match i.module() {
-                    "wasi_snapshot_preview1" => wasi_snapshot.get_export(i.name()),
-                    "wasi_unstable" => wasi_unstable.get_export(i.name()),
-                    other => bail!("import module `{}` was not found", other),
-                };
-                match export {
-                    Some(export) => Ok(export.clone().into()),
-                    None => bail!(
-                        "import `{}` was not found in module `{}`",
-                        i.name(),
-                        i.module()
-                    ),
+        // Clone the module data so it can be moved and we don't have to worry
+        // about the lifetime of the struct data
+        let module_data = self.module_data.clone();
+        // We could get multiple status updates, so this gives a little
+        // breathing room while avoiding blocking. This is currently super
+        // naive, but will work for now. In the future, we may just want to use
+        // a try_send with a retry
+        let (status_sender, status_recv) = watch::channel(ContainerState {
+            waiting: Some(ContainerStateWaiting {
+                message: Some("No status has been received from the process".into()),
+                reason: None,
+            }),
+            ..Default::default()
+        });
+        let handle = tokio::task::spawn_blocking(move || -> Result<_, failure::Error> {
+            let engine = wasmtime::Engine::default();
+            let store = wasmtime::Store::new(&engine);
+            let wasi_snapshot = Wasi::new(&store, wasi_ctx_snapshot);
+            let wasi_unstable = WasiUnstable::new(&store, wasi_ctx_unstable);
+            let module = match wasmtime::Module::new(&store, &module_data) {
+                // We can't map errors here or it moves the send channel, so we
+                // do it in a match
+                Ok(m) => Ok(m),
+                Err(e) => {
+                    let message = "unable to create module";
+                    error!("{}: {:?}", message, e);
+                    status_sender
+                        .broadcast(ContainerState {
+                            terminated: Some(ContainerStateTerminated {
+                                message: Some(message.into()),
+                                reason: None,
+                                exit_code: 1,
+                                finished_at: Some(Time(chrono::Utc::now())),
+                                ..Default::default()
+                            }),
+                            ..Default::default()
+                        })
+                        .expect("status should be able to send");
+                    // Converting from anyhow
+                    Err(format_err!("{}: {}", message, e))
                 }
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+            }?;
+            // Iterate through the module includes and resolve imports
+            let imports = match module
+                .imports()
+                .iter()
+                .map(|i| {
+                    // This is super funky logic, but it matches what is in 0.12.0
+                    let export = match i.module() {
+                        "wasi_snapshot_preview1" => wasi_snapshot.get_export(i.name()),
+                        "wasi_unstable" => wasi_unstable.get_export(i.name()),
+                        other => bail!("import module `{}` was not found", other),
+                    };
+                    match export {
+                        Some(export) => Ok(export.clone().into()),
+                        None => bail!(
+                            "import `{}` was not found in module `{}`",
+                            i.name(),
+                            i.module()
+                        ),
+                    }
+                })
+                .collect::<Result<Vec<_>, _>>()
+            {
+                // We can't map errors here or it moves the send channel, so we
+                // do it in a match
+                Ok(m) => Ok(m),
+                Err(e) => {
+                    let message = "unable to load module";
+                    error!("{}: {:?}", message, e);
+                    status_sender
+                        .broadcast(ContainerState {
+                            terminated: Some(ContainerStateTerminated {
+                                message: Some(message.into()),
+                                reason: None,
+                                exit_code: 1,
+                                finished_at: Some(Time(chrono::Utc::now())),
+                                ..Default::default()
+                            }),
+                            ..Default::default()
+                        })
+                        .expect("status should be able to send");
+                    Err(e)
+                }
+            }?;
 
-        let instance = wasmtime::Instance::new(&module, &imports)
-            .map_err(|e| format_err!("unable to instantiate module: {}", e))?;
+            let instance = match wasmtime::Instance::new(&module, &imports) {
+                // We can't map errors here or it moves the send channel, so we
+                // do it in a match
+                Ok(m) => Ok(m),
+                Err(e) => {
+                    let message = "unable to instantiate module";
+                    error!("{}: {:?}", message, e);
+                    status_sender
+                        .broadcast(ContainerState {
+                            terminated: Some(ContainerStateTerminated {
+                                message: Some(message.into()),
+                                reason: None,
+                                exit_code: 1,
+                                finished_at: Some(Time(chrono::Utc::now())),
+                                ..Default::default()
+                            }),
+                            ..Default::default()
+                        })
+                        .expect("status should be able to send");
+                    // Converting from anyhow
+                    Err(format_err!("{}: {}", message, e))
+                }
+            }?;
 
-        // NOTE(taylor): In the future, if we want to pass args directly, we'll
-        // need to do a bit more to pass them in here.
-        info!("starting run of module");
-        instance
-            .get_export("_start")
-            .expect("export")
-            .func()
-            .unwrap()
-            .call(&[])
-            .unwrap();
+            // NOTE(taylor): In the future, if we want to pass args directly, we'll
+            // need to do a bit more to pass them in here.
+            info!("starting run of module");
+            status_sender
+                .broadcast(ContainerState {
+                    running: Some(ContainerStateRunning {
+                        started_at: Some(Time(chrono::Utc::now())),
+                    }),
+                    ..Default::default()
+                })
+                .expect("status should be able to send");
+            match instance
+                .get_export("_start")
+                .expect("export")
+                .func()
+                .unwrap()
+                .call(&[])
+            {
+                // We can't map errors here or it moves the send channel, so we
+                // do it in a match
+                Ok(m) => Ok(m),
+                Err(e) => {
+                    let message = "unable to run module";
+                    error!("{}: {:?}", message, e);
+                    status_sender
+                        .broadcast(ContainerState {
+                            terminated: Some(ContainerStateTerminated {
+                                message: Some(message.into()),
+                                reason: None,
+                                exit_code: 1,
+                                finished_at: Some(Time(chrono::Utc::now())),
+                                ..Default::default()
+                            }),
+                            ..Default::default()
+                        })
+                        .expect("status should be able to send");
+                    // Converting from anyhow
+                    Err(format_err!("{}: {}", message, e))
+                }
+            }?;
 
-        info!("module run complete");
-        Ok(())
+            info!("module run complete");
+            status_sender
+                .broadcast(ContainerState {
+                    terminated: Some(ContainerStateTerminated {
+                        message: Some("Module run completed".into()),
+                        exit_code: 0,
+                        finished_at: Some(Time(chrono::Utc::now())),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                })
+                .expect("status should be able to send");
+            Ok(())
+        });
+
+        Ok(RuntimeHandle::new(
+            tokio::fs::File::from_std(self.output.reopen()?),
+            handle,
+            status_recv,
+        ))
+    }
+}
+
+/// Represents a handle to a running WASI instance. Right now, this is
+/// experimental and just for use with the [crate::WasiProvider]. If we like
+/// this pattern, we will expose it as part of the kubelet crate
+pub struct RuntimeHandle<R: AsyncReadExt + AsyncSeekExt + Unpin> {
+    output: BufReader<R>,
+    handle: JoinHandle<Result<(), failure::Error>>,
+    status_channel: Receiver<ContainerState>,
+}
+
+impl<R: AsyncReadExt + AsyncSeekExt + Unpin> RuntimeHandle<R> {
+    /// Create a new handle with the given reader for log output and a handle to
+    /// the running tokio task. The sender part of the channel should be given
+    /// to the running process and the receiver half passed to this constructor
+    /// to be used for reporting current status
+    pub fn new(
+        output: R,
+        handle: JoinHandle<Result<(), failure::Error>>,
+        status_channel: Receiver<ContainerState>,
+    ) -> Self {
+        RuntimeHandle {
+            output: BufReader::new(output),
+            handle,
+            status_channel,
+        }
+    }
+
+    pub async fn output(&mut self) -> Result<Vec<u8>, failure::Error> {
+        let mut output = Vec::new();
+        self.output.read_to_end(&mut output).await?;
+        // Reset the seek location for the next call to read from the file
+        // NOTE: This is a little janky, but the Tokio BufReader does not
+        // implement the AsyncSeek trait
+        self.output.get_mut().seek(SeekFrom::Start(0)).await?;
+        Ok(output)
+    }
+
+    pub async fn stop(&mut self) -> Result<(), failure::Error> {
+        // TODO: Send an actual stop signal once there is support in wasmtime
+        self.wait().await?;
+        unimplemented!("There is currently no way to stop a running wasmtime instance")
+    }
+
+    pub async fn status(&self) -> Result<ContainerState, failure::Error> {
+        // NOTE: For those who modify this in the future, borrow must be as
+        // short lived as possible. We do not use the recv method because it
+        // uses the value each time and blocks on the next call, whereas we want
+        // to return the last sent value until updated
+        Ok((*self.status_channel.borrow()).clone())
+    }
+
+    // For now this is private (for use in testing and in stop). If we find a
+    // need to expose it, we can do that later
+    async fn wait(&mut self) -> Result<(), failure::Error> {
+        (&mut self.handle).await.unwrap()
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use tempfile::NamedTempFile;
-    use tokio::io::AsyncReadExt;
-    use tokio::io::BufReader;
 
     #[tokio::test]
     async fn test_run() {
@@ -137,14 +336,21 @@ mod test {
             HashMap::default(),
             Vec::default(),
             HashMap::default(),
+            std::env::current_dir().unwrap(),
         )
         .expect("wasi runtime init");
-        let output = NamedTempFile::new().unwrap();
-        wr.run(output.reopen().unwrap()).expect("complete run");
-        let mut stdout = String::default();
+        let mut handle = wr.run().await.expect("runtime handle");
+        handle.wait().await.expect("successful run");
 
-        let mut output = BufReader::new(tokio::fs::File::from_std(output.into_file()));
-        output.read_to_string(&mut stdout).await.unwrap();
-        assert_eq!("Hello, world!\n", stdout);
+        let output = handle.output().await.unwrap();
+        assert_eq!("Hello, world!\n".to_string().into_bytes(), output);
+
+        let status = handle.status().await.unwrap();
+        assert!(status.terminated.is_some());
+
+        // TODO: Once we add args support and other things that could actually
+        // cause a failure on start, we can test the intermediate state. Same
+        // thing when we get a longer running module we can test for running
+        // state
     }
 }


### PR DESCRIPTION
Introduces the new `RuntimeHandler` type for the WASI runtime. The purpose
of this handle is to wrap all of the logic for managing the process and
getting its logs/status/etc. after it has started. Ideally, this could be
something we generalize across all providers in the future after we hammer
the kinks out. There are still some clippy warnings due to some of the code
not yet being used

Note: This also introduces some basic messaging for each "container" to
inform the provider that its status has changed