### PR TITLE
Add a HOWTO for running Krustlet on EKS.

### DIFF
--- a/docs/howto/assets/eks/.gitignore
+++ b/docs/howto/assets/eks/.gitignore
@@ -1,0 +1,1 @@
+manifest.json

--- a/docs/howto/assets/eks/Makefile
+++ b/docs/howto/assets/eks/Makefile
@@ -1,0 +1,36 @@
+PACKER_BINARY ?= packer
+PACKER_VARIABLES := aws_region ami_name krustlet_version source_ami_id source_ami_owners arch instance_type security_group_id
+
+aws_region ?= $(AWS_DEFAULT_REGION)
+ami_name ?= amazon-eks-node-krustlet-$(KRUSTLET_VERSION)-v$(shell date +'%Y%m%d')
+arch ?= x86_64
+ifeq ($(arch), arm64)
+instance_type ?= a1.large
+else
+instance_type ?= c5.2xlarge
+endif
+
+ifeq ($(aws_region), cn-northwest-1)
+source_ami_owners ?= 141808717104
+endif
+
+T_RED := \e[0;31m
+T_GREEN := \e[0;32m
+T_YELLOW := \e[0;33m
+T_RESET := \e[0m
+
+.PHONY: all
+all: 0.1.0
+
+.PHONY: validate
+validate:
+	$(PACKER_BINARY) validate $(foreach packerVar,$(PACKER_VARIABLES), $(if $($(packerVar)),--var $(packerVar)='$($(packerVar))',)) eks-worker-al2.json
+
+.PHONY: krustlet
+krustlet: validate
+	@echo "$(T_GREEN)Building AMI for Krustlet version $(T_YELLOW)$(KRUSTLET_VERSION)$(T_GREEN) on $(T_YELLOW)$(arch)$(T_RESET)"
+	$(PACKER_BINARY) build $(foreach packerVar,$(PACKER_VARIABLES), $(if $($(packerVar)),--var $(packerVar)='$($(packerVar))',)) eks-worker-al2.json
+ 
+.PHONY: 0.1.0
+0.1.0:
+	$(MAKE) krustlet KRUSTLET_VERSION=0.1.0

--- a/docs/howto/assets/eks/eks-worker-al2.json
+++ b/docs/howto/assets/eks/eks-worker-al2.json
@@ -1,0 +1,126 @@
+{
+  "variables": {
+    "aws_region": "us-west-2",
+    "ami_name": null,
+    "creator": "{{env `USER`}}",
+    "encrypted": "false",
+    "kms_key_id": "",
+    
+    "aws_access_key_id": "{{env `AWS_ACCESS_KEY_ID`}}",
+    "aws_secret_access_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
+    "aws_session_token": "{{env `AWS_SESSION_TOKEN`}}",
+
+    "krustlet_version": "0.1.0",
+
+    "source_ami_id": "",
+    "source_ami_owners": "137112412989",
+    "source_ami_filter_name": "amzn2-ami-minimal-hvm-*",
+    "arch": null,
+    "instance_type": null,
+    "ami_description": "EKS Kubernetes Worker AMI with AmazonLinux2 image",
+
+    "ssh_interface": "",
+    "ssh_username": "ec2-user",
+    "temporary_security_group_source_cidrs": "",
+    "security_group_id": "",
+    "associate_public_ip_address": "",
+    "subnet_id": "",
+    "remote_folder": "",
+    "launch_block_device_mappings_volume_size": "4",
+    "ami_users": ""
+  },
+
+  "builders": [
+    {
+      "type": "amazon-ebs",
+      "region": "{{user `aws_region`}}",
+      "source_ami": "{{user `source_ami_id`}}",
+      "ami_users": "{{user `ami_users`}}",
+      "snapshot_users": "{{user `ami_users`}}",
+      "source_ami_filter": {
+        "filters": {
+          "name": "{{user `source_ami_filter_name`}}",
+          "architecture": "{{user `arch`}}",
+          "root-device-type": "ebs",
+          "state": "available",
+          "virtualization-type": "hvm"
+        },
+        "owners": [ "{{user `source_ami_owners`}}" ],
+        "most_recent": true
+      },
+      "instance_type": "{{user `instance_type`}}",
+      "launch_block_device_mappings": [
+        {
+          "device_name": "/dev/xvda",
+          "volume_type": "gp2",
+          "volume_size": "{{user `launch_block_device_mappings_volume_size`}}",
+          "delete_on_termination": true
+        }
+      ],
+      "ami_block_device_mappings": [    
+        {
+          "device_name": "/dev/xvda",
+          "volume_type": "gp2",
+          "volume_size": 20,
+          "delete_on_termination": true
+        }
+      ],
+      "ssh_username": "{{user `ssh_username`}}",
+      "ssh_interface": "{{user `ssh_interface`}}",
+      "temporary_security_group_source_cidrs": "{{user `temporary_security_group_source_cidrs`}}",
+      "security_group_id": "{{user `security_group_id`}}",
+      "associate_public_ip_address": "{{user `associate_public_ip_address`}}",
+      "ssh_pty": true,
+      "encrypt_boot": "{{user `encrypted`}}",
+      "kms_key_id": "{{user `kms_key_id`}}",
+      "run_tags": {
+          "creator": "{{user `creator`}}"
+      },
+      "subnet_id": "{{user `subnet_id`}}",
+      "tags": {
+          "Name": "{{user `ami_name`}}",
+          "created": "{{timestamp}}",
+          "source_ami_id": "{{ user `source_ami_id`}}",
+          "krustlet": "{{ user `krustlet_version`}}"
+      },
+      "ami_name": "{{user `ami_name`}}",
+      "ami_description": "{{ user `ami_description` }}, (krustlet: {{ user `krustlet_version`}})"
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "remote_folder": "{{ user `remote_folder`}}",
+      "inline": ["mkdir -p /tmp/worker/"]
+    },
+    {
+      "type": "file",
+      "source": "{{template_dir}}/files/",
+      "destination": "/tmp/worker/"
+    },
+    {
+      "type": "shell",
+      "remote_folder": "{{ user `remote_folder`}}",
+      "script": "{{template_dir}}/scripts/install-worker.sh",
+      "environment_vars": [
+        "KRUSTLET_VERSION={{user `krustlet_version`}}",
+        "AWS_ACCESS_KEY_ID={{user `aws_access_key_id`}}",
+        "AWS_SECRET_ACCESS_KEY={{user `aws_secret_access_key`}}",
+        "AWS_SESSION_TOKEN={{user `aws_session_token`}}"
+      ]
+    },
+    {
+      "type": "shell",
+      "remote_folder": "{{ user `remote_folder`}}",
+      "script": "{{template_dir}}/scripts/validate.sh"
+    }
+  ],
+  "post-processors": [
+    {
+      "type": "manifest",
+      "output": "manifest.json",
+      "strip_path": true
+    }
+  ]
+}

--- a/docs/howto/assets/eks/files/bootstrap.sh
+++ b/docs/howto/assets/eks/files/bootstrap.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# This file is based upon https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh
+# The script is run when a node is started
+# Krustlet doesn't yet support TLS bootstraping, so this will generate a server certificate
+
+set -o pipefail
+set -o nounset
+set -o errexit
+
+echo "Generating certificate signing request..."
+openssl req -new -sha256 -newkey rsa:2048 -keyout /tmp/krustlet.key -out /tmp/krustlet.csr -nodes -config <(
+cat <<-EOF
+[req]
+default_bits = 2048
+prompt = no
+default_md = sha256
+req_extensions = req_ext
+distinguished_name = dn
+
+[dn]
+O=system:nodes
+CN=system:node:$(hostname)
+
+[req_ext]
+subjectAltName = @alt_names
+
+[alt_names]
+IP.1 = $(ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/ -f1)
+EOF
+)
+
+cat <<EOF > /tmp/csr.yaml
+apiVersion: certificates.k8s.io/v1beta1
+kind: CertificateSigningRequest
+metadata:
+  name: $(hostname)
+spec:
+  request: $(cat /tmp/krustlet.csr | base64 | tr -d '\n')
+  usages:
+  - digital signature
+  - key encipherment
+  - server auth
+EOF
+
+RETRY_ATTEMPTS=3
+
+for attempt in `seq 0 $RETRY_ATTEMPTS`; do
+    rc=0
+    
+    if [[ $attempt -gt 0 ]]; then
+        echo "Retry $attempt of $RETRY_ATTEMPTS to request certificate signing..."
+    fi
+
+    echo "Sending certificate signing request..."
+    /usr/local/bin/kubectl apply --kubeconfig /etc/eksctl/kubeconfig.yaml -f /tmp/csr.yaml || rc=$?
+
+    if [[ $rc -eq 0 ]]; then
+        break
+    fi
+
+    if [[ $attempt -eq $RETRY_ATTEMPTS ]]; then
+        exit $rc
+    fi
+
+    jitter=$((1 + RANDOM % 10))
+    sleep_sec="$(( $(( 5 << $((1+$attempt)) )) + $jitter))"
+    sleep $sleep_sec
+done
+
+for attempt in `seq 0 $RETRY_ATTEMPTS`; do
+    rc=0
+    
+    if [[ $attempt -gt 0 ]]; then
+        echo "Retry $attempt of $RETRY_ATTEMPTS to retrieve certificate..."
+    fi
+
+    echo "Retrieving certificate from Kubernetes API server..."
+    /usr/local/bin/kubectl get --kubeconfig /etc/eksctl/kubeconfig.yaml csr $(hostname) -o jsonpath='{.status.certificate}' > /tmp/krustlet.cert.base64 || rc=$?
+    
+    if [[ $rc -eq 0 ]] && [ -s /tmp/krustlet.cert.base64 ]; then
+        base64 --decode /tmp/krustlet.cert.base64 > /tmp/krustlet.cert || rc=$?
+
+        if [[ $rc -eq 0 ]]; then
+            break
+        fi
+    fi
+
+    if [[ $attempt -eq $RETRY_ATTEMPTS ]]; then
+        exit $rc
+    fi
+
+    jitter=$((1 + RANDOM % 10))
+    sleep_sec="$(( $(( 5 << $((1+$attempt)) )) + $jitter))"
+    sleep $sleep_sec
+done
+
+echo "Creating server PFX file..."
+openssl pkcs12 -export -out /etc/krustlet/cert.pfx -inkey /tmp/krustlet.key -in /tmp/krustlet.cert -password "pass:krustlet"
+chown root:root /etc/krustlet/cert.pfx
+chmod 640 /etc/krustlet/cert.pfx
+
+rm /tmp/krustlet.key /tmp/krustlet.csr /tmp/krustlet.cert
+
+echo "Starting krustlet service..."
+systemctl daemon-reload
+systemctl enable krustlet
+systemctl start krustlet

--- a/docs/howto/assets/eks/files/krustlet.service
+++ b/docs/howto/assets/eks/files/krustlet.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Krustlet - a kubelet implementation for running WebAssembly
+
+[Service]
+Environment=KUBECONFIG=/etc/eksctl/kubeconfig.yaml
+Environment=PFX_PATH=/etc/krustlet/cert.pfx
+Environment=PFX_PASSWORD=krustlet
+Environment=KRUSTLET_DATA_DIR=/var/cache/krustlet
+Environment=RUST_LOG=wascc_provider=info,wasi_provider=info,main=info
+ExecStart=/usr/local/bin/krustlet
+Restart=on-failure
+RestartForceExitStatus=SIGPIPE
+RestartSec=5
+KillMode=process
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/howto/assets/eks/scripts/install-worker.sh
+++ b/docs/howto/assets/eks/scripts/install-worker.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+
+set -o pipefail
+set -o nounset
+set -o errexit
+IFS=$'\n\t'
+
+TEMPLATE_DIR=${TEMPLATE_DIR:-/tmp/worker}
+
+################################################################################
+### Validate Required Arguments ################################################
+################################################################################
+validate_env_set() {
+    (
+        set +o nounset
+
+        if [ -z "${!1}" ]; then
+            echo "Packer variable '$1' was not set. Aborting"
+            exit 1
+        fi
+    )
+}
+
+validate_env_set KRUSTLET_VERSION
+
+################################################################################
+### Machine Architecture #######################################################
+################################################################################
+
+MACHINE=$(uname -m)
+if [ "$MACHINE" == "x86_64" ]; then
+    ARCH="amd64"
+else
+    echo "Unknown machine architecture '$MACHINE'" >&2
+    exit 1
+fi
+
+################################################################################
+### Packages ###################################################################
+################################################################################
+
+# Update the OS to begin with to catch up to the latest packages.
+sudo yum update -y
+
+# Install necessary packages
+sudo yum install -y \
+    aws-cfn-bootstrap \
+    awscli \
+    chrony \
+    conntrack \
+    curl \
+    jq \
+    ec2-instance-connect \
+    nfs-utils \
+    socat \
+    unzip \
+    wget \
+    git \
+    openssl-devel
+
+sudo yum group install -y "Development Tools"
+
+# Remove the ec2-net-utils package, if it's installed. This package interferes with the route setup on the instance.
+if yum list installed | grep ec2-net-utils; then sudo yum remove ec2-net-utils -y -q; fi
+
+################################################################################
+### Time #######################################################################
+################################################################################
+
+# Make sure Amazon Time Sync Service starts on boot.
+sudo chkconfig chronyd on
+
+# Make sure that chronyd syncs RTC clock to the kernel.
+cat <<EOF | sudo tee -a /etc/chrony.conf
+# This directive enables kernel synchronisation (every 11 minutes) of the
+# real-time clock. Note that it can’t be used along with the 'rtcfile' directive.
+rtcsync
+EOF
+
+# If current clocksource is xen, switch to tsc
+if grep --quiet xen /sys/devices/system/clocksource/clocksource0/current_clocksource &&
+  grep --quiet tsc /sys/devices/system/clocksource/clocksource0/available_clocksource; then
+    echo "tsc" | sudo tee /sys/devices/system/clocksource/clocksource0/current_clocksource
+else
+    echo "tsc as a clock source is not applicable, skipping."
+fi
+
+################################################################################
+### kubectl ####################################################################
+################################################################################
+
+curl -o kubectl https://amazon-eks.s3.us-west-2.amazonaws.com/1.15.10/2020-02-22/bin/linux/amd64/kubectl
+sudo chmod +x kubectl
+sudo chown root:root kubectl
+sudo mv kubectl /usr/local/bin 
+
+################################################################################
+### Krustlet ###################################################################
+################################################################################
+
+# Install a Rust toolchain
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+export PATH=$PATH:$HOME/.cargo/bin
+
+# Build krustlet to link against the system libssl
+# TODO: make the krustlet to build (wasi or wascc) configurable
+mkdir /tmp/krustlet
+git clone https://github.com/deislabs/krustlet /tmp/krustlet
+cargo build --release --manifest-path /tmp/krustlet/Cargo.toml --bin krustlet-wasi
+sudo mv /tmp/krustlet/target/release/krustlet-wasi /usr/local/bin/krustlet
+rm -rf /tmp/krustlet
+sudo chown root:root /usr/local/bin/krustlet
+sudo chmod 755 /usr/local/bin/krustlet
+
+sudo mkdir /etc/krustlet
+
+sudo mkdir -p /etc/systemd/system/krustlet.service.d
+sudo mv $TEMPLATE_DIR/krustlet.service /etc/systemd/system/krustlet.service
+sudo chown root:root /etc/systemd/system/krustlet.service
+
+sudo systemctl daemon-reload
+sudo systemctl disable krustlet
+
+################################################################################
+### IAM Authenticator ##########################################################
+################################################################################
+
+# This is currently needed for the eksctl kubeconfig
+curl -o aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.15.10/2020-02-22/bin/linux/amd64/aws-iam-authenticator
+chmod +x aws-iam-authenticator
+sudo chown root:root aws-iam-authenticator
+sudo mv aws-iam-authenticator /usr/bin/aws-iam-authenticator
+
+################################################################################
+### EKS ########################################################################
+################################################################################
+
+sudo mkdir -p /etc/eks
+sudo mv $TEMPLATE_DIR/bootstrap.sh /etc/eks/bootstrap.sh
+sudo chmod +x /etc/eks/bootstrap.sh
+
+################################################################################
+### AMI Metadata ###############################################################
+################################################################################
+
+BASE_AMI_ID=$(curl -s  http://169.254.169.254/latest/meta-data/ami-id)
+cat <<EOF > /tmp/release
+BASE_AMI_ID="$BASE_AMI_ID"
+BUILD_TIME="$(date)"
+BUILD_KERNEL="$(uname -r)"
+ARCH="$(uname -m)"
+EOF
+sudo mv /tmp/release /etc/eks/release
+sudo chown -R root:root /etc/eks
+
+################################################################################
+### Cleanup ####################################################################
+################################################################################
+
+# Clean up the Rust toolchain
+rustup self uninstall -y
+
+# Clean up yum caches to reduce the image size
+sudo yum autoremove -y git openssl-devel
+sudo yum group remove -y "Development Tools"
+sudo yum clean all
+sudo rm -rf \
+    $TEMPLATE_DIR  \
+    /var/cache/yum
+
+# Clean up files to reduce confusion during debug
+sudo rm -rf \
+    /etc/hostname \
+    /etc/machine-id \
+    /etc/resolv.conf \
+    /etc/ssh/ssh_host* \
+    /home/ec2-user/.ssh/authorized_keys \
+    /root/.ssh/authorized_keys \
+    /var/lib/cloud/data \
+    /var/lib/cloud/instance \
+    /var/lib/cloud/instances \
+    /var/lib/cloud/sem \
+    /var/lib/dhclient/* \
+    /var/lib/dhcp/dhclient.* \
+    /var/lib/yum/history \
+    /var/log/cloud-init-output.log \
+    /var/log/cloud-init.log \
+    /var/log/secure \
+    /var/log/wtmp
+
+sudo touch /etc/machine-id

--- a/docs/howto/assets/eks/scripts/install-worker.sh
+++ b/docs/howto/assets/eks/scripts/install-worker.sh
@@ -103,6 +103,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 export PATH=$PATH:$HOME/.cargo/bin
 
 # Build krustlet to link against the system libssl
+# Amazon Linux has an older openssl version than the krustlet release binary
 # TODO: make the krustlet to build (wasi or wascc) configurable
 mkdir /tmp/krustlet
 git clone https://github.com/deislabs/krustlet /tmp/krustlet

--- a/docs/howto/assets/eks/scripts/validate.sh
+++ b/docs/howto/assets/eks/scripts/validate.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Do basic validation of the generated AMI
+
+# Validates that a file or blob doesn't exist
+#
+# Arguments:
+#   a file name or blob
+# Returns:
+#   1 if a file exists, after printing an error
+validate_file_nonexists() {
+  local file_blob=$1
+  for f in $file_blob; do
+    if [ -e "$f" ]; then
+      echo "$f shouldn't exists"
+      exit 1
+    fi
+  done
+}
+
+validate_file_nonexists '/etc/hostname'
+validate_file_nonexists '/etc/resolv.conf'
+validate_file_nonexists '/etc/ssh/ssh_host*'
+validate_file_nonexists '/home/ec2-user/.ssh/authorized_keys'
+validate_file_nonexists '/root/.ssh/authorized_keys'
+validate_file_nonexists '/var/lib/cloud/data'
+validate_file_nonexists '/var/lib/cloud/instance'
+validate_file_nonexists '/var/lib/cloud/instances'
+validate_file_nonexists '/var/lib/cloud/sem'
+validate_file_nonexists '/var/lib/dhclient/*'
+validate_file_nonexists '/var/lib/dhcp/dhclient.*'
+validate_file_nonexists '/var/lib/yum/history'
+validate_file_nonexists '/var/log/cloud-init-output.log'
+validate_file_nonexists '/var/log/cloud-init.log'
+validate_file_nonexists '/var/log/secure'
+validate_file_nonexists '/var/log/wtmp'

--- a/docs/howto/krustlet-on-eks.md
+++ b/docs/howto/krustlet-on-eks.md
@@ -1,3 +1,173 @@
 # Running Krustlet on Amazon Elastic Kubernetes Service (EKS)
 
-TODO: https://github.com/deislabs/krustlet/issues/130
+Currently, [EKS does not support](https://github.com/aws/containers-roadmap/issues/741) running managed node groups with custom Amazon Machine Images (AMI).
+
+However, it does appear the feature might be coming soon.
+
+Until that time, we can use [eksctl](https://eksctl.io/) to create and manage a node group with a custom Krustlet-based AMI.
+
+# Prerequisites
+
+The following tools are needed to complete this walkthrough:
+
+* [Amazon CLI](https://aws.amazon.com/cli/) - *use `aws configure` to set your access keys and default region*
+* [Packer](https://packer.io/)
+* [eksctl](https://eksctl.io/) 
+
+# Building the Krustlet-based AMI
+
+We will be using [Packer](https://packer.io/) to spin up an EC2 instance to build the AMI.
+
+There is a Makefile in `docs/howto/assets/eks` that will run packer for you.  It will use a `c5.2xlarge` EC2 instance to build the AMI with.  Use the `instance_type` variable to `make` to change the type of the EC2 instance used.
+
+Run `make` to build the AMI:
+
+```bash
+$ cd docs/howto/assets/eks
+$ make
+```
+
+This command will take a while to build Krustlet from source on the EC2 instance.
+In the future, a prebuilt binary for Amazon Linux 2 might be available that would speed up the AMI creation process.
+
+If everything works correctly, you should see the command complete with output similar to: 
+
+```bash
+...
+==> Builds finished. The artifacts of successful builds are:
+--> amazon-ebs: AMIs were created:
+us-west-2: ami-07adf9ce893885a3d
+
+--> amazon-ebs:
+```
+
+Make note of the AMI identifier (in the example output above it would be `ami-07adf9ce893885a3d`) as it will be used to create the EKS cluster.
+
+# Creating the EKS cluster
+
+We will be using [eksctl](https://eksctl.io/) to deploy the EKS cluster.
+
+Create a file named `cluster.yaml` with the following contents, replacing the `region` and `ami` fields with your values:
+
+```yaml
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: krustlet-demo
+  region: <YOUR_AWS_REGION_HERE>
+  version: "1.15"
+
+nodeGroups:
+  - name: krustlet
+    ami: <YOUR_AMI_HERE>
+    instanceType: t3.small
+    minSize: 1
+    maxSize: 3
+    desiredCapacity: 2
+    ssh:
+      allow: true
+    overrideBootstrapCommand: /etc/eks/bootstrap.sh
+```
+
+This will create a EKS cluster named `krustlet-demo` with a single unmanaged node group named `krustlet` with two `t3.small` nodes.
+
+Be aware that the `overrideBootstrapCommand` setting is required to properly boot the nodes.  Without it, the Krustlet service will not be started and the nodes will not automatically join the cluster.
+
+Use `eksctl` to create the cluster:
+
+```bash
+$ eksctl create cluster -f cluster.yaml
+```
+
+This command will take a long time to run as it provisions the EKS cluster and nodes.
+
+Eventually, the command will be stuck on the following output:
+
+```text
+...
+[ℹ]  waiting for at least 1 node(s) to become ready in "krustlet"
+```
+
+With another shell, ensure the nodes have joined the cluster:
+
+```bash
+$ kubectl get nodes
+NAME                                          STATUS   ROLES   AGE   VERSION
+ip-192-168-24-34.us-west-2.compute.internal   Ready    agent   23s   v1.17.0
+ip-192-168-44-27.us-west-2.compute.internal   Ready    agent   17s   v1.17.0
+```
+
+You should see two nodes with different names in the output.
+
+`eksctl` expects the nodes to have been created with specific labels it uses to manage the nodes.
+
+Currently [Krustlet does not add these labels](https://github.com/deislabs/krustlet/issues/184) when it registers the node with the Kubernetes API server.
+
+To fix this, run `kubectl` to manually apply the labels to the nodes, where `$NODE_NAME` should be replaced with each of the two node names:
+
+```bash
+$ kubectl label nodes $NODE_NAME alpha.eksctl.io/cluster-name=krustlet-demo alpha.eksctl.io/nodegroup-name=krustlet
+```
+
+Once the labels are applied to the nodes, the `eksctl` command should continue and complete successfully.
+
+# Running a WebAssembly application
+
+Let's deploy a demo WebAssembly application to the cluster:
+
+```bash
+$ kubectl apply -f demos/wasi/hello-world-rust/k8s.yaml
+```
+
+Check that the pod ran to completion:
+
+```bash
+$ kubectl get pod hello-world-wasi-rust
+NAME                    READY   STATUS       RESTARTS   AGE
+hello-world-wasi-rust   0/1     ExitCode:0   0          7s
+```
+
+This output shows the pod completed with an exit code of 0.
+
+Take a look at the log to see the output of the application:
+
+```bash
+$ kubectl logs hello-world-wasi-rust
+hello from stdout!
+hello from stderr!
+POD_NAME=hello-world-wasi-rust
+FOO=bar
+CONFIG_MAP_VAL=cool stuff
+Args are: []
+```
+
+Congratulations!  You've run a WebAssembly program on an EKS cluster!
+
+# Deleting the cluster
+
+Use `eksctl` to delete the cluster and the nodes:
+
+```bash
+$ eksctl delete cluster --name krustlet-demo
+```
+
+# Deleting the Krustlet AMI
+
+Determine the snapshot identifier of the AMI, where `$AMI_ID` is the identifier of your Krustlet AMI:
+
+```bash
+$ aws ec2 describe-images --image-ids $AMI_ID | grep SnapshotId
+```
+
+Use `aws` to deregister the AMI, where `$AMI_ID` is the identifier of your Krustlet AMI:
+
+```bash
+$ aws ec2 deregister-image --image-id $AMI_ID
+```
+
+Next, delete the snapshot, where `$SNAPSHOT_ID` is the previously determined snapshot identifier:
+
+```bash
+$ aws ec2 delete-snapshot --snapshot-id $SNAPSHOT_ID
+```

--- a/docs/howto/krustlet-on-eks.md
+++ b/docs/howto/krustlet-on-eks.md
@@ -6,7 +6,7 @@ However, it does appear the feature might be coming soon.
 
 Until that time, we can use [eksctl](https://eksctl.io/) to create and manage a node group with a custom Krustlet-based AMI.
 
-# Prerequisites
+## Prerequisites
 
 The following tools are needed to complete this walkthrough:
 
@@ -18,7 +18,7 @@ The following tools are needed to complete this walkthrough:
 
 We will be using [Packer](https://packer.io/) to spin up an EC2 instance to build the AMI.
 
-There is a Makefile in `docs/howto/assets/eks` that will run packer for you.  It will use a `c5.2xlarge` EC2 instance to build the AMI with.  Use the `instance_type` variable to `make` to change the type of the EC2 instance used.
+There is a Makefile in `docs/howto/assets/eks` that will run `packer` for you.  It will use a `c5.2xlarge` EC2 instance to build the AMI with.  Use the `instance_type` variable to `make` to change the type of the EC2 instance used.
 
 Run `make` to build the AMI:
 
@@ -43,7 +43,7 @@ us-west-2: ami-07adf9ce893885a3d
 
 Make note of the AMI identifier (in the example output above it would be `ami-07adf9ce893885a3d`) as it will be used to create the EKS cluster.
 
-# Creating the EKS cluster
+## Creating the EKS cluster
 
 We will be using [eksctl](https://eksctl.io/) to deploy the EKS cluster.
 
@@ -112,7 +112,7 @@ $ kubectl label nodes $NODE_NAME alpha.eksctl.io/cluster-name=krustlet-demo alph
 
 Once the labels are applied to the nodes, the `eksctl` command should continue and complete successfully.
 
-# Running a WebAssembly application
+## Running a WebAssembly application
 
 Let's deploy a demo WebAssembly application to the cluster:
 
@@ -144,7 +144,7 @@ Args are: []
 
 Congratulations!  You've run a WebAssembly program on an EKS cluster!
 
-# Deleting the cluster
+## Deleting the cluster
 
 Use `eksctl` to delete the cluster and the nodes:
 
@@ -152,7 +152,7 @@ Use `eksctl` to delete the cluster and the nodes:
 $ eksctl delete cluster --name krustlet-demo
 ```
 
-# Deleting the Krustlet AMI
+## Deleting the Krustlet AMI
 
 Determine the snapshot identifier of the AMI, where `$AMI_ID` is the identifier of your Krustlet AMI:
 


### PR DESCRIPTION
This PR adds scripts for building a Krustlet-based AMI and defining an EKS
cluster using Krustet.

It also provides a walkthrough of how to get Krustlet running on EKS.

Closes #130.