### PR TITLE
Fix docker build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN cargo build --example empty --release && \
     rm -rf ./target/release/.fingerprint/krustlet-*
 
 # Build real binaries now
-RUN rm ./src/main.rs ./src/lib.rs
 COPY ./src ./src
 
 RUN cargo build --release


### PR DESCRIPTION
Closes https://github.com/deislabs/krustlet/issues/131.

```console
$ just dockerize
docker build -t technosophos/krustlet:latest .
Sending build context to Docker daemon  72.47MB
Step 1/14 : FROM rust:1.41
 ---> a716da47d5b9
Step 2/14 : WORKDIR /usr/src/krustlet
 ---> Using cache
 ---> 54fe51bfef33
Step 3/14 : RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
 ---> Using cache
 ---> b31170e18dd7
Step 4/14 : COPY Cargo.toml .
 ---> Using cache
 ---> 4a4c8bf8a862
Step 5/14 : COPY Cargo.lock .
 ---> Using cache
 ---> 661adee73dec
Step 6/14 : COPY justfile .
 ---> Using cache
 ---> 547d34665c27
Step 7/14 : COPY crates ./crates
 ---> Using cache
 ---> 9221b517f346
Step 8/14 : RUN mkdir -p ./examples/ &&     echo 'fn main() {}' > ./examples/empty.rs
 ---> Using cache
 ---> 8e6c04e6d736
Step 9/14 : RUN just prefetch
 ---> Using cache
 ---> c8087cb5d09f
Step 10/14 : RUN cargo build --example empty --release &&     rm -rf ./target/release/.fingerprint/krustlet-*
 ---> Using cache
 ---> b8fbb5757799
Step 11/14 : RUN rm -f ./src/main.rs ./src/lib.rs
 ---> Running in e088221a0947
Removing intermediate container e088221a0947
 ---> 476a77077653
Step 12/14 : COPY ./src ./src
 ---> c072847cbb1f
Step 13/14 : RUN cargo build --release
 ---> Running in 3a10537d0ab8
...
   Compiling krustlet v0.1.0 (/usr/src/krustlet)
    Finished release [optimized] target(s) in 3m 12s
Removing intermediate container 3a10537d0ab8
 ---> 16e0d744bbb8
Step 14/14 : CMD ["/usr/src/krustlet/target/release/krustlet"]
 ---> Running in 6918dfbb5d2a
Removing intermediate container 6918dfbb5d2a
 ---> 2574cd5bf8cc
Successfully built 2574cd5bf8cc
Successfully tagged technosophos/krustlet:latest
```