### PR TITLE
docs(intro): Clarify how to get started

### DIFF
--- a/docs/intro/install.md
+++ b/docs/intro/install.md
@@ -50,5 +50,9 @@ guide](../community/developers.md).
 
 ## Next Steps
 
-After installing Krustlet, you can go through [the tutorial](tutorial01.md) to learn how to start
-using Krustlet.
+After installing Krustlet, if you'd like to get started and see something running, go checkout any
+one of the [demos](../../demos). Each of them has a prebuilt WebAssembly module stored in a registry
+and a Kubernetes manifest that you can `kubectl apply`.
+
+If you'd like to learn how to write your own simple module in Rust and deploy it, [follow through
+the tutorial](tutorial01.md) to deploy your first application.

--- a/docs/intro/quickstart.md
+++ b/docs/intro/quickstart.md
@@ -47,7 +47,12 @@ For testing/development environments:
 
 ## Step 3: Deploy your First Application
 
-Last but not least, [follow through the tutorial](tutorial01.md) to deploy your first application.
+If you just want to get started and see something running, go checkout any one of the
+[demos](../../demos). Each of them has a prebuilt WebAssembly module stored in a registry and a Kubernetes
+manifest that you can `kubectl apply`.
+
+If you'd like to learn how to write your own simple module in Rust and deploy it, [follow through
+the tutorial](tutorial01.md) to deploy your first application.
 
 
 [development guide]: ../community/developers.md


### PR DESCRIPTION
The docs currently lead new users down a path of downloading Rust and
a bunch of other tools, which they may not be interested in doing immediately.
This adds some clarification that directs users to the demos if they
just want to get started with running something on their new Krustlet node