### PR TITLE
fix the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,8 @@ on:
   push:
     branches:
       - master
-  release:
-    types:
-      - published
+    tags:
+      - 'v*'
 
 jobs:
   build:
@@ -19,15 +18,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: get the version
-        id: get_version
-        if: github.event_name == 'release'
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      - name: set the release version
+        if: startsWith(github.ref, 'refs/tags')
+        run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF/refs\/tags\//}
 
-      - name: get the version
-        id: get_version
-        if: github.event_name == 'push'
-        run: echo ::set-output name=VERSION::canary
+      - name: set the release version
+        if: github.ref == 'refs/heads/master'
+        run: echo ::set-env name=RELEASE_VERSION::canary
 
       - name: build release
         uses: actions-rs/cargo@v1
@@ -40,12 +37,12 @@ jobs:
           mkdir _dist
           cp README.md LICENSE target/release/krustlet-wasi target/release/krustlet-wascc _dist/
           cd _dist
-          tar czf krustlet-${{ steps.get_version.outputs.VERSION }}-${{ runner.os }}-${{ matrix.arch }}.tar.gz README.md LICENSE krustlet-wasi krustlet-wascc
+          tar czf krustlet-${{ env.RELEASE_VERSION }}-${{ runner.os }}-${{ matrix.arch }}.tar.gz README.md LICENSE krustlet-wasi krustlet-wascc
 
       - uses: actions/upload-artifact@v1
         with:
           name: krustlet
-          path: _dist/krustlet-${{ steps.get_version.outputs.VERSION }}-${{ runner.os }}-${{ matrix.arch }}.tar.gz
+          path: _dist/krustlet-${{ env.RELEASE_VERSION }}-${{ runner.os }}-${{ matrix.arch }}.tar.gz
 
   crates:
     name: publish to crates.io


### PR DESCRIPTION
This commit fixes two things:

We want the release workflow to start when the tag is pushed rather than when it is published on github. That way, the release assets are ready and available when the release is published.

It turns out that you cannot have two conditional jobs with the same ID. Go figure. Instead, we now inject the release version into the environment and run the step if the reference is valid.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>