### PR TITLE
Allow specifying labels

### DIFF
--- a/crates/kubelet/src/config.rs
+++ b/crates/kubelet/src/config.rs
@@ -297,8 +297,12 @@ fn read_password_from_tty() -> String {
 fn split_one_label(in_string: &str) -> Result<(String, String), String> {
     let mut splitter = in_string.splitn(2, '=');
     let key = splitter.next().unwrap();
-    match splitter.next() {
-        Some(val) => Ok((key.to_string(), val.to_string())),
-        None => Err("empty label".to_string()),
+    if key.is_empty() {
+        Err("error splitting label".to_string())
+    } else {
+        match splitter.next() {
+            Some(val) => Ok((key.to_string(), val.to_string())),
+            None => Ok((key.to_string(), "".to_string())),
+        }
     }
 }

--- a/crates/kubelet/src/config.rs
+++ b/crates/kubelet/src/config.rs
@@ -201,7 +201,7 @@ pub struct Opts {
 
     #[structopt(
         long = "node-labels",
-        env = "KRUSTLET_NODE_LABELS",
+        env = "NODE_LABELS",
         help = "Labels to add when registering the node in the cluster. Labels must be key-value pairs separated by ','"
     )]
     node_labels: Option<String>,

--- a/crates/kubelet/src/config.rs
+++ b/crates/kubelet/src/config.rs
@@ -105,8 +105,7 @@ impl Config {
 
         let node_labels = opts
             .node_labels
-            .unwrap_or_default()
-            .split(',')
+            .iter()
             .map(|i| split_one_label(i))
             .filter_map(Result::ok)
             .collect();
@@ -202,9 +201,10 @@ pub struct Opts {
     #[structopt(
         long = "node-labels",
         env = "NODE_LABELS",
+        use_delimiter = true,
         help = "Labels to add when registering the node in the cluster. Labels must be key-value pairs separated by ','"
     )]
-    node_labels: Option<String>,
+    node_labels: Vec<String>,
 
     #[structopt(
         long = "hostname",

--- a/crates/kubelet/src/node.rs
+++ b/crates/kubelet/src/node.rs
@@ -244,7 +244,7 @@ async fn replace_node(client: &kube::Client, node_name: &str, node: &Node) -> Re
 /// use seems like a misstep. Ideally, we'll be able to support multiple runtimes.
 fn node_definition(config: &Config, arch: &str) -> serde_json::Value {
     let ts = Time(Utc::now());
-    serde_json::json!({
+    let mut json = serde_json::json!({
         "apiVersion": "v1",
         "kind": "Node",
         "metadata": {
@@ -336,7 +336,14 @@ fn node_definition(config: &Config, arch: &str) -> serde_json::Value {
                 }
             }
         }
-    })
+    });
+
+    // extra labels from config
+    for (key, val) in &config.node_labels {
+        json["metadata"]["labels"][key] = serde_json::json!(val);
+    }
+
+    json
 }
 
 /// Define a new coordination.Lease object for Kubernetes

