### PR TITLE
feat(docs): Adds how-to guides with complete AKS guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,3 +9,4 @@ Krustlet has a lot of documentation. A high-level overview of how it’s organiz
 - [The introduction](intro/README.md) takes you by the hand through a series of steps to run an application on Krustlet. Start here if you’re new to Krustlet.
 - [Topic guides](topics/README.md) discuss key topics and concepts at a fairly high level and provide useful background information and explanation.
 - [Community Guides](community/README.md) teach you about the development process for Krustlet and how you can contribute to the project.
+- [How To Guides](how-to/README.md) explain how to run Krustlet with various types of Kubernetes clusters.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,4 +9,4 @@ Krustlet has a lot of documentation. A high-level overview of how it’s organiz
 - [The introduction](intro/README.md) takes you by the hand through a series of steps to run an application on Krustlet. Start here if you’re new to Krustlet.
 - [Topic guides](topics/README.md) discuss key topics and concepts at a fairly high level and provide useful background information and explanation.
 - [Community Guides](community/README.md) teach you about the development process for Krustlet and how you can contribute to the project.
-- [How To Guides](how-to/README.md) explain how to run Krustlet with various types of Kubernetes clusters.
+- [How To Guides](how-to/README.md) explain how to run Krustlet with various types of Kubernetes clusters and other configuration tasks

--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -1,0 +1,7 @@
+# How To Guides
+
+Setup guides for various Kubernetes distributions
+
+- [Running in KinD](kind.md)
+- [Running in Minikube](minikube.md)
+- [Running in AKS](aks.md)

