### PR TITLE
Add image layer pull

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1588,6 +1588,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "futures-util",
  "hyperx",
  "reqwest",
  "serde",

--- a/crates/oci-distribution/Cargo.toml
+++ b/crates/oci-distribution/Cargo.toml
@@ -21,3 +21,4 @@ serde_json = "1.0"
 www-authenticate = "0.3.0"
 hyperx = "0.13"
 chrono = { version = "0.4", features = ["serde"] }
+futures-util = "0.3.4"

--- a/crates/oci-distribution/src/lib.rs
+++ b/crates/oci-distribution/src/lib.rs
@@ -35,8 +35,18 @@ pub struct Client {
     client: reqwest::Client,
 }
 
+/*
 impl Default for Client {
     fn default() -> Self {
+        Client {
+            token: None,
+            client: reqwest::Client::new(),
+        }
+    }
+}
+*/
+impl Client {
+    fn new() -> Self {
         Client {
             token: None,
             client: reqwest::Client::new(),
@@ -112,22 +122,11 @@ impl Client {
         }
     }
 
-    fn auth_headers(&self) -> HeaderMap {
-        let mut headers = HeaderMap::new();
-        headers.insert("Accept", "application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.list.v2+json".parse().unwrap());
-
-        if let Some(bearer) = self.token.as_ref() {
-            headers.insert("Authorization", bearer.bearer_token().parse().unwrap());
-        }
-        headers
-    }
-
     /// Pull a manifest from the remote OCI Distribution service.
     ///
     /// If the connection has already gone through authentication, this will
     /// use the bearer token. Otherwise, this will attempt an anonymous pull.
     pub async fn pull_manifest(&self, image: &Reference) -> OciResult<OciManifest> {
-        // We unwrap right now because this try_from literally cannot fail.
         let url = image.to_v2_manifest_url();
         let request = self.client.get(&url);
 
@@ -160,7 +159,7 @@ impl Client {
     /// repository and the registry, but it is not used to verify that
     /// the digest is a layer inside of the image. (The manifest is
     /// used for that.)
-    pub async fn pull_layer<T: std::io::Write>(
+    pub async fn pull_layer<T: std::io::Write + tokio::io::AsyncWrite>(
         &self,
         image: &Reference,
         digest: &str,
@@ -176,10 +175,26 @@ impl Client {
             .bytes_stream();
 
         while let Some(bytes) = stream.next().await {
-            out.write_all(&bytes?.to_vec())?;
+            //out.write_all(&bytes?.to_vec())?;
+            out.write_all(&bytes?)?;
         }
 
         Ok(out)
+    }
+
+    /// Generate the headers necessary for authentication.
+    ///
+    /// If the struct has Some(bearer), this will insert the bearer token in an
+    /// Authorization header. It will also set the Accept header, which must
+    /// be set on all OCI Registry request.
+    fn auth_headers(&self) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert("Accept", "application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.list.v2+json".parse().unwrap());
+
+        if let Some(bearer) = self.token.as_ref() {
+            headers.insert("Authorization", bearer.bearer_token().parse().unwrap());
+        }
+        headers
     }
 }
 
@@ -244,7 +259,7 @@ mod test {
 
     #[tokio::test]
     async fn test_version() {
-        let c = Client::default();
+        let c = Client::new();
         let ver = c
             .version("webassembly.azurecr.io")
             .await
@@ -254,8 +269,8 @@ mod test {
 
     #[tokio::test]
     async fn test_auth() {
-        let image = Reference::try_from(HELLO_IMAGE).expect("parsed reference");
-        let mut c = Client::default();
+        let image = Reference::try_from(HELLO_IMAGE).expect("failed to parse reference");
+        let mut c = Client::new();
         c.auth(&image, None)
             .await
             .expect("result from auth request");
@@ -267,17 +282,17 @@ mod test {
 
     #[tokio::test]
     async fn test_pull_manifest() {
-        let image = Reference::try_from(HELLO_IMAGE).expect("parsed reference");
+        let image = Reference::try_from(HELLO_IMAGE).expect("failed to parse reference");
         // Currently, pull_manifest does not perform Authz, so this will fail.
-        let c = Client::default();
+        let c = Client::new();
         c.pull_manifest(&image)
             .await
             .expect_err("pull manifest should fail");
 
         // But this should pass
-        let image = Reference::try_from(HELLO_IMAGE).expect("parsed reference");
+        let image = Reference::try_from(HELLO_IMAGE).expect("failed to parse reference");
         // Currently, pull_manifest does not perform Authz, so this will fail.
-        let mut c = Client::default();
+        let mut c = Client::new();
         c.auth(&image, None).await.expect("authenticated");
         let manifest = c
             .pull_manifest(&image)
@@ -291,17 +306,20 @@ mod test {
 
     #[tokio::test]
     async fn test_pull_layer() {
-        let image = Reference::try_from(HELLO_IMAGE).expect("parsed reference");
-        let mut c = Client::default();
+        let image = Reference::try_from(HELLO_IMAGE).expect("failed to parse reference");
+        let mut c = Client::new();
         c.auth(&image, None).await.expect("authenticated");
-        let manifest = c.pull_manifest(&image).await.expect("pull manifest");
+        let manifest = c
+            .pull_manifest(&image)
+            .await
+            .expect("failed to pull manifest");
 
         // Pull one specific layer
         let file: Vec<u8> = Vec::new();
-        let layer0 = manifest.layers[0].clone();
+        let layer0 = &manifest.layers[0];
 
         let file = c
-            .pull_layer(&image, layer0.digest.as_str(), file)
+            .pull_layer(&image, &layer0.digest, file)
             .await
             .expect("Pull layer into vec");
 

--- a/crates/oci-distribution/src/lib.rs
+++ b/crates/oci-distribution/src/lib.rs
@@ -36,17 +36,8 @@ pub struct Client {
     client: reqwest::Client,
 }
 
-/*
-impl Default for Client {
-    fn default() -> Self {
-        Client {
-            token: None,
-            client: reqwest::Client::new(),
-        }
-    }
-}
-*/
 impl Client {
+    // Create a new client initialized to share HTTP connections across multiple requests.
     fn new() -> Self {
         Client {
             token: None,
@@ -160,7 +151,7 @@ impl Client {
     /// repository and the registry, but it is not used to verify that
     /// the digest is a layer inside of the image. (The manifest is
     /// used for that.)
-    pub async fn pull_layer<T: AsyncWrite + AsyncWriteExt + Unpin>(
+    pub async fn pull_layer<T: AsyncWrite + Unpin>(
         &self,
         image: &Reference,
         digest: &str,

--- a/crates/oci-distribution/src/manifest.rs
+++ b/crates/oci-distribution/src/manifest.rs
@@ -76,7 +76,7 @@ impl Default for OciManifest {
 ///
 /// It is defined in the OCI Image Specification:
 /// https://github.com/opencontainers/image-spec/blob/master/descriptor.md#properties
-#[derive(Debug, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OciDescriptor {
     /// The media type of this descriptor.

--- a/crates/oci-distribution/src/reference.rs
+++ b/crates/oci-distribution/src/reference.rs
@@ -11,28 +11,43 @@ pub struct Reference {
 }
 
 impl Reference {
+    /// Get the original reference.
     pub fn whole(&self) -> &str {
         &self.whole
     }
 
+    /// Get the registry name.
     pub fn registry(&self) -> &str {
         &self.whole[..self.slash]
     }
 
+    /// Get the repository (a.k.a the image name) of this reference
     pub fn repository(&self) -> &str {
         &self.whole[self.slash + 1..self.colon]
     }
 
+    /// Get the tag for this reference.
     pub fn tag(&self) -> &str {
         &self.whole[self.colon + 1..]
     }
 
+    /// Convert a Reference to a v2 manifest URL.
     pub fn to_v2_manifest_url(&self) -> String {
         format!(
             "https://{}/v2/{}/manifests/{}",
             self.registry(),
             self.repository(),
             self.tag()
+        )
+    }
+
+    /// Convert a Reference to a v2 blob (layer) URL.
+    pub fn to_v2_blob_url(&self, digest: &str) -> String {
+        format!(
+            "https://{}/v2/{}/blobs/{}",
+            self.registry(),
+            self.repository(),
+            digest
         )
     }
 }


### PR DESCRIPTION
This adds support for _layer_ pulls on OCI images. OCI images have two artifact types that have to be pulled: manifests and layers. This adds support for pulling layers into local writers.

I am still working on this, but need help with one particular thing having to do with whether to use `tokio::io::AsyncWrite` or `std::io::Write`. Left a note inline.

The rest is not yet ready for review. Still need:

- [ ] ~A high-level `pull()` function~
- [ ] ~A way to describe where/how to store the full image~

*UPDATE:* To keep this from blocking other work, I have pared it back down to the minimum. I have addressed almost all of @rylev 's comments, but have reached out to him for a follow-up PR on the AsyncWrite in the loop.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>