### PR TITLE
Small cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2625,9 +2625,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa5e81d6bc4e67fe889d5783bd2a128ab2e0cfa487e0be16b6a8d177b101616"
+checksum = "2751672f9da075d045c67fdb0068be9850ab7b231fa77bb51d6fd35da9c0bb0d"
 dependencies = [
  "bytes 0.5.4",
  "fnv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ default-run = "krustlet-wascc"
 
 [dependencies]
 anyhow = "1.0"
-tokio = { version = "0.2.13", features = ["macros"] }
+tokio = { version = "0.2.14", features = ["macros"] }
 kube = "0.31.0"
 env_logger = "0.7.1"
 kubelet = { path = "./crates/kubelet", version = "0.1.0", features = ["cli"] }

--- a/crates/oci-distribution/Cargo.toml
+++ b/crates/oci-distribution/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 [dependencies]
 reqwest = { version = "0.10.4", features = ["json", "stream"] }
 anyhow = "1.0"
-tokio = {version  = "0.2.13", features = ["macros", "fs"] }
+tokio = {version  = "0.2.14", features = ["macros", "fs"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 www-authenticate = "0.3.0"

--- a/crates/wascc-provider/Cargo.toml
+++ b/crates/wascc-provider/Cargo.toml
@@ -21,7 +21,7 @@ serde = "1.0"
 serde_derive = "1.0"
 kube = "0.31.0" 
 kubelet = { path = "../kubelet", version = "0.1.0" }
-tokio = { version = "0.2.11", features = ["fs", "macros"] }
+tokio = { version = "0.2.14", features = ["fs", "macros"] }
 chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]

--- a/crates/wasi-provider/Cargo.toml
+++ b/crates/wasi-provider/Cargo.toml
@@ -23,7 +23,7 @@ wasi-common = "0.12"
 tempfile = "3.1"
 kubelet = { path = "../kubelet", version = "0.1.0" }
 wat = "1.0"
-tokio = { version = "0.2.13", features = ["fs", "stream", "macros", "io-util", "sync"] }
+tokio = { version = "0.2.14", features = ["fs", "stream", "macros", "io-util", "sync"] }
 k8s-openapi = { version = "0.7.1", default-features = false, features = ["v1_17"] }
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3.4"

--- a/crates/wasi-provider/src/lib.rs
+++ b/crates/wasi-provider/src/lib.rs
@@ -53,7 +53,7 @@ const LOG_DIR_NAME: &str = "wasi-logs";
 /// binaries conforming to the WASI spec
 #[derive(Clone)]
 pub struct WasiProvider<S> {
-    handles: Arc<RwLock<HashMap<String, PodHandle<File, HandleStopper>>>>,
+    handles: Arc<RwLock<HashMap<String, PodHandle<HandleStopper, File>>>>,
     store: S,
     log_path: PathBuf,
     kubeconfig: kube::config::Configuration,

--- a/crates/wasi-provider/src/wasi_runtime.rs
+++ b/crates/wasi-provider/src/wasi_runtime.rs
@@ -90,7 +90,7 @@ impl WasiRuntime {
         })
     }
 
-    pub async fn start(&self) -> anyhow::Result<RuntimeHandle<tokio::fs::File, HandleStopper>> {
+    pub async fn start(&self) -> anyhow::Result<RuntimeHandle<HandleStopper, tokio::fs::File>> {
         let temp = self.output.clone();
         // Because a reopen is blocking, run in a blocking task to get new
         // handles to the tempfile
@@ -130,8 +130,8 @@ impl WasiRuntime {
         let handle = self.spawn_wasmtime(status_sender, wasi_ctx_snapshot, wasi_ctx_unstable);
 
         Ok(RuntimeHandle::new(
-            tokio::fs::File::from_std(output_read),
             HandleStopper { handle },
+            tokio::fs::File::from_std(output_read),
             status_recv,
         ))
     }


### PR DESCRIPTION
* Update tokio
* Rearrange generics in `RuntimeHandle` and `PodHandle` so that the stopper is listed before the logs reader since the former is arguably more important than the latter.
* Remove `BufReader` from RuntimeHandle since we're doing large and relatively infrequent reads which is the opposite of when `BufReader` works well. Additionally, seeking the inner reader of the `BufReader` does not fully work as the `BufReader` still has contents in its buffer potentially. 
* Fix docs links. We were using `crate::TYPE` links for items that were not available at the top level of the crate so the links were broken. 