--- a/docs/howto/assets/eks/files/bootstrap.sh
+++ b/docs/howto/assets/eks/files/bootstrap.sh
@@ -23,7 +23,7 @@ while [[ $# -gt 0 ]]; do
             exit 1
             ;;
         --krustlet-node-labels)
-            KRUSTLET_NODE_LABELS=$2
+            NODE_LABELS=$2
             shift
             shift
             ;;
@@ -34,7 +34,7 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-KRUSTLET_NODE_LABELS="${KRUSTLET_NODE_LABELS:-}"
+NODE_LABELS="${NODE_LABELS:-}"
 
 echo "Generating certificate signing request..."
 openssl req -new -sha256 -newkey rsa:2048 -keyout /tmp/krustlet.key -out /tmp/krustlet.csr -nodes -config <(
@@ -130,9 +130,9 @@ chmod 640 /etc/krustlet/cert.pfx
 
 rm /tmp/krustlet.key /tmp/krustlet.csr /tmp/krustlet.cert
 
-if [[ -n "$KRUSTLET_NODE_LABELS" ]]; then
+if [[ -n "$NODE_LABELS" ]]; then
     cat <<EOF > /etc/eksctl/krustlet.local.env
-KRUSTLET_NODE_LABELS=$KRUSTLET_NODE_LABELS
+NODE_LABELS=$NODE_LABELS
 EOF
 fi
 chown root:root /etc/eksctl/krustlet.local.env

--- a/docs/howto/assets/eks/files/bootstrap.sh
+++ b/docs/howto/assets/eks/files/bootstrap.sh
@@ -7,6 +7,35 @@ set -o pipefail
 set -o nounset
 set -o errexit
 
+function print_help {
+    echo "usage: $0 [options] <cluster-name>"
+    echo "Bootstraps a Krustlet instance into an EKS cluster"
+    echo ""
+    echo "-h,--help print this help"
+    echo "--krustlet-node-labels Add extra labels to Krustlet."
+}
+
+while [[ $# -gt 0 ]]; do
+    key="$1"
+    case $key in
+        -h|--help)
+            print_help
+            exit 1
+            ;;
+        --krustlet-node-labels)
+            KRUSTLET_NODE_LABELS=$2
+            shift
+            shift
+            ;;
+        *) # unknown option
+            print_help
+            exit 1
+            ;;
+    esac
+done
+
+KRUSTLET_NODE_LABELS="${KRUSTLET_NODE_LABELS:-}"
+
 echo "Generating certificate signing request..."
 openssl req -new -sha256 -newkey rsa:2048 -keyout /tmp/krustlet.key -out /tmp/krustlet.csr -nodes -config <(
 cat <<-EOF
@@ -100,6 +129,13 @@ chown root:root /etc/krustlet/cert.pfx
 chmod 640 /etc/krustlet/cert.pfx
 
 rm /tmp/krustlet.key /tmp/krustlet.csr /tmp/krustlet.cert
+
+if [[ -n "$KRUSTLET_NODE_LABELS" ]]; then
+    cat <<EOF > /etc/eksctl/krustlet.local.env
+KRUSTLET_NODE_LABELS=$KRUSTLET_NODE_LABELS
+EOF
+fi
+chown root:root /etc/eksctl/krustlet.local.env
 
 echo "Starting krustlet service..."
 systemctl daemon-reload

--- a/docs/howto/assets/eks/files/krustlet.service
+++ b/docs/howto/assets/eks/files/krustlet.service
@@ -2,6 +2,8 @@
 Description=Krustlet - a kubelet implementation for running WebAssembly
 
 [Service]
+# Global and static parameters: KRUSTLET_NODE_LABELS
+EnvironmentFile=/etc/eksctl/krustlet.local.env
 Environment=KUBECONFIG=/etc/eksctl/kubeconfig.yaml
 Environment=PFX_PATH=/etc/krustlet/cert.pfx
 Environment=PFX_PASSWORD=krustlet

--- a/docs/howto/assets/eks/files/krustlet.service
+++ b/docs/howto/assets/eks/files/krustlet.service
@@ -2,7 +2,7 @@
 Description=Krustlet - a kubelet implementation for running WebAssembly
 
 [Service]
-# Global and static parameters: KRUSTLET_NODE_LABELS
+# Global and static parameters: NODE_LABELS
 EnvironmentFile=/etc/eksctl/krustlet.local.env
 Environment=KUBECONFIG=/etc/eksctl/kubeconfig.yaml
 Environment=PFX_PATH=/etc/krustlet/cert.pfx

--- a/docs/howto/krustlet-on-eks.md
+++ b/docs/howto/krustlet-on-eks.md
@@ -67,7 +67,7 @@ nodeGroups:
     desiredCapacity: 2
     ssh:
       allow: true
-    overrideBootstrapCommand: /etc/eks/bootstrap.sh
+    overrideBootstrapCommand: /etc/eks/bootstrap.sh --krustlet-node-labels "alpha.eksctl.io/cluster-name=krustlet-demo,alpha.eksctl.io/nodegroup-name=krustlet"
 ```
 
 This will create a EKS cluster named `krustlet-demo` with a single unmanaged node group named `krustlet` with two `t3.small` nodes.
@@ -99,18 +99,6 @@ ip-192-168-44-27.us-west-2.compute.internal   Ready    agent   17s   v1.17.0
 ```
 
 You should see two nodes with different names in the output.
-
-`eksctl` expects the nodes to have been created with specific labels it uses to manage the nodes.
-
-Currently [Krustlet does not add these labels](https://github.com/deislabs/krustlet/issues/184) when it registers the node with the Kubernetes API server.
-
-To fix this, run `kubectl` to manually apply the labels to the nodes, where `$NODE_NAME` should be replaced with each of the two node names:
-
-```bash
-$ kubectl label nodes $NODE_NAME alpha.eksctl.io/cluster-name=krustlet-demo alpha.eksctl.io/nodegroup-name=krustlet
-```
-
-Once the labels are applied to the nodes, the `eksctl` command should continue and complete successfully.
 
 ## Running a WebAssembly application
 


### PR DESCRIPTION
Add `--node-labels` to the command line option which appends extra
labels when registering a Krustlet node.

Disclaimer: My Rust skill is rusty and my code may not be idiomatic Rust code :-).

This fixes https://github.com/deislabs/krustlet/issues/184