### PR TITLE
fix(actions): Fixes GH actions checkout with version upgrade

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,20 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - {os: "ubuntu-latest", url: "https://github.com/casey/just/releases/download/v0.5.8/just-v0.5.8-x86_64-unknown-linux-musl.tar.gz", name: "just", pathInArchive: "just" }
-        - {os: "macos-latest", url: "https://github.com/casey/just/releases/download/v0.5.8/just-v0.5.8-x86_64-apple-darwin.tar.gz", name: "just", pathInArchive: "just" }
+          - {
+              os: "ubuntu-latest",
+              url: "https://github.com/casey/just/releases/download/v0.5.8/just-v0.5.8-x86_64-unknown-linux-musl.tar.gz",
+              name: "just",
+              pathInArchive: "just",
+            }
+          - {
+              os: "macos-latest",
+              url: "https://github.com/casey/just/releases/download/v0.5.8/just-v0.5.8-x86_64-apple-darwin.tar.gz",
+              name: "just",
+              pathInArchive: "just",
+            }
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: engineerd/configurator@v0.0.1
         with:
           name: ${{ matrix.config.name }}


### PR DESCRIPTION
The old v1 had issues re-running builds if master had changed