### PR TITLE
wait for build job to complete

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,7 @@ jobs:
   publish:
     name: publish release assets
     runs-on: ubuntu-latest
+    needs: build
     steps:
       - name: download release assets
         uses: actions/download-artifact@v1


### PR DESCRIPTION
github actions runs all jobs in parallel. the publish job relies on the build job completing first before going ahead.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>