### PR TITLE
docs(demos): shift around WASI demo docs

### DIFF
--- a/demos/wasi/hello-world-assemblyscript/README.md
+++ b/demos/wasi/hello-world-assemblyscript/README.md
@@ -1,52 +1,59 @@
 # Hello World AssemblyScript for WASI
+
 A simple hello world example in AssemblyScript that will print:
+
 - The environment variables available to the process
 - Text to both stdout and stderr.
-- Any args passed to the process 
+- Any args passed to the process
 
 It is meant to be a simple demo for the wasi-provider with Krustlet.
 
-## Prerequisites
-You'll need `npm` installed in order to install and build the dependencies. This
-project is using the [as-wasi](https://github.com/jedisct1/as-wasi) dependency,
-which is a helpful set of wrappers around the low level wasi bindings provided
-in AssemblyScript. If you are interested in starting your own AssemblyScript
-project, visit the AssemblyScript [getting
-started](https://docs.assemblyscript.org/quick-start) guide.
-
-If you don't have Krustlet with the WASI provider running locally, see the
-instructions in the [tutorial](../../../docs/intro/tutorial03.md) for running
-locally.
-
-## Building
-Simply run:
-
-```shell
-$ npm install && npm run asbuild
-```
-
-## Pushing
-Detailed instructions for pushing a module can be found
-[here](../../../docs/intro/tutorial02.md). We hope to improve and streamline the
-build and push process in the future. However, for test purposes, the image has
-been pushed to the `webassembly` Azure Container Registry
-
 ## Running the example
-First create the pod and configmap:
+
+This example has already been pre-built, so you only need to install it into your Kubernetes cluster.
+
+Create the pod and configmap with `kubectl`:
 
 ```shell
 $ kubectl apply -f k8s.yaml
 ```
 
-You should then be able to get the logs and see the output from the wasm module
-run:
+You should then be able to get the logs and see the output from the pod:
 
 ```shell
-$ kubectl logs hello-world-wasi-assemblyscript                                                                                   
+$ kubectl logs hello-world-wasi-assemblyscript
 hello from stdout!
 hello from stderr!
 FOO=bar
 CONFIG_MAP_VAL=cool stuff
 POD_NAME=hello-world-wasi-assemblyscript
-Args are: 
+Args are:
 ```
+
+## Building from Source
+
+If you want to compile the demo and inspect it, you'll need to do the following.
+
+### Prerequisites
+
+You'll need `npm` installed in order to install and build the dependencies. This project is using the
+[as-wasi](https://github.com/jedisct1/as-wasi) dependency, which is a helpful set of wrappers around the low level
+WASI bindings provided in AssemblyScript.
+
+If you are interested in starting your own AssemblyScript project, visit the AssemblyScript
+[getting started guide](https://docs.assemblyscript.org/quick-start).
+
+If you don't have Krustlet with the WASI provider running locally, see the instructions in the
+[tutorial](../../../docs/intro/tutorial03.md) for running locally.
+
+### Compiling
+
+Run:
+
+```shell
+$ npm install && npm run asbuild
+```
+
+### Pushing
+
+Detailed instructions for pushing a module can be found in the [tutorial](../../../docs/intro/tutorial02.md).

--- a/demos/wasi/hello-world-c/README.md
+++ b/demos/wasi/hello-world-c/README.md
@@ -1,42 +1,14 @@
 # Hello World C for WASI
+
 A simple hello world example in C that will print:
 - The environment variables available to the process
 - Text to both stdout and stderr.
-- Any args passed to the process 
+- Any args passed to the process
 
 It is meant to be a simple demo for the wasi-provider with Krustlet.
 
-## Prerequisites
-Building WASI in C is easiest with the custom [SDK]() from wasmtime. Feel free
-to go down the rabbit hole of figuring things out with vanilla `clang` for your
-own project should you so desire. To install the SDK, follow the steps below,
-replacing `$OS_NAME` with your OS (current choices are `linux` and `macos`):
-
-```shell
-$ wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-8/wasi-sysroot-8.0.tar.gz
-$ tar -xzf wasi-sysroot-8.0.tar.gz
-$ wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-8/wasi-sdk-8.0-${OS_NAME}.tar.gz
-$ tar -xzf wasi-sdk-8.0-${OS_NAME}.tar.gz
-```
-
-If you don't have Krustlet with the WASI provider running locally, see the
-instructions in the [tutorial](../../../docs/intro/tutorial03.md) for running
-locally.
-
-## Building
-Run:
-
-```shell
-$ ./wasi-sdk-8.0/bin/clang -v demo.c --sysroot ./wasi-sysroot -o demo.wasm
-```
-
-## Pushing
-Detailed instructions for pushing a module can be found
-[here](../../../docs/intro/tutorial02.md). We hope to improve and streamline the
-build and push process in the future. However, for test purposes, the image has
-been pushed to the `webassembly` Azure Container Registry
-
 ## Running the example
+
 First create the pod and configmap:
 
 ```shell
@@ -55,3 +27,39 @@ CONFIG_MAP_VAL=cool stuff
 POD_NAME=hello-world-wasi-c
 []
 ```
+
+## Building from Source
+
+If you want to compile the demo and inspect it, you'll need to do the following.
+
+### Prerequisites
+
+Building WASI in C is easiest with the custom [SDK](https://github.com/WebAssembly/wasi-sdk) from wasmtime. Feel free to
+go down the rabbit hole of figuring things out with vanilla `clang` for your own project should you so desire.
+
+To install the SDK, follow the steps below, replacing `$OS_NAME` with your OS (current choices are `linux` and `macos`):
+
+```shell
+$ wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-8/wasi-sysroot-8.0.tar.gz
+$ tar -xzf wasi-sysroot-8.0.tar.gz
+$ wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-8/wasi-sdk-8.0-${OS_NAME}.tar.gz
+$ tar -xzf wasi-sdk-8.0-${OS_NAME}.tar.gz
+```
+
+If you don't have Krustlet with the WASI provider running locally, see the instructions in the
+[tutorial](../../../docs/intro/tutorial03.md) for running locally.
+
+### Building
+
+Run:
+
+```shell
+$ ./wasi-sdk-8.0/bin/clang -v demo.c --sysroot ./wasi-sysroot -o demo.wasm
+```
+
+### Pushing
+
+Detailed instructions for pushing a module can be found [here](../../../docs/intro/tutorial02.md).
+
+We hope to improve and streamline the build and push process in the future. However, for test purposes, the image has
+been pushed to the `webassembly` Azure Container Registry.

--- a/demos/wasi/hello-world-rust/README.md
+++ b/demos/wasi/hello-world-rust/README.md
@@ -1,12 +1,39 @@
 # Hello World Rust for WASI
+
 A simple hello world example in Rust that will print:
+
 - The environment variables available to the process
 - Text to both stdout and stderr.
-- Any args passed to the process 
+- Any args passed to the process
 
 It is meant to be a simple demo for the wasi-provider with Krustlet.
 
-## Prerequisites
+## Running the example
+
+First create the pod and configmap:
+
+```shell
+$ kubectl apply -f k8s.yaml
+```
+
+You should then be able to get the logs and see the output from the wasm module run:
+
+```shell
+$ kubectl logs hello-world-wasi-rust
+hello from stdout!
+hello from stderr!
+FOO=bar
+CONFIG_MAP_VAL=cool stuff
+POD_NAME=hello-world-wasi-rust
+Args are: []
+```
+
+## Building from Source
+
+If you want to compile the demo and inspect it, you'll need to do the following.
+
+### Prerequisites
+
 You'll need to have Rust installed with `wasm32-wasi` target installed:
 
 ```shell
@@ -17,34 +44,17 @@ If you don't have Krustlet with the WASI provider running locally, see the
 instructions in the [tutorial](../../../docs/intro/tutorial03.md) for running
 locally.
 
-## Building
-Simply run:
+### Building
+
+Run:
 
 ```shell
 $ cargo build --target wasm32-wasi --release
 ```
 
-## Pushing
-Detailed instructions for pushing a module can be found
-[here](../../../docs/intro/tutorial02.md). We hope to improve and streamline the
-build and push process in the future. However, for test purposes, the image has
-been pushed to the `webassembly` Azure Container Registry
+### Pushing
 
-## Running the example
-First create the pod and configmap:
+Detailed instructions for pushing a module can be found [here](../../../docs/intro/tutorial02.md).
 
-```shell
-$ kubectl apply -f k8s.yaml
-```
-
-You should then be able to get the logs and see the output from the wasm module run:
-
-```shell
-$ kubectl logs hello-world-wasi-rust                                                                                   
-hello from stdout!
-hello from stderr!
-FOO=bar
-CONFIG_MAP_VAL=cool stuff
-POD_NAME=hello-world-wasi-rust
-Args are: []
-```
+We hope to improve and streamline the build and push process in the future. However, for test purposes, the image has
+been pushed to the `webassembly` Azure Container Registry.


### PR DESCRIPTION
Because the examples in the WASI demo are pre-built and ready to go, I felt that should be the first thing users can try out. If they want to recreate the example for themselves, they can do so by following the instructions.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>