### PR TITLE
ref(docs): word wrap at 100 characters

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,34 +4,30 @@ This document describes the requirements for committing to this repository.
 
 ## Code of Conduct
 
-All participants in the Krustlet community must comply with the [Microsoft Open
-Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). This
-includes issues filed in the queue as well as PRs.
+All participants in the Krustlet community must comply with the [Microsoft Open Source Code of
+Conduct](https://opensource.microsoft.com/codeofconduct/). This includes issues filed in the queue
+as well as PRs.
 
 ## Contributor License Agreement
 
 This repository is governed under a [Contributor License
-Agreement](https://cla.opensource.microsoft.com/deislabs/krustlet). All PR
-submitters must accept the CLA before their contributions can be merged.
+Agreement](https://cla.opensource.microsoft.com/deislabs/krustlet). All PR submitters must accept
+the CLA before their contributions can be merged.
 
 ## Pull Request Management
 
-All code that is contributed to Krustlet must go through the Pull Request (PR)
-process. To contribute a PR, fork this project, create a new branch, make
-changes on that branch, and then use GitHub to open a pull request with your
-changes.
+All code that is contributed to Krustlet must go through the Pull Request (PR) process. To
+contribute a PR, fork this project, create a new branch, make changes on that branch, and then use
+GitHub to open a pull request with your changes.
 
-Every PR must be reviewed by at least one Core Maintainer of the project. Once a
-PR has been marked "Approved" by a Core Maintainer (and no other core maintainer
-has an open "Rejected" vote), the PR may be merged. While it is fine for
-non-maintainers to contribute their own code reviews, those reviews do not
-satisfy the above requirement.
+Every PR must be reviewed by at least one Core Maintainer of the project. Once a PR has been marked
+"Approved" by a Core Maintainer (and no other core maintainer has an open "Rejected" vote), the PR
+may be merged. While it is fine for non-maintainers to contribute their own code reviews, those
+reviews do not satisfy the above requirement.
 
 ## Code of Conduct
 
 This project has adopted the [Microsoft Open Source Code of
-Conduct](https://opensource.microsoft.com/codeofconduct/). For more information
-see the [Code of Conduct
-FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact
-[opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional
-questions or comments.
+Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of
+Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact
+[opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/README.md
+++ b/README.md
@@ -1,29 +1,29 @@
 # Krustlet: Kubernetes Kubelet in Rust for running WASM
 
-**This project is highly experimental.** It is not yet fully ready for
-production, so you should use it in production at your own risk
+**This project is highly experimental.** It is not yet fully ready for production, so you should use
+it in production at your own risk
 
-Krustlet acts as a Kubelet by listening on the event stream for new pod requests
-that match a particular set of node selectors.
+Krustlet acts as a Kubelet by listening on the event stream for new pod requests that match a
+particular set of node selectors.
 
-The default implementation of Krustlet listens for the architecture
-`wasm32-wasi` and schedules those workloads to run in a `wasmtime`-based runtime
-instead of a container runtime.
+The default implementation of Krustlet listens for the architecture `wasm32-wasi` and schedules
+those workloads to run in a `wasmtime`-based runtime instead of a container runtime.
 
 ## Documentation
 
-If you're new to the project, get started with [the introduction](docs/intro/README.md). For more in-depth information
-about Krustlet, plunge right into the [topic guides](docs/topics/README.md).
+If you're new to the project, get started with [the introduction](docs/intro/README.md). For more
+in-depth information about Krustlet, plunge right into the [topic guides](docs/topics/README.md).
 
-Looking for the developer guide? [Start here](docs/community/developers.md). If
-you are interested in the project, please feel free to join us in our weekly
-public call [on
-Zoom](https://zoom.us/j/200921512?pwd=N3hBblRaUE1FL3luVkJ6ZzZsM0NIUT09) at 9:00
-am Pacific Time every Monday
+Looking for the developer guide? [Start here](docs/community/developers.md). If you are interested
+in the project, please feel free to join us in our weekly public call [on
+Zoom](https://zoom.us/j/200921512?pwd=N3hBblRaUE1FL3luVkJ6ZzZsM0NIUT09) at 9:00 am Pacific Time
+every Monday
 
 ## Code of Conduct
 
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+This project has adopted the [Microsoft Open Source Code of
+Conduct](https://opensource.microsoft.com/codeofconduct/).
 
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
-or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+For more information see the [Code of Conduct
+FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact
+[opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/demos/wasi/hello-world-assemblyscript/README.md
+++ b/demos/wasi/hello-world-assemblyscript/README.md
@@ -10,7 +10,8 @@ It is meant to be a simple demo for the wasi-provider with Krustlet.
 
 ## Running the example
 
-This example has already been pre-built, so you only need to install it into your Kubernetes cluster.
+This example has already been pre-built, so you only need to install it into your Kubernetes
+cluster.
 
 Create the pod and configmap with `kubectl`:
 
@@ -36,12 +37,12 @@ If you want to compile the demo and inspect it, you'll need to do the following.
 
 ### Prerequisites
 
-You'll need `npm` installed in order to install and build the dependencies. This project is using the
-[as-wasi](https://github.com/jedisct1/as-wasi) dependency, which is a helpful set of wrappers around the low level
-WASI bindings provided in AssemblyScript.
+You'll need `npm` installed in order to install and build the dependencies. This project is using
+the [as-wasi](https://github.com/jedisct1/as-wasi) dependency, which is a helpful set of wrappers
+around the low level WASI bindings provided in AssemblyScript.
 
-If you are interested in starting your own AssemblyScript project, visit the AssemblyScript
-[getting started guide](https://docs.assemblyscript.org/quick-start).
+If you are interested in starting your own AssemblyScript project, visit the AssemblyScript [getting
+started guide](https://docs.assemblyscript.org/quick-start).
 
 If you don't have Krustlet with the WASI provider running locally, see the instructions in the
 [tutorial](../../../docs/intro/tutorial03.md) for running locally.
@@ -56,4 +57,5 @@ $ npm install && npm run asbuild
 
 ### Pushing
 
-Detailed instructions for pushing a module can be found in the [tutorial](../../../docs/intro/tutorial02.md).
+Detailed instructions for pushing a module can be found in the
+[tutorial](../../../docs/intro/tutorial02.md).

--- a/demos/wasi/hello-world-c/README.md
+++ b/demos/wasi/hello-world-c/README.md
@@ -15,8 +15,7 @@ First create the pod and configmap:
 $ kubectl apply -f k8s.yaml
 ```
 
-You should then be able to get the logs and see the output from the wasm module
-run:
+You should then be able to get the logs and see the output from the wasm module run:
 
 ```shell
 $ kubectl logs hello-world-wasi-c
@@ -34,10 +33,12 @@ If you want to compile the demo and inspect it, you'll need to do the following.
 
 ### Prerequisites
 
-Building WASI in C is easiest with the custom [SDK](https://github.com/WebAssembly/wasi-sdk) from wasmtime. Feel free to
-go down the rabbit hole of figuring things out with vanilla `clang` for your own project should you so desire.
+Building WASI in C is easiest with the custom [SDK](https://github.com/WebAssembly/wasi-sdk) from
+wasmtime. Feel free to go down the rabbit hole of figuring things out with vanilla `clang` for your
+own project should you so desire.
 
-To install the SDK, follow the steps below, replacing `$OS_NAME` with your OS (current choices are `linux` and `macos`):
+To install the SDK, follow the steps below, replacing `$OS_NAME` with your OS (current choices are
+`linux` and `macos`):
 
 ```shell
 $ wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-8/wasi-sysroot-8.0.tar.gz
@@ -61,5 +62,5 @@ $ ./wasi-sdk-8.0/bin/clang -v demo.c --sysroot ./wasi-sysroot -o demo.wasm
 
 Detailed instructions for pushing a module can be found [here](../../../docs/intro/tutorial02.md).
 
-We hope to improve and streamline the build and push process in the future. However, for test purposes, the image has
-been pushed to the `webassembly` Azure Container Registry.
+We hope to improve and streamline the build and push process in the future. However, for test
+purposes, the image has been pushed to the `webassembly` Azure Container Registry.

--- a/demos/wasi/hello-world-rust/README.md
+++ b/demos/wasi/hello-world-rust/README.md
@@ -40,9 +40,8 @@ You'll need to have Rust installed with `wasm32-wasi` target installed:
 $ rustup target add wasm32-wasi
 ```
 
-If you don't have Krustlet with the WASI provider running locally, see the
-instructions in the [tutorial](../../../docs/intro/tutorial03.md) for running
-locally.
+If you don't have Krustlet with the WASI provider running locally, see the instructions in the
+[tutorial](../../../docs/intro/tutorial03.md) for running locally.
 
 ### Building
 
@@ -56,5 +55,5 @@ $ cargo build --target wasm32-wasi --release
 
 Detailed instructions for pushing a module can be found [here](../../../docs/intro/tutorial02.md).
 
-We hope to improve and streamline the build and push process in the future. However, for test purposes, the image has
-been pushed to the `webassembly` Azure Container Registry.
+We hope to improve and streamline the build and push process in the future. However, for test
+purposes, the image has been pushed to the `webassembly` Azure Container Registry.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,9 +4,15 @@ Everything you need to know about Krustlet.
 
 # How the documentation is organized
 
-Krustlet has a lot of documentation. A high-level overview of how it’s organized will help you know where to look for certain things:
+Krustlet has a lot of documentation. A high-level overview of how it’s organized will help you know
+where to look for certain things:
 
-- [The introduction](intro/README.md) takes you by the hand through a series of steps to run an application on Krustlet. Start here if you’re new to Krustlet.
-- [Topic guides](topics/README.md) discuss key topics and concepts at a fairly high level and provide useful background information and explanation.
-- [Community Guides](community/README.md) teach you about the development process for Krustlet and how you can contribute to the project.
-- [How To Guides](howto/README.md) are recipes. They guide you through the steps involved in addressing key problems and use-cases. They are more advanced than tutorials and assume some knowledge of how Krustlet works.
+- [The introduction](intro/README.md) takes you by the hand through a series of steps to run an
+  application on Krustlet. Start here if you’re new to Krustlet.
+- [Topic guides](topics/README.md) discuss key topics and concepts at a fairly high level and
+  provide useful background information and explanation.
+- [Community Guides](community/README.md) teach you about the development process for Krustlet and
+  how you can contribute to the project.
+- [How To Guides](howto/README.md) are recipes. They guide you through the steps involved in
+  addressing key problems and use-cases. They are more advanced than tutorials and assume some
+  knowledge of how Krustlet works.

--- a/docs/community/code-of-conduct.md
+++ b/docs/community/code-of-conduct.md
@@ -1,6 +1,8 @@
 # Code of Conduct
 
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+This project has adopted the [Microsoft Open Source Code of
+Conduct](https://opensource.microsoft.com/codeofconduct/).
 
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
-or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+For more information see the [Code of Conduct
+FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact
+[opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/docs/community/developers.md
+++ b/docs/community/developers.md
@@ -33,14 +33,15 @@ $ just build
 
 There are two different runtimes available for Krustlet: `wascc` or `wasi`.
 
-The `wascc` runtime is a secure WebAssembly host runtime, connecting "actors" and "capability providers" together to
-connect your WebAssembly runtime to cloud-native services like message brokers, databases, or other external services
-normally unavailable to the WebAssembly runtime.
+The `wascc` runtime is a secure WebAssembly host runtime, connecting "actors" and "capability
+providers" together to connect your WebAssembly runtime to cloud-native services like message
+brokers, databases, or other external services normally unavailable to the WebAssembly runtime.
 
-The `wasi` runtime uses a project called [`wasmtime`](https://github.com/bytecodealliance/wasmtime). wasmtime is a
-standalone JIT-style host runtime for WebAssembly modules. It is focused primarily on standards compliance with the WASM
-specification as it relates to [WASI](https://wasi.dev/). If your WebAssembly module complies with the
-[WebAssembly specification](https://github.com/WebAssembly/spec), wasmtime can run it.
+The `wasi` runtime uses a project called [`wasmtime`](https://github.com/bytecodealliance/wasmtime).
+wasmtime is a standalone JIT-style host runtime for WebAssembly modules. It is focused primarily on
+standards compliance with the WASM specification as it relates to [WASI](https://wasi.dev/). If your
+WebAssembly module complies with the [WebAssembly
+specification](https://github.com/WebAssembly/spec), wasmtime can run it.
 
 Depending on which host runtime you want, choose one of either:
 
@@ -49,13 +50,14 @@ $ just run-wascc
 $ just run-wasi
 ```
 
-Before startup, this command will delete any nodes in your Kubernetes cluster named with your hostname, so make sure
-you're running this in a test environment.
+Before startup, this command will delete any nodes in your Kubernetes cluster named with your
+hostname, so make sure you're running this in a test environment.
 
-If you want to interact with the kubelet (for things like `kubectl logs` and `kubectl exec`), you'll likely need to set
-a specific KRUSTLET_NODE_IP that krustlet will be available at. Otherwise, calls to the kubelet will result in errors.
-This may differ from machine to machine. For example, with Minikube on a Mac, you'll have an interface called `bridge0`
-which the cluster can talk to. So your node IP should be that IP address.
+If you want to interact with the kubelet (for things like `kubectl logs` and `kubectl exec`), you'll
+likely need to set a specific KRUSTLET_NODE_IP that krustlet will be available at. Otherwise, calls
+to the kubelet will result in errors. This may differ from machine to machine. For example, with
+Minikube on a Mac, you'll have an interface called `bridge0` which the cluster can talk to. So your
+node IP should be that IP address.
 
 To set the node IP, run:
 
@@ -65,7 +67,8 @@ $ export KRUSTLET_NODE_IP=<the ip address>
 
 ## Testing
 
-Krustlet contains both integration and unit tests. For convenience, there are `just` targets for running one or the other.
+Krustlet contains both integration and unit tests. For convenience, there are `just` targets for
+running one or the other.
 
 For unit tests:
 
@@ -73,7 +76,8 @@ For unit tests:
 $ just test
 ```
 
-For the integration tests, start a wascc and wasi node in separate terminals before running the tests.
+For the integration tests, start a wascc and wasi node in separate terminals before running the
+tests.
 
 In terminal 1:
 
@@ -95,6 +99,8 @@ $ just test-e2e
 
 ## Creating your own Kubelets with Krustlet
 
-If you want to create your own Kubelet based on Krustlet, all you need to do is implement a `Provider`.
+If you want to create your own Kubelet based on Krustlet, all you need to do is implement a
+`Provider`.
 
-See `src/krustlet-*.rs` and their corresponding provider implementation in `crates/*-provider` to get started.
+See `src/krustlet-*.rs` and their corresponding provider implementation in `crates/*-provider` to
+get started.

--- a/docs/howto/README.md
+++ b/docs/howto/README.md
@@ -1,8 +1,8 @@
 # How-To Guides
 
-Here you’ll find short answers to "How do I...?" types of questions. These how-to guides don’t cover topics in
-depth – you’ll find that material in the [topic guides](../topics/README.md) section. However, these guides will help
-you quickly accomplish common tasks.
+Here you’ll find short answers to "How do I...?" types of questions. These how-to guides don’t cover
+topics in depth – you’ll find that material in the [topic guides](../topics/README.md) section.
+However, these guides will help you quickly accomplish common tasks.
 
 - [Running Krustlet on Azure Kubernetes Service (AKS)](krustlet-on-aks.md)
 - [Running Krustlet on Amazon Elastic Kubernetes Service (EKS)](krustlet-on-eks.md)

--- a/docs/howto/kubernetes-on-aks.md
+++ b/docs/howto/kubernetes-on-aks.md
@@ -1,7 +1,7 @@
 # Running Kubernetes on Azure Kubernetes Service (AKS)
 
-Azure Kubernetes Service (AKS) is an optimized container hosting solution that works with all the open source tools you
-know. Azure is great for Krustlet.
+Azure Kubernetes Service (AKS) is an optimized container hosting solution that works with all the
+open source tools you know. Azure is great for Krustlet.
 
 If you don't yet have a Microsoft Azure account, start a trial with $200 of free credit
 [here](https://azure.microsoft.com/en-us/free/).
@@ -10,16 +10,17 @@ If you don't yet have a Microsoft Azure account, start a trial with $200 of free
 
 You should be able to run the `az` command, which is used to provision resources in the Azure cloud.
 
-Either [install Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest) to your
-computer or [open a Cloud Shell][cloudshell] by clicking this icon near
-the upper right of the Azure Portal: ![Azure Cloud Shell Icon](img/cloudshell.png)
+Either [install Azure
+CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest) to your
+computer or [open a Cloud Shell][cloudshell] by clicking this icon near the upper right of the Azure
+Portal: ![Azure Cloud Shell Icon](img/cloudshell.png)
 
 ## Configure the Azure CLI
 
 If you use [Cloud Shell][cloudshell], the `az` client command is already configured.
 
-If you installed `az` locally, log in to your Azure account by typing `az login` at a command prompt and complete the
-confirmation code process.
+If you installed `az` locally, log in to your Azure account by typing `az login` at a command prompt
+and complete the confirmation code process.
 
 You can verify which account is active with the `az account show` command.
 
@@ -41,15 +42,16 @@ $ export AZURE_RG_NAME=myresourcegroup
 $ az group create --name "${AZURE_RG_NAME}" --location "${AZURE_DC_LOCATION}"
 ```
 
-Run the `az aks create` command to create your Kubernetes cluster, replacing the cluster name below with your values:
+Run the `az aks create` command to create your Kubernetes cluster, replacing the cluster name below
+with your values:
 
 ```
 $ export CLUSTER_NAME=krustlet-demo
 $ az aks create --resource-group="${AZURE_RG_NAME}" --name="${CLUSTER_NAME}"
 ```
 
-Azure Kubernetes Service immediately begins creating the Kubernetes cluster. After a few minutes, the command
-returns with information about the new deployment:
+Azure Kubernetes Service immediately begins creating the Kubernetes cluster. After a few minutes,
+the command returns with information about the new deployment:
 
 ```
 DnsPrefix                          EnableRbac    Fqdn                                                             KubernetesVersion    Location    MaxAgentPools    Name           NodeResourceGroup                        ProvisioningState    ResourceGroup
@@ -59,20 +61,21 @@ krustlet-d-myresourcegroup-dd5bc9  True          krustlet-d-myresourcegroup-dd5b
 
 ### Option 2: Web Portal
 
-Sign in to the Azure Portal and create a new Azure Kubernetes Service. Click on the **+ Create a Resouce** link, then
-the **Compute** link, then **Kubernetes Service**.
+Sign in to the Azure Portal and create a new Azure Kubernetes Service. Click on the **+ Create a
+Resouce** link, then the **Compute** link, then **Kubernetes Service**.
 
 You should be greeted with the following window:
 
 ![azure web portal](img/portal.png)
 
-Review and change the details to match your preferences, then click **Review + Create** in the bottom-left of your
-screen.
+Review and change the details to match your preferences, then click **Review + Create** in the
+bottom-left of your screen.
 
-You can monitor the progress of the deployment on the Azure dashboard, or just wait for a notification that it has
-completed.
+You can monitor the progress of the deployment on the Azure dashboard, or just wait for a
+notification that it has completed.
 
-Once the cluster has booted, you'll want to connect to the cluster with `kubectl`, the Kubernetes command line client.
+Once the cluster has booted, you'll want to connect to the cluster with `kubectl`, the Kubernetes
+command line client.
 
 If you don't already have it installed, you can install it with:
 

--- a/docs/howto/kubernetes-on-kind.md
+++ b/docs/howto/kubernetes-on-kind.md
@@ -1,11 +1,12 @@
 # Running Kubernetes on Kubernetes in Docker (KinD)
 
-This tutorial will focus on using a tool called [kind](https://github.com/kubernetes-sigs/kind), also known as
-"Kubernetes IN Docker".
+This tutorial will focus on using a tool called [kind](https://github.com/kubernetes-sigs/kind),
+also known as "Kubernetes IN Docker".
 
-If you haven't installed them already, go ahead and [install Docker](https://docs.docker.com/install/),
-[install kind](https://github.com/kubernetes-sigs/kind#installation-and-usage), and
-[install kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
+If you haven't installed them already, go ahead and [install
+Docker](https://docs.docker.com/install/), [install
+kind](https://github.com/kubernetes-sigs/kind#installation-and-usage), and [install
+kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 
 You'll need `kubectl` to interact with the cluster once it's created.
 

--- a/docs/intro/install.md
+++ b/docs/intro/install.md
@@ -4,31 +4,38 @@ This guide shows how to install Krustlet.
 
 ## From the Binary Releases
 
-Every release of Krustlet provides compiled releases for a variety of Operating Systems. These compiled releases can
-be manually downloaded and installed.
+Every release of Krustlet provides compiled releases for a variety of Operating Systems. These
+compiled releases can be manually downloaded and installed.
 
-1. Download your desired version from [the releases page](https://github.com/deislabs/krustlet/releases)
+1. Download your desired version from [the releases
+   page](https://github.com/deislabs/krustlet/releases)
 1. Unpack it (`tar -xzf krustlet-v0.1.0-Linux-amd64.tar.gz`)
-1. Find the desired Krustlet provider in the unpacked directory, and move it to its desired destination (`mv krustlet-wasi /usr/local/bin/`)
+1. Find the desired Krustlet provider in the unpacked directory, and move it to its desired
+   destination (`mv krustlet-wasi /usr/local/bin/`)
 
-From there, you should be able to run the client in your terminal emulator. If your terminal cannot find Krustlet, check
-to make sure that your `$PATH` environment variable is set correctly.
+From there, you should be able to run the client in your terminal emulator. If your terminal cannot
+find Krustlet, check to make sure that your `$PATH` environment variable is set correctly.
 
 ## From Canary Builds
 
-“Canary” builds are versions of Krustlet that are built from `master`. They are not official releases, and may not be
-stable. However, they offer the opportunity to test the cutting edge features before they are released.
+“Canary” builds are versions of Krustlet that are built from `master`. They are not official
+releases, and may not be stable. However, they offer the opportunity to test the cutting edge
+features before they are released.
 
 Here are links to the common builds:
 
 - [checksum file](https://krustlet.blob.core.windows.net/releases/checksums-canary.txt)
-- [64-bit Linux (AMD architecture)](https://krustlet.blob.core.windows.net/releases/krustlet-canary-Linux-amd64.tar.gz)
-- [64-bit macOS (AMD architecture)](https://krustlet.blob.core.windows.net/releases/krustlet-canary-macOS-amd64.tar.gz)
+- [64-bit Linux (AMD
+  architecture)](https://krustlet.blob.core.windows.net/releases/krustlet-canary-Linux-amd64.tar.gz)
+- [64-bit macOS (AMD
+  architecture)](https://krustlet.blob.core.windows.net/releases/krustlet-canary-macOS-amd64.tar.gz)
 
 ## Compiling from Source
 
-If you want to compile Krustlet from source, you will need to follow the [developer guide](../community/developers.md).
+If you want to compile Krustlet from source, you will need to follow the [developer
+guide](../community/developers.md).
 
 ## Next Steps
 
-After installing Krustlet, you can go through [the tutorial](tutorial01.md) to learn how to start using Krustlet.
+After installing Krustlet, you can go through [the tutorial](tutorial01.md) to learn how to start
+using Krustlet.

--- a/docs/intro/quickstart.md
+++ b/docs/intro/quickstart.md
@@ -6,37 +6,37 @@ Get started with Krustlet in three easy steps:
 2. Boot a Krustlet node
 3. Deploy your first application
 
-As Krustlet is under active development, this guide will help you set up a cluster suitable for evaluation, development,
-and testing purposes.
+As Krustlet is under active development, this guide will help you set up a cluster suitable for
+evaluation, development, and testing purposes.
 
 ## Step 1: Boot a Kubernetes Cluster
 
-There are many ways to boot up a Kubernetes cluster. You may choose to get up and running in cloud environments or
-locally on your laptop.
+There are many ways to boot up a Kubernetes cluster. You may choose to get up and running in cloud
+environments or locally on your laptop.
 
-If you have already created a Kubernetes cluster, proceed to the next step to install Krustlet on your own Kubernetes
-cluster.
+If you have already created a Kubernetes cluster, proceed to the next step to install Krustlet on
+your own Kubernetes cluster.
 
 For production use:
 
 - [Azure Kubernetes Service (AKS)](../howto/kubernetes-on-aks.md)
 - [Amazon Elastic Kubernetes Service (EKS)](../howto/kubernetes-on-eks.md)
 
-For development and evaluation purposes, it may make sense to use a VM-based Kubernetes cluster for quick and easy setup
-and teardown:
+For development and evaluation purposes, it may make sense to use a VM-based Kubernetes cluster for
+quick and easy setup and teardown:
 
 - [Kubernetes-in-Docker (KinD)](../howto/kubernetes-on-kind.md)
 
 ## Step 2: Boot a Krustlet Node
 
-Depending on whatever provider you chose in step 1, you now have a few options to boot and register Krustlet with your
-Kubernetes cluster.
+Depending on whatever provider you chose in step 1, you now have a few options to boot and register
+Krustlet with your Kubernetes cluster.
 
-If you have your own Kubernetes cluster, you may want to follow the steps in the cloud-based option guides to determine
-how to set up Krustlet for your own infrastructure.
+If you have your own Kubernetes cluster, you may want to follow the steps in the cloud-based option
+guides to determine how to set up Krustlet for your own infrastructure.
 
-For production use, you'll want to boot Krustlet on a device that can start a web server on an IP accessible from the
-Kubernetes control plane.
+For production use, you'll want to boot Krustlet on a device that can start a web server on an IP
+accessible from the Kubernetes control plane.
 
 - [Azure Kubernetes Service (AKS)](../howto/krustlet-on-aks.md)
 - [Amazon Elastic Kubernetes Service (EKS)](../howto/krustlet-on-eks.md)

--- a/docs/intro/readnext.md
+++ b/docs/intro/readnext.md
@@ -1,31 +1,33 @@
 # What to read next
 
-So you’ve read all the introductory material and have decided you’d like to keep using Krustlet to run your WebAssembly
-applications. We’ve only just scratched the surface.
+So you’ve read all the introductory material and have decided you’d like to keep using Krustlet to
+run your WebAssembly applications. We’ve only just scratched the surface.
 
 So what’s next?
 
-Well, we’ve always been big fans of learning by doing. At this point you should know enough to start a project of your
-own and start fooling around. As you need to learn new tricks, come back to the documentation.
+Well, we’ve always been big fans of learning by doing. At this point you should know enough to start
+a project of your own and start fooling around. As you need to learn new tricks, come back to the
+documentation.
 
-We’ve put a lot of effort into making Krustlet's documentation useful, easy to read and as complete as possible. The
-rest of this document explains more about how the documentation works so that you can get the most out of it.
+We’ve put a lot of effort into making Krustlet's documentation useful, easy to read and as complete
+as possible. The rest of this document explains more about how the documentation works so that you
+can get the most out of it.
 
-(Yes, this is documentation about documentation. Rest assured we have no plans to write a document about how to read the
-document about documentation.)
+(Yes, this is documentation about documentation. Rest assured we have no plans to write a document
+about how to read the document about documentation.)
 
 ## How the documentation is organized
 
 Krustlet's main documentation is broken up into “chunks” designed to fill different needs:
 
-The [introductory material][intro] is designed for people new to Krustlet – or to WebAssembly on Kubernetes in
-general. It doesn’t cover anything in depth, but instead gives a high-level overview of how running apps on Kubernetes
-“feels”.
+The [introductory material][intro] is designed for people new to Krustlet – or to WebAssembly on
+Kubernetes in general. It doesn’t cover anything in depth, but instead gives a high-level overview
+of how running apps on Kubernetes“feels”.
 
-The [topic guides][topics], on the other hand, dive deep into individual parts of Krustlet. There are complete guides to
-the internals of Krustlet's architecture. This is probably where you’ll want to spend most of your time; if you work
-your way through these guides you should come out knowing pretty much everything there is to know about Krustlet.
+The [topic guides][topics], on the other hand, dive deep into individual parts of Krustlet. There
+are complete guides to the internals of Krustlet's architecture. This is probably where you’ll want
+to spend most of your time; if you work your way through these guides you should come out knowing
+pretty much everything there is to know about Krustlet.
 
 
-[intro]: README.md
-[topics]: ../topics/README.md
+[intro]: README.md [topics]: ../topics/README.md

--- a/docs/intro/tutorial01.md
+++ b/docs/intro/tutorial01.md
@@ -2,8 +2,8 @@
 
 Let’s learn by example.
 
-Throughout this tutorial, we’ll walk you through the creation of a basic WASI application. Once ready, we will package
-that application and install it onto the Kubernetes cluster using krustlet.
+Throughout this tutorial, we’ll walk you through the creation of a basic WASI application. Once
+ready, we will package that application and install it onto the Kubernetes cluster using krustlet.
 
 The tutorial will consist of three parts:
 
@@ -15,28 +15,30 @@ The tutorial will consist of three parts:
 
 We’ll assume you have Cargo (a package management system for Rust) installed already.
 
-If you're compiling the application written in C, you'll want to install the
-[WASI SDK](https://github.com/WebAssembly/wasi-sdk), though if you're following the tutorial with the Rust example, this
-step is optional.
+If you're compiling the application written in C, you'll want to install the [WASI
+SDK](https://github.com/WebAssembly/wasi-sdk), though if you're following the tutorial with the Rust
+example, this step is optional.
 
-In part 2 of this tutorial, we will be publishing our application to a registry hosted on Microsoft Azure. The steps
-assume you have an Azure account and the `az` CLI installed. However, there are other cloud providers available with
-their own solutions, and if you're feeling particularly brave, you can
-[run your own registry on your own infrastructure](https://github.com/docker/distribution). You'll also need
-[wasm-to-oci](https://github.com/engineerd/wasm-to-oci) (a tool for publishing WebAssembly modules to a registry).
+In part 2 of this tutorial, we will be publishing our application to a registry hosted on Microsoft
+Azure. The steps assume you have an Azure account and the `az` CLI installed. However, there are
+other cloud providers available with their own solutions, and if you're feeling particularly brave,
+you can [run your own registry on your own infrastructure](https://github.com/docker/distribution).
+You'll also need [wasm-to-oci](https://github.com/engineerd/wasm-to-oci) (a tool for publishing
+WebAssembly modules to a registry).
 
-We’ll assume you have Krustlet installed already. See [the quickstart guide](quickstart.md) for advice on how to boot
-a Kubernetes cluster and install Krustlet.
+We’ll assume you have Krustlet installed already. See [the quickstart guide](quickstart.md) for
+advice on how to boot a Kubernetes cluster and install Krustlet.
 
 If you're having trouble going through this tutorial, please post an issue to
-[deislabs/krustlet](https://github.com/deislabs/krustlet) to chat with other Krustlet users who might be able to help.
+[deislabs/krustlet](https://github.com/deislabs/krustlet) to chat with other Krustlet users who
+might be able to help.
 
 ## Creating your first application
 
 For this tutorial, we'll be creating an example application written either in C or in Rust.
 
-The application a very simple "hello world" application, running forever and printing "hello world!" every 5 seconds
-to standard output.
+The application a very simple "hello world" application, running forever and printing "hello world!"
+every 5 seconds to standard output.
 
 ### Option 1: From C
 
@@ -63,14 +65,15 @@ int main() {
 }
 ```
 
-The wasi-sdk provides a clang which is configured to target WASI. We can compile our program like so:
+The wasi-sdk provides a clang which is configured to target WASI. We can compile our program like
+so:
 
 ```console
 $ clang main.c -o demo.wasm
 ```
 
-This is just regular clang, configured to use a WebAssembly target and sysroot. The output of clang here is a standard
-WebAssembly module:
+This is just regular clang, configured to use a WebAssembly target and sysroot. The output of clang
+here is a standard WebAssembly module:
 
 ```console
 $ file demo.wasm
@@ -115,11 +118,12 @@ demo.wasm: WebAssembly (wasm) binary module version 0x1 (MVP)
 
 ## Optional: executing with wasmtime
 
-The WebAssembly module `demo.wasm` we just compiled either from C or Rust is simply a single file containing a
-self-contained WASM module.
+The WebAssembly module `demo.wasm` we just compiled either from C or Rust is simply a single file
+containing a self-contained WASM module.
 
-`wasmtime` is a standalone JIT-style runtime for WebAssembly and WASI. It runs WebAssembly code outside of the web, and
-can be used both as a command-line utility or as a library embedded in a larger application.
+`wasmtime` is a standalone JIT-style runtime for WebAssembly and WASI. It runs WebAssembly code
+outside of the web, and can be used both as a command-line utility or as a library embedded in a
+larger application.
 
 We can execute our application with `wasmtime` directly, like so:
 
@@ -135,5 +139,5 @@ To exit the program, enter CTRL+C with your keyboard.
 
 Great! Our program runs as expected!
 
-When you’re comfortable with the application, read [part 2](tutorial02.md) of this tutorial to learn about publishing
-our application to a registry, where Krustlet will be able to find it and run it.
+When you’re comfortable with the application, read [part 2](tutorial02.md) of this tutorial to learn
+about publishing our application to a registry, where Krustlet will be able to find it and run it.

--- a/docs/intro/tutorial02.md
+++ b/docs/intro/tutorial02.md
@@ -1,36 +1,38 @@
 # Writing your first app, part 2
 
-This tutorial begins where [Tutorial 1](tutorial01.md) left off. We’ll walk through the process to set up your personal
-registry and publish your application to that registry.
+This tutorial begins where [Tutorial 1](tutorial01.md) left off. We’ll walk through the process to
+set up your personal registry and publish your application to that registry.
 
-For this tutorial, we will be creating a registry hosted on Microsoft Azure, but there are other cloud providers that
-provide their own solutions, and you can [run one on your own infrastructure](https://github.com/docker/distribution),
-too!
+For this tutorial, we will be creating a registry hosted on Microsoft Azure, but there are other
+cloud providers that provide their own solutions, and you can [run one on your own
+infrastructure](https://github.com/docker/distribution), too!
 
 ## What is a registry, and what is wasm-to-oci?
 
-A registry allows you to store your local WebAssembly modules in the cloud. With a registry, you can backup your
-personal modules, share your projects, and collaborate with others.
+A registry allows you to store your local WebAssembly modules in the cloud. With a registry, you can
+backup your personal modules, share your projects, and collaborate with others.
 
-[wasm-to-oci][] is an open source project that understands how to communicate with a registry. It takes a module you've
-built locally on your computer and publishes it to the registry, making it publicly available for others to access.
+[wasm-to-oci][] is an open source project that understands how to communicate with a registry. It
+takes a module you've built locally on your computer and publishes it to the registry, making it
+publicly available for others to access.
 
 ## Create a registry
 
-This tutorial uses the Azure CLI to create an Azure Container Registry. We will be using this registry to publish our
-modules and provide Krustlet the URL for fetching these modules.
+This tutorial uses the Azure CLI to create an Azure Container Registry. We will be using this
+registry to publish our modules and provide Krustlet the URL for fetching these modules.
 
-The steps here assume you have an Azure account and the `az` CLI installed. However, there are other cloud providers
-available with their own solutions, and if you're feeling particularly brave, you can
-[run your own registry on your own infrastructure](https://github.com/docker/distribution).
+The steps here assume you have an Azure account and the `az` CLI installed. However, there are other
+cloud providers available with their own solutions, and if you're feeling particularly brave, you
+can [run your own registry on your own infrastructure](https://github.com/docker/distribution).
 
 ### Create a resource group
 
 An Azure resource group is a logical container into which Azure resources are deployed and managed.
 
-The following example creates a resource group named `myResourceGroup` in the `eastus` region. You may want to change it
-to a region closer to you. You can find out what regions are available with `az account list-locations`, and you can set
-your default region with `az configure --defaults location=<location>`.
+The following example creates a resource group named `myResourceGroup` in the `eastus` region. You
+may want to change it to a region closer to you. You can find out what regions are available with
+`az account list-locations`, and you can set your default region with `az configure --defaults
+location=<location>`.
 
 Create a resource group with the `az group create` command.
 
@@ -40,15 +42,16 @@ $ az group create --name myResourceGroup --location eastus
 
 ### Create a container registry
 
-In this tutorial, we will be creating a basic registry, which is cost-optimized for developers learning about Azure
-Container Registry. For details on available service tiers, see
-[Container registry SKUs](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-skus) in the
-Azure documentation.
+In this tutorial, we will be creating a basic registry, which is cost-optimized for developers
+learning about Azure Container Registry. For details on available service tiers, see [Container
+registry SKUs](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-skus) in
+the Azure documentation.
 
-Create an ACR instance using the `az acr create command`. The registry name must be unique within Azure, and contain
-5-50 alphanumeric characters.
+Create an ACR instance using the `az acr create command`. The registry name must be unique within
+Azure, and contain 5-50 alphanumeric characters.
 
-In the following example, `mycontainerregistry007` is used as the name. Update this to a unique value.
+In the following example, `mycontainerregistry007` is used as the name. Update this to a unique
+value.
 
 ```console
 $ az acr create --sku Basic --resource-group myResourceGroup --name mycontainerregistry007
@@ -77,12 +80,13 @@ When the registry is created, the output is similar to the following:
 }
 ```
 
-Take note of the `loginServer` field. That is the URL for our registry. We'll need to know that when we publish our
-application in a bit.
+Take note of the `loginServer` field. That is the URL for our registry. We'll need to know that when
+we publish our application in a bit.
 
 ### Log in
 
-Now that our registry was created, we can go ahead and authenticate with this registry to publish our application:
+Now that our registry was created, we can go ahead and authenticate with this registry to publish
+our application:
 
 ```console
 $ az acr login --name mycontainerregistry007
@@ -90,13 +94,16 @@ $ az acr login --name mycontainerregistry007
 
 ## Publish your app
 
-Now that we've created our registry and are logged in, we can publish our application using [wasm-to-oci][].
+Now that we've created our registry and are logged in, we can publish our application using
+[wasm-to-oci][].
 
-wasm-to-oci is a tool for publishing WebAssembly modules to a registry. It packages the module and uploads it to the
-registry. Krustlet understands the registry API and will fetch the module based on the URL you uploaded it to.
+wasm-to-oci is a tool for publishing WebAssembly modules to a registry. It packages the module and
+uploads it to the registry. Krustlet understands the registry API and will fetch the module based on
+the URL you uploaded it to.
 
-To publish our application, we need to come up with a name and a version number. Our `loginServer` field from earlier
-was `mycontainerregistry007.azurecr.io`, and we want to name our application `krustlet-tutorial`, version `v1.0.0`.
+To publish our application, we need to come up with a name and a version number. Our `loginServer`
+field from earlier was `mycontainerregistry007.azurecr.io`, and we want to name our application
+`krustlet-tutorial`, version `v1.0.0`.
 
 The pattern for a registry URL is:
 
@@ -104,7 +111,8 @@ The pattern for a registry URL is:
 <URL>/<NAME>:<VERSION>
 ```
 
-In our case, our application URL will look like `mycontainerregistry007.azurecr.io/krustlet-tutorial:v1.0.0`. Great!
+In our case, our application URL will look like
+`mycontainerregistry007.azurecr.io/krustlet-tutorial:v1.0.0`. Great!
 
 Let's publish that now:
 
@@ -112,11 +120,12 @@ Let's publish that now:
 $ wasm-to-oci push demo.wasm mycontainerregistry007.azurecr.io/krustlet-tutorial:v1.0.0
 ```
 
-`demo.wasm` is the filename of the WebAssembly module we compiled during [part 1](tutorial01.md) of this tutorial. If
-you are publishing the Rust example, use `target/wasm32-wasi/debug/demo.wasm` instead.
+`demo.wasm` is the filename of the WebAssembly module we compiled during [part 1](tutorial01.md) of
+this tutorial. If you are publishing the Rust example, use `target/wasm32-wasi/debug/demo.wasm`
+instead.
 
-When you’re comfortable with publishing your application with wasm-to-oci, read [part 3 of this tutorial](tutorial03.md)
-to install your application.
+When you’re comfortable with publishing your application with wasm-to-oci, read [part 3 of this
+tutorial](tutorial03.md) to install your application.
 
 
 [wasm-to-oci]: https://github.com/engineerd/wasm-to-oci

--- a/docs/intro/tutorial03.md
+++ b/docs/intro/tutorial03.md
@@ -1,15 +1,17 @@
 # Writing your first app, part 3
 
-This tutorial begins where [Tutorial 2](tutorial02.md) left off. We’ll walk through the process for installing your
-first application written in WebAssembly into your Kubernetes cluster, then test our application using `kubectl`.
+This tutorial begins where [Tutorial 2](tutorial02.md) left off. We’ll walk through the process for
+installing your first application written in WebAssembly into your Kubernetes cluster, then test our
+application using `kubectl`.
 
 ## Scheduling pods on the Krustlet
 
-In Kubernetes, Pods are the smallest deployable units of compute that can be created and managed in Kubernetes. In other
-words, your application runs inside a Pod, and we can inspect the status of the application by inspecting the Pod.
+In Kubernetes, Pods are the smallest deployable units of compute that can be created and managed in
+Kubernetes. In other words, your application runs inside a Pod, and we can inspect the status of the
+application by inspecting the Pod.
 
-Krustlet listens for pods requesting a node with the `wasm32-wasi` architecture. To schedule a Pod that Krustlet
-understands, we need to provide Kubernetes with a YAML file describing our Pod.
+Krustlet listens for pods requesting a node with the `wasm32-wasi` architecture. To schedule a Pod
+that Krustlet understands, we need to provide Kubernetes with a YAML file describing our Pod.
 
 Create a new file and call it `krustlet-tutorial.yaml`:
 
@@ -41,8 +43,8 @@ To deploy this workload to Kubernetes, we use `kubectl`.
 $ kubectl create -f krustlet-tutorial.yaml
 ```
 
-Now that the workload has been scheduled, Krustlet should start spewing out some logs in its terminal window, reporting
-updates on the workload that was scheduled.
+Now that the workload has been scheduled, Krustlet should start spewing out some logs in its
+terminal window, reporting updates on the workload that was scheduled.
 
 We can check the status of our pod:
 
@@ -83,6 +85,7 @@ $ az group delete --name myResourceGroup
 
 This concludes the basic tutorial. Congratulations!
 
-If you are familiar with Krustlet and are interested in more in-depth topics, check out the [Topic Guides](../topics/README.md).
+If you are familiar with Krustlet and are interested in more in-depth topics, check out the [Topic
+Guides](../topics/README.md).
 
 You might also be scratching your head on what to [read next](readnext.md).

--- a/docs/topics/architecture.md
+++ b/docs/topics/architecture.md
@@ -4,17 +4,17 @@ This document describes the Krustlet architecture at a high level.
 
 ## The purpose of Krustlet
 
-Krustlet acts as a Kubernetes Kubelet by listening on the Kubernetes API's event stream for new Pod requests that match
-a particular set of node selectors, scheduling those workloads to run using a WASI-based runtime instead of a
-container-based runtime.
+Krustlet acts as a Kubernetes Kubelet by listening on the Kubernetes API's event stream for new Pod
+requests that match a particular set of node selectors, scheduling those workloads to run using a
+WASI-based runtime instead of a container-based runtime.
 
 ## Implementation
 
 Krustlet is written in Rust.
 
-By acting as a Kubelet, Krustlet uses Kubernetes client libraries to communicate with the Kubernetes API. Currently,
-the client libraries use HTTP(s) as the communication protocol between Krustlet and the Kubernetes API, using JSON as
-the data format for serializing and de-serializing request bodies.
+By acting as a Kubelet, Krustlet uses Kubernetes client libraries to communicate with the Kubernetes
+API. Currently, the client libraries use HTTP(s) as the communication protocol between Krustlet and
+the Kubernetes API, using JSON as the data format for serializing and de-serializing request bodies.
 
-Krustlet sends status updates about scheduled pods to the Kubernetes API. Therefore, it does not require its own
-database.
+Krustlet sends status updates about scheduled pods to the Kubernetes API. Therefore, it does not
+require its own database.

--- a/docs/topics/providers.md
+++ b/docs/topics/providers.md
@@ -2,14 +2,16 @@
 
 There are two different runtimes available for Krustlet: `wascc` or `wasi`.
 
-The `wascc` runtime is a secure WebAssembly host runtime, connecting "actors" and "capability providers" together to
-connect your WebAssembly runtime to cloud-native services like message brokers, databases, or other external services
-normally unavailable to the WebAssembly runtime.
+The `wascc` runtime is a secure WebAssembly host runtime, connecting "actors" and "capability
+providers" together to connect your WebAssembly runtime to cloud-native services like message
+brokers, databases, or other external services normally unavailable to the WebAssembly runtime.
 
-The `wasi` runtime uses a project called [`wasmtime`](https://github.com/bytecodealliance/wasmtime). wasmtime is a
-standalone JIT-style host runtime for WebAssembly modules. It is focused primarily on standards compliance with the WASM
-specification as it relates to [WASI](https://wasi.dev/). If your WebAssembly module complies with the
-[WebAssembly specification](https://github.com/WebAssembly/spec), wasmtime can run it.
+The `wasi` runtime uses a project called [`wasmtime`](https://github.com/bytecodealliance/wasmtime).
+wasmtime is a standalone JIT-style host runtime for WebAssembly modules. It is focused primarily on
+standards compliance with the WASM specification as it relates to [WASI](https://wasi.dev/). If your
+WebAssembly module complies with the [WebAssembly
+specification](https://github.com/WebAssembly/spec), wasmtime can run it.
 
-It's important to note that the WASI standard and `wasmtime` are still under heavy development. There are some key
-features (like networking) that are currently missing, but will be made available in future updates.
+It's important to note that the WASI standard and `wasmtime` are still under heavy development.
+There are some key features (like networking) that are currently missing, but will be made available
+in future updates.


### PR DESCRIPTION
120 characters is too long for many editor UIs to handle, and 80 seems a little on the low side for writing documentation. 100 looks just right.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>