### PR TITLE
Feat/status updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,20 +35,24 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: engineerd/setup-kind@v0.3.0
-    - uses: engineerd/configurator@v0.0.1
-      with:
-        name: just
-        url: https://github.com/casey/just/releases/download/v0.5.8/just-v0.5.8-x86_64-unknown-linux-musl.tar.gz
-        pathInArchive: just
-    - name: Run e2e tests
-      run: |
-        cd crates/wascc-provider
-        cargo build --bin krustlet-wascc --manifest-path ../../Cargo.toml
-        ../../target/debug/krustlet-wascc --node-name krustlet-wascc --node-ip 172.17.0.1 --port 3000 &
-        cd ../wasi-provider
-        cargo build --bin krustlet-wasi --manifest-path ../../Cargo.toml
-        ../../target/debug/krustlet-wasi --node-name krustlet-wasi --node-ip 172.17.0.1 --port 3001 &
-        cd ../..
-        just test-e2e
+      - uses: actions/checkout@v2
+      - uses: engineerd/setup-kind@v0.3.0
+      - uses: engineerd/configurator@v0.0.1
+        with:
+          name: just
+          url: https://github.com/casey/just/releases/download/v0.5.8/just-v0.5.8-x86_64-unknown-linux-musl.tar.gz
+          pathInArchive: just
+      - name: Run e2e tests
+        env:
+          KRUSTLET_NODE_IP: "172.17.0.1"
+          # The default location for the cert is not accessible on build hosts, so do it in the current dir
+          KEY_DIR: "./config"
+          PFX_PASSWORD: "testing"
+        run: |
+          just bootstrap-ssl
+          just build
+          cd crates/wascc-provider
+          ../../target/debug/krustlet-wascc --node-name krustlet-wascc --port 3000 --pfx-path ../../config/certificate.pfx &
+          cd ../wasi-provider
+          ../../target/debug/krustlet-wasi --node-name krustlet-wasi --port 3001 --pfx-path ../../config/certificate.pfx &
+          just test-e2e

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2933,6 +2933,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "chrono",
  "k8s-openapi",
  "kube",
  "kubelet",

--- a/crates/kubelet/src/kubelet.rs
+++ b/crates/kubelet/src/kubelet.rs
@@ -64,14 +64,14 @@ pub struct Status {
     /// Allows a provider to set a custom message, otherwise, kubelet will infer
     /// a message from the container statuses
     pub message: Option<String>,
-    pub container_statuses: Vec<ContainerStatus>,
+    pub container_statuses: HashMap<String, ContainerStatus>,
 }
 
 /// ContainerStatus is a simplified version of the Kubernetes container status
 /// for use in providers. It allows for simple creation of the current status of
 /// a "container" (a running wasm process) without worrying about a bunch of
 /// Options. Use the [ContainerStatus::to_kubernetes] method for converting it