--- a/docs/how-to/aks.md
+++ b/docs/how-to/aks.md
@@ -16,7 +16,8 @@ $ az aks get-credentials --name $CLUSTER_NAME --resource-group $RESOURCE_GROUP
 ```
 
 This specific tutorial will be running krustlet on another Azure VM; however,
-you can follow these steps from any device that can access the internet.
+you can follow these steps from any device that can start a web server on an IP
+accessible from the Kubernetes control plane.
 
 ## Instructions
 

--- a/docs/how-to/aks.md
+++ b/docs/how-to/aks.md
@@ -1,0 +1,247 @@
+# Running Krustlet in AKS
+
+These are steps for running a krustlet node in an AKS cluster. Ideally, we will
+want to simplify this process in the future so you do not have to do a bunch of
+configuration to connect a node to the cluster
+
+## Prerequisites
+A running AKS cluster (the steps below assume a non-custom vnet, though they are
+easily adaptable to custom vnets) and `kubectl` installed. See the [AKS
+docs](https://docs.microsoft.com/en-us/azure/aks/tutorial-kubernetes-deploy-cluster)
+for more information. Make sure you have the credentials to your cluster
+downloaded by running:
+
+```shell
+$ az aks get-credentials --name $CLUSTER_NAME --resource-group $RESOURCE_GROUP
+```
+
+This specific tutorial will be running krustlet on another Azure VM; however,
+you can follow these steps from any device that can access the internet.
+
+## Instructions
+
+### Step 1: Create a service account user for the node
+We will need to create a Kubernetes configuration file (known as the kubeconfig)
+and service account for krustlet to use to register nodes and access specific
+secrets.
+
+This can be done by using the Kubernetes manifest in the [assets](./assets)
+directory:
+
+```shell
+$ kubectl apply -n kube-system -f ./docs/how-to/assets/krustlet-service-account.yaml
+```
+
+You can also do this by using the manifest straight from GitHub:
+
+```shell
+$ kubectl apply -n kube-system -f https://raw.githubusercontent.com/deislabs/krustlet/master/docs/how-to/assets/krustlet-service-account.yaml
+```
+
+Now that things are all set up, we need to generate the kubeconfig. You can do
+this by running (assuming you are in the root of the krustlet repo):
+
+```shell
+$ ./docs/how-to/assets/generate-kubeconfig.sh
+```
+
+Or if you are feeling a bit more trusting, you can run it straight from the
+repo:
+```shell
+bash <(curl https://raw.githubusercontent.com/deislabs/krustlet/master/docs/how-to/assets/generate-kubeconfig.sh)
+```
+
+Either way, it will output a file called `kubeconfig-sa` in your current
+directory. Save this for later
+
+### Step 2: Create Certificate
+Krustlet requires a certificate for securing communication with the Kubernetes
+API. Because Kubernetes has its own certificates, we'll need to get a signed
+certificate from the Kubernetes API that we can use. First things first, let's
+create a certificate signing request (CSR):
+
+```shell
+$ openssl req -new -sha256 -newkey rsa:2048 -keyout krustlet.key -out krustlet.csr -nodes -subj "/C=US/ST=./L=./O=./OU=./CN=krustlet"
+```
+
+This will create a CSR and a new key for the certificate, using `krustlet` as
+the hostname of the server.
+
+Now that it is created, we'll need to send the request to Kubernetes:
+
+```shell
+$ cat <<EOF | kubectl apply -f -
+apiVersion: certificates.k8s.io/v1beta1
+kind: CertificateSigningRequest
+metadata:
+  name: krustlet
+spec:
+  request: $(cat krustlet.csr | base64 | tr -d '\n')
+  usages:
+  - digital signature
+  - key encipherment
+  - server auth
+EOF
+certificatesigningrequest.certificates.k8s.io/krustlet created
+```
+
+Once that runs, an admin (that is probably you! at least it should be if you are
+trying to add a node to the cluster) needs to approve the request:
+
+```shell
+$ kubectl certificate approve krustlet
+certificatesigningrequest.certificates.k8s.io/krustlet approved
+```
+
+After approval, you can download the cert like so:
+
+```shell
+$ kubectl get csr krustlet -o jsonpath='{.status.certificate}' \
+    | base64 --decode > krustlet.crt
+```
+
+Lastly, combine the key and the cert into a PFX bundle, choosing your own
+password instead of "password":
+
+```shell
+$ openssl pkcs12 -export -out krustlet.pfx -inkey krustlet.key -in krustlet.crt -password "pass:password"
+```
+
+### Step 3: Creating and accessing a new VM
+Now we need to create a VM in the same resource group as the AKS cluster. In
+order for the kubernetes master to be able to access the node, we'll need to do
+some additional legwork. The node will need to be in the same vnet, subnet, and
+resource group as the nodes in the cluster. When you create an AKS cluster, it
+actually creates the resources in a separate resource group so they can be
+managed properly. To find the resource group of your cluster and export it as a
+variable for use in other steps, run the following command:
+
+```shell
+$ export CLUSTER_RESOURCE_GROUP=$(az aks show --resource-group <resource group of AKS cluster> --name <AKS cluster name> --query nodeResourceGroup -o tsv)
+```
+
+You'll also need the name of the vnet in that resource group:
+
+```shell
+$ az network vnet list --resource-group $CLUSTER_RESOURCE_GROUP -o table
+```
+
+Copy the name of the vnet from the output and then run the following command.
+This command will create a new small sized (you can change the size if you
+desire) Ubuntu VM in the right vnet and using the `aks-subnet` inside of the
+vnet. It will also create a user named `krustlet` with SSH authentication using
+your public key. If you do not have SSH keys configured, see [this useful
+guide](https://help.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)
+for steps on how to do so:
+
+```shell
+$ az vm create -n krustlet -g $CLUSTER_RESOURCE_GROUP --image UbuntuLTS --admin-username krustlet --ssh-key-values ~/.ssh/id_rsa.pub --size Standard_B1ms --vnet-name <vnet name from above> --subnet aks-subnet
+```
+
+Once the command completes, you'll see output like this:
+```json
+{
+  "fqdns": "",
+  "id": "/subscriptions/27f15ea3-ac5d-2fd4-66ca-a5fe9431f5db/resourceGroups/MC_wasm-testing_krustlet-demo_southcentralus/providers/Microsoft.Compute/virtualMachines/krustlet",
+  "location": "southcentralus",
+  "macAddress": "00-0D-3A-72-2A-92",
+  "powerState": "VM running",
+  "privateIpAddress": "10.240.0.5",
+  "publicIpAddress": "13.65.90.126",
+  "resourceGroup": "MC_wasm-testing_krustlet-demo_southcentralus",
+  "zones": ""
+}
+```
+
+You'll need the value of `privateIpAddress` for connecting to the cluster.
+
+Because the new node is in the AKS vnet, you cannot access it directly. In order
+to access it, you'll need to be in a pod in the cluster. To do so, follow the
+step in the documentation [found
+here](https://docs.microsoft.com/en-us/azure/aks/ssh). And return to this
+document after you have copied your SSH key into the pod.
+
+Once you have the SSH key in the pod, you should be able to access the node by
+running:
+
+```shell
+$ ssh -i id_rsa krustlet@<private IP from above>
+```
+
+However, before doing so, go to the next step.
+
+### Step 4: Copy assets to VM
+The first thing we'll need to do is copy up the assets we generated in steps 1
+and 2. This is a two step process because we need to copy them to the pod and
+then copy them to the server. So first open another terminal in the same
+directory and then copy them to the pod:
+
+```shell
+$ kubectl cp krustlet.pfx $(kubectl get pod -l run=aks-ssh -o jsonpath='{.items[0].metadata.name}'):/
+$ kubectl cp kubeconfig-sa $(kubectl get pod -l run=aks-ssh -o jsonpath='{.items[0].metadata.name}'):/
+```
+
+Now return to your terminal in the pod and copy them to the new VM:
+
+```shell
+$ scp -i id_rsa {krustlet.pfx,kubeconfig-sa} krustlet@<private IP from above>:~/
+```
+
+Then go ahead and SSH to the VM:
+
+```shell
+$ ssh -i id_rsa krustlet@<private IP from above>
+```
+
+### Step 5: Install and configure Krustlet
+Whew, ok...that was a lot. Now let's actually configure stuff. First we'll
+create the config directory for Krustlet and place all of our assets there:
+
+```shell
+$ sudo mkdir -p /etc/krustlet && sudo chown krustlet:krustlet /etc/krustlet
+$ mv {krustlet.pfx,kubeconfig-sa} /etc/krustlet && chmod 600 /etc/krustlet/*
+```
+
+Once that is in place, we'll download the latest release of krustlet and install
+it
+
+<!-- TODO: Add 0.1 link when released -->
+```shell
+$ curl -LO https://krustlet.blob.core.windows.net/releases/krustlet-canary-Linux-amd64.tar.gz && tar -xzf krustlet-canary-Linux-amd64.tar.gz
+$ sudo mv krustlet-wa* /usr/local/bin/
+```
+
+Next we'll enable krustlet as a systemd service. There is an example
+[`krustlet.service`](./assets/krustlet.service) that you can either copy to the
+box, but it is probably easier just to copy and paste it to
+`/etc/systemd/system/krustlet.service` on the VM. Make sure to change the value
+of `PFX_PASSWORD` to the password you set for your certificate. Once you have
+done that, run the following commands to make sure the unit is configured to
+start on boot:
+
+```shell
+$ sudo systemctl enable krustlet && sudo systemctl start krustlet
+```
+
+In another terminal, run `kubectl get nodes -o wide` and you should see output
+that looks similar to below:
+```
+NAME                                STATUS   ROLES   AGE     VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
+aks-agentpool-81651327-vmss000000   Ready    agent   3h32m   v1.17.3   10.240.0.4    <none>        Ubuntu 16.04.6 LTS   4.15.0-1071-azure   docker://3.0.10+azure
+krustlet                            Ready    agent   11s     v1.17.0   10.240.0.5    <none>        <unknown>            <unknown>           mvp
+```
+
+### Step 6: Test that things work
+Now you can see things work! Feel free to give any of the demos a try like so:
+
+```shell
+$ kubectl apply -f demos/wasi/hello-world-rust/k8s.yaml
+# wait a few seconds for the pod to run
+$ kubectl logs hello-world-wasi-rust
+hello from stdout!
+hello from stderr!
+CONFIG_MAP_VAL=cool stuff
+FOO=bar
+POD_NAME=hello-world-wasi-rust
+Args are: []
+```

--- a/docs/how-to/assets/generate-kubeconfig.sh
+++ b/docs/how-to/assets/generate-kubeconfig.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Helpful script taken from the armory docs: https://docs.armory.io/spinnaker-install-admin-guides/manual-service-account/
+
+SERVICE_ACCOUNT_NAME=krustlet
+CONTEXT=$(kubectl config current-context)
+NAMESPACE=kube-system
+
+NEW_CONTEXT=default
+KUBECONFIG_FILE="kubeconfig-sa"
+
+SECRET_NAME=$(kubectl get serviceaccount ${SERVICE_ACCOUNT_NAME} \
+  --context ${CONTEXT} \
+  --namespace ${NAMESPACE} \
+  -o jsonpath='{.secrets[0].name}')
+TOKEN_DATA=$(kubectl get secret ${SECRET_NAME} \
+  --context ${CONTEXT} \
+  --namespace ${NAMESPACE} \
+  -o jsonpath='{.data.token}')
+
+TOKEN=$(echo ${TOKEN_DATA} | base64 -d)
+
+# Create dedicated kubeconfig
+# Create a full copy
+kubectl config view --raw > ${KUBECONFIG_FILE}.full.tmp
+# Switch working context to correct context
+kubectl --kubeconfig ${KUBECONFIG_FILE}.full.tmp config use-context ${CONTEXT}
+# Minify
+kubectl --kubeconfig ${KUBECONFIG_FILE}.full.tmp \
+  config view --flatten --minify > ${KUBECONFIG_FILE}.tmp
+# Rename context
+kubectl config --kubeconfig ${KUBECONFIG_FILE}.tmp \
+  rename-context ${CONTEXT} ${NEW_CONTEXT}
+# Create token user
+kubectl config --kubeconfig ${KUBECONFIG_FILE}.tmp \
+  set-credentials ${CONTEXT}-${NAMESPACE}-token-user \
+  --token ${TOKEN}
+# Set context to use token user
+kubectl config --kubeconfig ${KUBECONFIG_FILE}.tmp \
+  set-context ${NEW_CONTEXT} --user ${CONTEXT}-${NAMESPACE}-token-user
+# Set context to correct namespace
+kubectl config --kubeconfig ${KUBECONFIG_FILE}.tmp \
+  set-context ${NEW_CONTEXT} --namespace ${NAMESPACE}
+# Flatten/minify kubeconfig
+kubectl config --kubeconfig ${KUBECONFIG_FILE}.tmp \
+  view --flatten --minify > ${KUBECONFIG_FILE}
+# Remove tmp
+rm ${KUBECONFIG_FILE}.full.tmp
+rm ${KUBECONFIG_FILE}.tmp

--- a/docs/how-to/assets/krustlet-service-account.yaml
+++ b/docs/how-to/assets/krustlet-service-account.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: krustlet
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: krustlet
+rules:
+  - apiGroups: [""]
+    resources: ["secrets", "configmaps"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: [""]
+    resources: ["pods", "nodes", "pods/status"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: krustlet
+subjects:
+  - kind: ServiceAccount
+    name: krustlet
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: krustlet
+  apiGroup: ""

--- a/docs/how-to/assets/krustlet.service
+++ b/docs/how-to/assets/krustlet.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Krustlet, a kubelet implementation for running WASM
+
+[Service]
+Restart=on-failure
+RestartSec=5s
+Environment=KUBECONFIG=/etc/krustlet/kubeconfig-sa
+Environment=PFX_PATH=/etc/krustlet/krustlet.pfx
+Environment=PFX_PASSWORD=password
+Environment=KRUSTLET_DATA_DIR=/etc/krustlet
+Environment=RUST_LOG=wascc_provider=info,wasi_provider=info,main=info
+ExecStart=/usr/local/bin/krustlet-wasi
+User=krustlet
+Group=krustlet
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/how-to/kind.md
+++ b/docs/how-to/kind.md
@@ -1,0 +1,1 @@
+TODO: Under construction

--- a/docs/how-to/minikube.md
+++ b/docs/how-to/minikube.md
@@ -1,0 +1,1 @@
+TODO: Under construction

--- a/src/krustlet-wascc.rs
+++ b/src/krustlet-wascc.rs
@@ -6,6 +6,10 @@ use wascc_provider::WasccProvider;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // The provider is responsible for all the "back end" logic. If you are creating
+    // a new Kubelet, all you need to implement is a provider.
+    let config = Config::new_from_flags(env!("CARGO_PKG_VERSION"));
+
     // Read the environment. Note that this tries a KubeConfig file first, then
     // falls back on an in-cluster configuration.
     let kubeconfig = config::load_kube_config()
@@ -15,10 +19,6 @@ async fn main() -> anyhow::Result<()> {
 
     // Initialize the logger
     env_logger::init();
-
-    // The provider is responsible for all the "back end" logic. If you are creating
-    // a new Kubelet, all you need to implement is a provider.
-    let config = Config::new_from_flags(env!("CARGO_PKG_VERSION"));
 
     let client = oci_distribution::Client::default();
     let mut module_store_path = config.data_dir.join(".oci");

--- a/src/krustlet-wasi.rs
+++ b/src/krustlet-wasi.rs
@@ -6,6 +6,10 @@ use wasi_provider::WasiProvider;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // The provider is responsible for all the "back end" logic. If you are creating
+    // a new Kubelet, all you need to implement is a provider.
+    let config = Config::new_from_flags(env!("CARGO_PKG_VERSION"));
+
     // Read the environment. Note that this tries a KubeConfig file first, then
     // falls back on an in-cluster configuration.
     let kubeconfig = config::load_kube_config()
@@ -14,10 +18,6 @@ async fn main() -> anyhow::Result<()> {
 
     // Initialize the logger
     env_logger::init();
-
-    // The provider is responsible for all the "back end" logic. If you are creating
-    // a new Kubelet, all you need to implement is a provider.
-    let config = Config::new_from_flags(env!("CARGO_PKG_VERSION"));
 
     let client = oci_distribution::Client::default();
     let mut module_store_path = config.data_dir.join(".oci");


### PR DESCRIPTION
This also stubs out the rest of this documentation and includes a tiny
bug fix to make sure flags load before the kubeconfig in binaries.

Closes #88 