### PR TITLE
fix(*): Adds node tainting to control pod scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 **This project is highly experimental.** It is not yet fully ready for production, so you should use
 it in production at your own risk
 
-Krustlet acts as a Kubelet by listening on the event stream for new pod requests that match a
-particular set of node selectors.
+Krustlet acts as a Kubelet by listening on the event stream for new pods that
+the scheduler assigns to it based on specific Kubernetes
+[tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/).
 
 The default implementation of Krustlet listens for the architecture `wasm32-wasi` and schedules
 those workloads to run in a `wasmtime`-based runtime instead of a container runtime.

--- a/crates/kubelet/src/kubelet.rs
+++ b/crates/kubelet/src/kubelet.rs
@@ -65,11 +65,11 @@ impl<T: 'static + Provider + Sync + Send> Kubelet<T> {
 
         // This informer listens for pod events.
         let provider = self.provider.clone();
-        let node_name = self.config.node_name.clone();
+        let node_selector = format!("spec.nodeName={}", self.config.node_name);
         let pod_informer = tokio::task::spawn(async move {
             // Create our informer and start listening.
             let params = ListParams {
-                field_selector: Some(format!("spec.nodeName={}", node_name)),
+                field_selector: Some(node_selector),
                 ..Default::default()
             };
             let informer = Informer::new(client, params, Resource::all::<KubePod>());

--- a/crates/kubelet/src/lib.rs
+++ b/crates/kubelet/src/lib.rs
@@ -21,7 +21,6 @@
 //!     }
 //!
 //!     // Implement the rest of the methods
-//!     # fn can_schedule(&self, pod: &Pod) -> bool { todo!() }
 //!     # async fn modify(&self, pod: Pod) -> anyhow::Result<()> { todo!() }
 //!     # async fn delete(&self, pod: Pod) -> anyhow::Result<()> { todo!() }
 //!     # async fn logs(&self, namespace: String, pod: String, container: String) -> anyhow::Result<Vec<u8>> { todo!() }

--- a/crates/wasi-provider/src/lib.rs
+++ b/crates/wasi-provider/src/lib.rs
@@ -81,18 +81,6 @@ impl<S: ModuleStore + Send + Sync> WasiProvider<S> {
 impl<S: ModuleStore + Send + Sync> Provider for WasiProvider<S> {
     const ARCH: &'static str = TARGET_WASM32_WASI;
 
-    fn can_schedule(&self, pod: &Pod) -> bool {
-        // If there is a node selector and it has arch set to wasm32-wasi, we can
-        // schedule it.
-        match pod.node_selector() {
-            Some(node_selector) => node_selector
-                .get("beta.kubernetes.io/arch")
-                .map(|v| v == TARGET_WASM32_WASI)
-                .unwrap_or(false),
-            _ => false,
-        }
-    }
-
     async fn add(&self, pod: Pod) -> anyhow::Result<()> {
         // To run an Add event, we load the WASM, update the pod status to Running,
         // and then execute the WASM, passing in the relevant data.
@@ -222,59 +210,4 @@ fn key_from_pod(pod: &Pod) -> String {
 
 fn pod_key<N: AsRef<str>, T: AsRef<str>>(namespace: N, pod_name: T) -> String {
     format!("{}:{}", namespace.as_ref(), pod_name.as_ref())
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use k8s_openapi::api::core::v1::Pod as KubePod;
-    use k8s_openapi::api::core::v1::PodSpec;
-
-    struct TestStore;
-
-    #[async_trait::async_trait]
-    impl ModuleStore for TestStore {
-        async fn get(&self, _image_ref: &oci_distribution::Reference) -> anyhow::Result<Vec<u8>> {
-            unimplemented!()
-        }
-    }
-
-    #[tokio::test]
-    async fn test_can_schedule() {
-        let store = TestStore;
-        let provider = WasiProvider::new(
-            store,
-            &Default::default(),
-            kube::config::Configuration {
-                base_path: String::new(),
-                client: Default::default(),
-                default_ns: String::new(),
-            },
-        )
-        .await
-        .expect("unable to create new runtime");
-        let mock = Pod::default();
-        assert!(!provider.can_schedule(&mock));
-
-        let mut selector = std::collections::BTreeMap::new();
-        selector.insert(
-            "beta.kubernetes.io/arch".to_string(),
-            "wasm32-wasi".to_string(),
-        );
-        let mut mock = KubePod::default();
-        mock.spec = Some(PodSpec {
-            node_selector: Some(selector.clone()),
-            ..Default::default()
-        });
-
-        assert!(provider.can_schedule(&mock.into()));
-        selector.insert("beta.kubernetes.io/arch".to_string(), "amd64".to_string());
-        let mut mock = KubePod::default();
-        mock.spec = Some(PodSpec {
-            node_selector: Some(selector),
-            ..Default::default()
-        });
-
-        assert!(!provider.can_schedule(&mock.into()));
-    }
 }

--- a/demos/wasi/hello-world-assemblyscript/k8s.yaml
+++ b/demos/wasi/hello-world-assemblyscript/k8s.yaml
@@ -25,5 +25,8 @@ spec:
             configMapKeyRef:
               key: myval
               name: hello-world-wasi-assemblyscript
-  nodeSelector:
-    beta.kubernetes.io/arch: wasm32-wasi
+  tolerations:
+    - key: "krustlet/arch"
+      operator: "Equal"
+      value: "wasm32-wasi"
+      effect: "NoExecute"

--- a/demos/wasi/hello-world-c/k8s.yaml
+++ b/demos/wasi/hello-world-c/k8s.yaml
@@ -25,5 +25,8 @@ spec:
             configMapKeyRef:
               key: myval
               name: hello-world-wasi-c
-  nodeSelector:
-    beta.kubernetes.io/arch: wasm32-wasi
+  tolerations:
+    - key: "krustlet/arch"
+      operator: "Equal"
+      value: "wasm32-wasi"
+      effect: "NoExecute"

--- a/demos/wasi/hello-world-rust/k8s.yaml
+++ b/demos/wasi/hello-world-rust/k8s.yaml
@@ -25,5 +25,8 @@ spec:
             configMapKeyRef:
               key: myval
               name: hello-world-wasi-rust
-  nodeSelector:
-    beta.kubernetes.io/arch: wasm32-wasi
+  tolerations:
+    - key: "krustlet/arch"
+      operator: "Equal"
+      value: "wasm32-wasi"
+      effect: "NoExecute"

--- a/docs/intro/tutorial03.md
+++ b/docs/intro/tutorial03.md
@@ -24,8 +24,11 @@ spec:
   containers:
     - name: krustlet-tutorial
       image: mycontainerregistry007.azurecr.io/krustlet-tutorial:v1.0.0
-  nodeSelector:
-    beta.kubernetes.io/arch: wasm32-wasi
+  tolerations:
+    - key: "krustlet/arch"
+      operator: "Equal"
+      value: "wasm32-wasi"
+      effect: "NoExecute"
 ```
 
 Let's break this file down:
@@ -35,7 +38,7 @@ Let's break this file down:
 - `metadata.name`: what is the name of our workload?
 - `spec.containers[0].name`: what should I name this module?
 - `spec.containers[0].image`: where can I find the module?
-- `spec.nodeSelector.beta.kubernetes.io/arch`: what chip architecture can run this workload?
+- `spec.tolerations`: what kind of node am I allowed to run on?
 
 To deploy this workload to Kubernetes, we use `kubectl`.
 

--- a/examples/greet-wascc.yaml
+++ b/examples/greet-wascc.yaml
@@ -6,16 +6,16 @@ metadata:
     deislabs.io/wascc-action-key: MB4OLDIC3TCZ4Q4TGGOVAZC43VXFE2JQVRAXQMQFXUCREOOFEKOKZTY2
 spec:
   containers:
-    - image: webassembly.azurecr.io/hello-wasm:v1 
+    - image: webassembly.azurecr.io/hello-wasm:v1
       imagePullPolicy: Always
       name: greet
       ports:
         - containerPort: 80
-  nodeSelector:
-    kubernetes.io/role: agent
-    beta.kubernetes.io/os: linux
-    beta.kubernetes.io/arch: wasm32-wascc
   tolerations:
     - key: "node.kubernetes.io/network-unavailable"
       operator: "Exists"
       effect: "NoSchedule"
+    - key: "krustlet/arch"
+      operator: "Equal"
+      value: "wasm32-wascc"
+      effect: "NoExecute"

--- a/examples/greet-wasi.yaml
+++ b/examples/greet-wasi.yaml
@@ -4,16 +4,16 @@ metadata:
   name: greet
 spec:
   containers:
-    - image: webassembly.azurecr.io/hello-wasm:v1 
+    - image: webassembly.azurecr.io/hello-wasm:v1
       imagePullPolicy: Always
       name: greet
       ports:
         - containerPort: 80
-  nodeSelector:
-    kubernetes.io/role: agent
-    beta.kubernetes.io/os: linux
-    beta.kubernetes.io/arch: wasm32-wasi
   tolerations:
     - key: "node.kubernetes.io/network-unavailable"
       operator: "Exists"
       effect: "NoSchedule"
+    - key: "krustlet/arch"
+      operator: "Equal"
+      value: "wasm32-wasi"
+      effect: "NoExecute"

--- a/justfile
+++ b/justfile
@@ -31,5 +31,4 @@ bootstrap-ssl:
     @chmod 400 $(eval echo $KEY_DIR)/*
 
 _cleanup_kube:
-    kubectl delete node krustlet-wasi krustlet-wascc || true
     kubectl delete --all pods --namespace=default || true

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,5 +1,5 @@
 use futures::{StreamExt, TryStreamExt};
-use k8s_openapi::api::core::v1::{Node, Pod};
+use k8s_openapi::api::core::v1::{Node, Pod, Taint};
 use kube::{
     api::{Api, DeleteParams, ListParams, LogParams, PostParams, Resource, WatchEvent},
     config,
@@ -40,6 +40,27 @@ async fn test_wascc_provider() -> Result<(), Box<dyn std::error::Error>> {
         "wasm32-wascc"
     );
 
+    let taints = node
+        .spec
+        .expect("node had no spec")
+        .taints
+        .expect("node had no taints");
+    let taint = taints
+        .iter()
+        .find(|t| t.key == "krustlet/arch")
+        .expect("did not find krustlet/arch taint");
+    // There is no "operator" field in the type for the crate for some reason,
+    // so we can't compare it here
+    assert_eq!(
+        taint,
+        &Taint {
+            effect: "NoExecute".to_owned(),
+            key: "krustlet/arch".to_owned(),
+            value: Some("wasm32-wascc".to_owned()),
+            ..Default::default()
+        }
+    );
+
     let pods: Api<Pod> = Api::namespaced(client.clone(), "default");
     let p = serde_json::from_value(json!({
         "apiVersion": "v1",
@@ -57,9 +78,14 @@ async fn test_wascc_provider() -> Result<(), Box<dyn std::error::Error>> {
                     "image": "webassembly.azurecr.io/hello-wasm:v1",
                 },
             ],
-            "nodeSelector": {
-                "beta.kubernetes.io/arch": "wasm32-wascc",
-            },
+            "tolerations": [
+                {
+                    "effect": "NoExecute",
+                    "key": "krustlet/arch",
+                    "operator": "Equal",
+                    "value": "wasm32-wascc"
+                },
+            ]
         }
     }))?;
 
@@ -140,6 +166,27 @@ async fn test_wasi_provider() -> Result<(), Box<dyn std::error::Error>> {
         "wasm32-wasi"
     );
 
+    let taints = node
+        .spec
+        .expect("node had no spec")
+        .taints
+        .expect("node had no taints");
+    let taint = taints
+        .iter()
+        .find(|t| t.key == "krustlet/arch")
+        .expect("did not find krustlet/arch taint");
+    // There is no "operator" field in the type for the crate for some reason,
+    // so we can't compare it here
+    assert_eq!(
+        taint,
+        &Taint {
+            effect: "NoExecute".to_owned(),
+            key: "krustlet/arch".to_owned(),
+            value: Some("wasm32-wasi".to_owned()),
+            ..Default::default()
+        }
+    );
+
     let pods: Api<Pod> = Api::namespaced(client.clone(), "default");
     let p = serde_json::from_value(json!({
         "apiVersion": "v1",
@@ -154,9 +201,14 @@ async fn test_wasi_provider() -> Result<(), Box<dyn std::error::Error>> {
                     "image": "webassembly.azurecr.io/hello-wasm:v1",
                 },
             ],
-            "nodeSelector": {
-                "beta.kubernetes.io/arch": "wasm32-wasi",
-            },
+            "tolerations": [
+                {
+                    "effect": "NoExecute",
+                    "key": "krustlet/arch",
+                    "operator": "Equal",
+                    "value": "wasm32-wasi"
+                },
+            ]
         }
     }))?;
 


### PR DESCRIPTION
This change forces pods to add a toleration for the specified architecture
before scheduling. Other normal pods were getting scheduled to the attached
krustlet nodes and ever starting before this.

I also found that we were listing _all_ pods instead of pods scoped to the
node, so now the informer has a field selector to only get pods that are
assigned to the node.

With this change, we no longer have a need for the `can_schedule` method, so
it has been removed from the provider trait

NOTE: I have also included a bugfix for getting nodes to go back to ready
on restart. It is hacky, but sufficient for now

Closes #126 