-/// to a Kubernetes API status
+/// to a Kubernetes API container status
 #[derive(Clone, Debug)]
 pub enum ContainerStatus {
     Waiting {
@@ -95,7 +95,7 @@ pub enum ContainerStatus {
 }
 
 impl ContainerStatus {
-    pub fn to_kubernetes(&self, pod_name: String) -> KubeContainerStatus {
+    pub fn to_kubernetes(&self, container_name: String) -> KubeContainerStatus {
         let mut state = ContainerState::default();
         match self {
             Self::Waiting { message, .. } => {
@@ -125,7 +125,7 @@ impl ContainerStatus {
         let ready = state.running.is_some();
         KubeContainerStatus {
             state: Some(state),
-            name: pod_name,
+            name: container_name,
             // Right now we don't have a way to probe, so just set to ready if
             // in a running state
             ready,

--- a/crates/kubelet/src/kubelet.rs
+++ b/crates/kubelet/src/kubelet.rs
@@ -37,7 +37,7 @@ pub struct NotImplementedError;
 ///
 /// This is specified by Kubernetes itself.
 #[derive(Clone, Debug, serde::Serialize)]
-pub enum Phase {
+pub(crate) enum Phase {
     /// The workload is currently executing.
     Running,
     /// The workload has exited with an error.
@@ -61,7 +61,8 @@ impl Default for Phase {
 /// state of the workload.
 #[derive(Clone, Debug, Default)]
 pub struct Status {
-    pub phase: Phase,
+    /// Allows a provider to set a custom message, otherwise, kubelet will infer
+    /// a message from the container statuses
     pub message: Option<String>,
     pub container_statuses: Vec<ContainerStatus>,
 }

--- a/crates/kubelet/src/pod.rs
+++ b/crates/kubelet/src/pod.rs
@@ -118,7 +118,7 @@ impl Pod {
             .container_statuses
             .unwrap_or_default()
             .into_iter()
-            .filter(|s| current_statuses.contains_key(&s.name))
+            .filter(|s| !current_statuses.contains_key(&s.name))
             .collect::<Vec<KubeContainerStatus>>();
         container_statuses.extend(current_statuses.drain().map(|(_, v)| v));
         let mut num_succeeded: usize = 0;

--- a/crates/kubelet/src/server.rs
+++ b/crates/kubelet/src/server.rs
@@ -49,9 +49,9 @@ pub async fn start_webserver<T: 'static + Provider + Send + Sync>(
                             get_container_logs(
                                 &*provider.lock().await,
                                 &req,
-                                namespace.to_string(),
-                                pod.to_string(),
-                                container.to_string(),
+                                (*namespace).to_string(),
+                                (*pod).to_string(),
+                                (*container).to_string(),
                             )
                             .await
                         }

--- a/crates/wascc-provider/Cargo.toml
+++ b/crates/wascc-provider/Cargo.toml
@@ -22,6 +22,7 @@ serde_derive = "1.0"
 kube =  "0.29.0" 
 kubelet = { path = "../kubelet", version = "0.1.0" }
 tokio = { version = "0.2.11", features = ["fs", "macros"] }
+chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
 k8s-openapi = { version = "0.7.1", features = ["v1_17"] }

--- a/crates/wascc-provider/src/lib.rs
+++ b/crates/wascc-provider/src/lib.rs
@@ -1,5 +1,5 @@
 use kube::client::APIClient;
-use kubelet::{pod::Pod, Phase, Provider, Status};
+use kubelet::{pod::Pod, ContainerStatus, Provider, Status};
 use log::{debug, info};
 use wascc_host::{host, Actor, NativeCapability};
 
@@ -108,7 +108,9 @@ impl Provider for WasccProvider {
                     pod.patch_status(
                         client.clone(),
                         Status {
-                            phase: Phase::Running,
+                            container_statuses: vec![ContainerStatus::Running {
+                                timestamp: chrono::Utc::now(),
+                            }],
                             ..Default::default()
                         },
                     )
@@ -118,7 +120,11 @@ impl Provider for WasccProvider {
                     pod.patch_status(
                         client,
                         Status {
-                            phase: Phase::Failed,
+                            container_statuses: vec![ContainerStatus::Terminated {
+                                timestamp: chrono::Utc::now(),
+                                failed: true,
+                                message: "Error while starting container".to_string(),
+                            }],
                             ..Default::default()
                         },
                     )

--- a/crates/wasi-provider/src/handle.rs
+++ b/crates/wasi-provider/src/handle.rs
@@ -1,10 +1,16 @@
+use std::collections::HashMap;
 use std::io::SeekFrom;
 
+use kube::client::APIClient;
+use log::{debug, error, info};
 use tokio::io::{AsyncReadExt, AsyncSeekExt, BufReader};
+use tokio::stream::{StreamExt, StreamMap};
 use tokio::sync::watch::Receiver;
+use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 
-use kubelet::ContainerStatus;
+use kubelet::pod::Pod;
+use kubelet::{ContainerStatus, Phase, ProviderError, Status};
 
 /// Represents a handle to a running WASI instance. Right now, this is
 /// experimental and just for use with the [crate::WasiProvider]. If we like
@@ -34,7 +40,7 @@ impl<R: AsyncReadExt + AsyncSeekExt + Unpin> RuntimeHandle<R> {
 
     /// Write all of the output from the running process into the given buffer.
     /// Returns the number of bytes written to the buffer
-    pub async fn output(&mut self, buf: &mut Vec<u8>) -> anyhow::Result<usize> {
+    pub(crate) async fn output(&mut self, buf: &mut Vec<u8>) -> anyhow::Result<usize> {
         let bytes_written = self.output.read_to_end(buf).await?;
         // Reset the seek location for the next call to read from the file
         // NOTE: The Tokio BufReader does not implement seek, so we need to get
@@ -46,25 +52,127 @@ impl<R: AsyncReadExt + AsyncSeekExt + Unpin> RuntimeHandle<R> {
     /// Signal the running instance to stop and wait for it to complete. As of
     /// right now, there is not a way to do this in wasmtime, so this does
     /// nothing
-    pub async fn stop(&mut self) -> anyhow::Result<()> {
+    pub(crate) async fn stop(&mut self) -> anyhow::Result<()> {
         // TODO: Send an actual stop signal once there is support in wasmtime
-        self.wait().await?;
         unimplemented!("There is currently no way to stop a running wasmtime instance")
     }
 
-    /// Returns the current status of the process
-    pub async fn status(&self) -> anyhow::Result<ContainerStatus> {
-        // NOTE: For those who modify this in the future, borrow must be as
-        // short lived as possible as it can block the send half. We do not use
-        // the recv method because it uses the value each time and then waits
-        // for a new value on the next call, whereas we want to return the last
-        // sent value until updated
-        Ok(self.status_channel.borrow().clone())
+    pub(crate) fn status(&self) -> Receiver<ContainerStatus> {
+        self.status_channel.clone()
     }
 
-    // For now this is private (for use in testing and in stop). If we find a
-    // need to expose it, we can do that later
     pub(crate) async fn wait(&mut self) -> anyhow::Result<()> {
         (&mut self.handle).await.unwrap()
+    }
+}
+
+/// PodHandle is the top level handle into managing a pod. It manages updating
+/// statuses for the containers in the pod and can be used to stop the pod and
+/// access logs
+pub struct PodHandle<R: AsyncReadExt + AsyncSeekExt + Unpin> {
+    container_handles: RwLock<HashMap<String, RuntimeHandle<R>>>,
+    // The channel for sending a stop signal to the status updater tasks
+    status_handle: JoinHandle<()>,
+    pod: Pod,
+}
+
+impl<R: AsyncReadExt + AsyncSeekExt + Unpin> PodHandle<R> {
+    /// Creates a new pod handle that manages the given map of container names
+    /// to [crate::RuntimeHandle]s. The given pod and client are used to
+    /// maintain a reference to the kubernetes object and to be able to update
+    /// the status of that object
+    pub fn new(
+        container_handles: HashMap<String, RuntimeHandle<R>>,
+        pod: Pod,
+        client: APIClient,
+    ) -> anyhow::Result<Self> {
+        let mut channel_map = StreamMap::with_capacity(container_handles.len());
+        for (name, handle) in container_handles.iter() {
+            channel_map.insert(name.clone(), handle.status().clone());
+        }
+        // TODO: This does not allow for restarting single containers because we
+        // move the stream map and lose the ability to insert a new channel for
+        // the restarted runtime. It may involve sending things to the task with
+        // a channel
+        let cloned_pod = pod.clone();
+        let status_handle = tokio::task::spawn(async move {
+            loop {
+                println!("got here");
+                let status = match channel_map.next().await {
+                    Some(s) => s,
+                    // None means everything is closed, so go ahead and exit
+                    None => return,
+                };
+                debug!(
+                    "Got status update from container {}: {:#?}",
+                    status.0, status.1
+                );
+                cloned_pod
+                    .patch_status(
+                        client.clone(),
+                        Status {
+                            phase: Phase::Running,
+                            message: Some("todo".into()),
+                            container_statuses: vec![status.1],
+                        },
+                    )
+                    .await;
+            }
+        });
+        Ok(PodHandle {
+            container_handles: RwLock::new(container_handles),
+            status_handle,
+            pod,
+        })
+    }
+
+    /// Write all of the output from the specified container into the given
+    /// buffer. Returns the number of bytes written to the buffer
+    pub async fn output(
+        &mut self,
+        container_name: &str,
+        buf: &mut Vec<u8>,
+    ) -> anyhow::Result<usize> {
+        let mut handles = self.container_handles.write().await;
+        let handle =
+            handles
+                .get_mut(container_name)
+                .ok_or_else(|| ProviderError::ContainerNotFound {
+                    pod_name: self.pod.name().unwrap().to_owned(),
+                    container_name: container_name.to_owned(),
+                })?;
+        handle.output(buf).await
+    }
+
+    /// Signal the pod and all its running containers to stop and wait for them
+    /// to complete. As of right now, there is not a way to do this in wasmtime,
+    /// so this does nothing
+    pub async fn stop(&mut self) -> anyhow::Result<()> {
+        {
+            let mut handles = self.container_handles.write().await;
+            for (name, handle) in handles.iter_mut() {
+                info!("Stopping container: {}", name);
+                match handle.stop().await {
+                    Ok(_) => debug!("Successfully stopped container {}", name),
+                    // NOTE: I am not sure what recovery or retry steps should be
+                    // done here, but we should definitely continue and try to stop
+                    // the other containers
+                    Err(e) => error!("Error while trying to stop pod {}: {:?}", name, e),
+                }
+            }
+        }
+        self.wait().await?;
+        (&mut self.status_handle).await?;
+        unimplemented!("There is currently no way to stop a running wasmtime instance")
+    }
+
+    /// Wait for all containers in the pod to complete
+    pub async fn wait(&mut self) -> anyhow::Result<()> {
+        let mut handles = self.container_handles.write().await;
+        for (name, handle) in handles.iter_mut() {
+            debug!("Waiting for container {} to terminate", name);
+            handle.stop().await?;
+        }
+        Ok(())
     }
 }

--- a/crates/wasi-provider/src/handle.rs
+++ b/crates/wasi-provider/src/handle.rs
@@ -106,15 +106,13 @@ impl<R: AsyncReadExt + AsyncSeekExt + Unpin> PodHandle<R> {
                     "Got status update from container {}: {:#?}",
                     status.0, status.1
                 );
-                cloned_pod
-                    .patch_status(
-                        client.clone(),
-                        Status {
-                            message: None,
-                            container_statuses: vec![status.1],
-                        },
-                    )
-                    .await;
+                let mut container_statuses = HashMap::new();
+                container_statuses.insert(status.0, status.1);
+                let status = Status {
+                    message: None,
+                    container_statuses,
+                };
+                cloned_pod.patch_status(client.clone(), status).await;
             }
         });
         Ok(PodHandle {

--- a/crates/wasi-provider/src/handle.rs
+++ b/crates/wasi-provider/src/handle.rs
@@ -10,7 +10,7 @@ use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 
 use kubelet::pod::Pod;
-use kubelet::{ContainerStatus, Phase, ProviderError, Status};
+use kubelet::{ContainerStatus, ProviderError, Status};
 
 /// Represents a handle to a running WASI instance. Right now, this is
 /// experimental and just for use with the [crate::WasiProvider]. If we like
@@ -97,7 +97,6 @@ impl<R: AsyncReadExt + AsyncSeekExt + Unpin> PodHandle<R> {
         let cloned_pod = pod.clone();
         let status_handle = tokio::task::spawn(async move {
             loop {
-                println!("got here");
                 let status = match channel_map.next().await {
                     Some(s) => s,
                     // None means everything is closed, so go ahead and exit
@@ -111,8 +110,7 @@ impl<R: AsyncReadExt + AsyncSeekExt + Unpin> PodHandle<R> {
                     .patch_status(
                         client.clone(),
                         Status {
-                            phase: Phase::Running,
-                            message: Some("todo".into()),
+                            message: None,
                             container_statuses: vec![status.1],
                         },
                     )
@@ -138,7 +136,7 @@ impl<R: AsyncReadExt + AsyncSeekExt + Unpin> PodHandle<R> {
             handles
                 .get_mut(container_name)
                 .ok_or_else(|| ProviderError::ContainerNotFound {
-                    pod_name: self.pod.name().unwrap().to_owned(),
+                    pod_name: self.pod.name().to_owned(),
                     container_name: container_name.to_owned(),
                 })?;
         handle.output(buf).await

--- a/crates/wasi-provider/src/wasi_runtime.rs
+++ b/crates/wasi-provider/src/wasi_runtime.rs
@@ -283,7 +283,7 @@ mod test {
         handle.output(&mut output).await.unwrap();
         assert_eq!("Hello, world!\n".to_string().into_bytes(), output);
 
-        let status = handle.status().await.unwrap();
+        let status = handle.status().recv().await.unwrap();
         assert!(match status {
             ContainerStatus::Terminated { .. } => true,
             _ => false,

--- a/justfile
+++ b/justfile
@@ -1,5 +1,6 @@
 export RUST_LOG := "wascc_host=debug,wascc_provider=debug,wasi_provider=debug,main=debug"
 export PFX_PASSWORD := "testing"
+export KEY_DIR := env_var_or_default('KEY_DIR', '$HOME/.krustlet/config')
 
 run: run-wascc
 
@@ -18,12 +19,12 @@ test-e2e:
     cargo test --test integration_tests
 
 run-wascc: _cleanup_kube bootstrap-ssl
-    # Change directories so we have access to the ./lib dir
+    @# Change directories so we have access to the ./lib dir
     cd ./crates/wascc-provider && cargo run --bin krustlet-wascc --manifest-path ../../Cargo.toml -- --node-name krustlet-wascc --port 3000
 
 run-wasi: _cleanup_kube bootstrap-ssl
-    # HACK: Temporary step to change to a directory so it has access to a hard
-    # coded module. This should be removed once we have image support
+    @# HACK: Temporary step to change to a directory so it has access to a hard
+    @# coded module. This should be removed once we have image support
     cd ./crates/wasi-provider && cargo run --bin krustlet-wasi --manifest-path ../../Cargo.toml -- --node-name krustlet-wasi --port 3001
 
 dockerize:
@@ -33,14 +34,12 @@ push:
     docker push technosophos/krustlet:latest
 
 bootstrap-ssl:
-    mkdir -p ~/.krustlet/config
-    test -f  ~/.krustlet/config/host.key && test -f ~/.krustlet/config/host.cert || openssl req -x509 -sha256 -newkey rsa:2048 -keyout ~/.krustlet/config/host.key -out ~/.krustlet/config/host.cert -days 365 -nodes -subj "/C=AU/ST=./L=./O=./OU=./CN=."
-    test -f ~/.krustlet/config/certificate.pfx || openssl pkcs12 -export -out  ~/.krustlet/config/certificate.pfx -inkey  ~/.krustlet/config/host.key -in  ~/.krustlet/config/host.cert -password "pass:${PFX_PASSWORD}"
-    chmod 400 ~/.krustlet/config/*
+    @# This is to get around an issue with the default function returning a string that gets escaped
+    @mkdir -p $(eval echo $KEY_DIR)
+    @test -f  $(eval echo $KEY_DIR)/host.key && test -f $(eval echo $KEY_DIR)/host.cert || openssl req -x509 -sha256 -newkey rsa:2048 -keyout $(eval echo $KEY_DIR)/host.key -out $(eval echo $KEY_DIR)/host.cert -days 365 -nodes -subj "/C=AU/ST=./L=./O=./OU=./CN=."
+    @test -f $(eval echo $KEY_DIR)/certificate.pfx || openssl pkcs12 -export -out  $(eval echo $KEY_DIR)/certificate.pfx -inkey  $(eval echo $KEY_DIR)/host.key -in  $(eval echo $KEY_DIR)/host.cert -password "pass:${PFX_PASSWORD}"
+    @chmod 400 $(eval echo $KEY_DIR)/*
 
 _cleanup_kube:
     kubectl delete no $(hostname | tr '[:upper:]' '[:lower:]') || true
     kubectl delete po greet || true
-
-testfor:
-    for i in 1 2 3 4 5; do sleep 3 && echo hello $i; done

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -174,12 +174,17 @@ async fn test_wasi_provider() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let mut watcher = inf.poll().await?.boxed();
-
+    let mut found_running = false;
     while let Some(event) = watcher.try_next().await? {
         match event {
             WatchEvent::Modified(o) => {
                 let phase = o.status.unwrap().phase.unwrap();
                 if phase == "Running" {
+                    found_running = true;
+                }
+                if phase == "Succeeded" && !found_running {
+                    panic!("Reached completed phase before receiving Running phase")
+                } else if phase == "Succeeded" {
                     break;
                 }
             }
@@ -193,8 +198,19 @@ async fn test_wasi_provider() -> Result<(), Box<dyn std::error::Error>> {
     let mut logs = pods.log_stream("hello-wasi", &LogParams::default()).await?;
 
     while let Some(line) = logs.try_next().await? {
-        assert_eq!("Hello World!\n", String::from_utf8_lossy(&line));
+        assert_eq!("Hello, world!\n", String::from_utf8_lossy(&line));
     }
+
+    let pod = pods.get("hello-wasi").await?;
+
+    let state = pod.status.unwrap().container_statuses.unwrap()[0]
+        .state
+        .as_ref()
+        .unwrap()
+        .terminated
+        .clone()
+        .unwrap();
+    assert_eq!(state.exit_code, 0);
 
     // cleanup
     pods.delete("hello-wasi", &DeleteParams::default()).await?;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -203,13 +203,13 @@ async fn test_wasi_provider() -> Result<(), Box<dyn std::error::Error>> {
 
     let pod = pods.get("hello-wasi").await?;
 
-    let state = pod.status.unwrap().container_statuses.unwrap()[0]
+    let state = pod.status.expect("foo").container_statuses.expect("bar")[0]
         .state
         .as_ref()
-        .unwrap()
+        .expect("baz")
         .terminated
         .clone()
-        .unwrap();
+        .expect("bash");
     assert_eq!(state.exit_code, 0);
 
     // cleanup


### PR DESCRIPTION
Updating status is now working for wasi. This has all been added as part
of the `wasi_runtime::handle` module, and so should be portable to
wascc when it is ready. It introduces a new `PodHandle` which is a higher
level (and possibly better?) abstraction for interacting with a running Pod.

I also removed the `status` method from the provider interface as it should
be done with handles and not by the kubelet calling the provider.

Closes #61 