### PR TITLE
fixed: now krustlet can pull wasm image from standard registry

### DIFF
--- a/crates/oci-distribution/src/client.rs
+++ b/crates/oci-distribution/src/client.rs
@@ -216,7 +216,7 @@ impl Client {
     /// be set on all OCI Registry request.
     fn auth_headers(&self) -> HeaderMap {
         let mut headers = HeaderMap::new();
-        headers.insert("Accept", "application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.list.v2+json".parse().unwrap());
+        headers.insert("Accept", "application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json".parse().unwrap());
 
         if let Some(bearer) = self.token.as_ref() {
             headers.insert("Authorization", bearer.bearer_token().parse().unwrap());


### PR DESCRIPTION
I'm trying to run a pod with an image on my own registry, but when the pod was created, I saw that in my registry's log: `OCI manifest found, but accept header does not support OCI manifests"}]}`

Appended "application/vnd.oci.image.manifest.v1+json" in the `accept` header, it works now.