### PR TITLE
feat(config): prompt for --pfx-password

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1741,6 +1741,7 @@ dependencies = [
  "native-tls",
  "oci-distribution",
  "reqwest",
+ "rpassword",
  "serde",
  "serde_json",
  "structopt",
@@ -2630,6 +2631,16 @@ dependencies = [
  "byteorder",
  "rmp",
  "serde",
+]
+
+[[package]]
+name = "rpassword"
+version = "4.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99371657d3c8e4d816fb6221db98fa408242b0b53bac08f8676a41f8554fe99f"
+dependencies = [
+ "libc",
+ "winapi 0.3.8",
 ]
 
 [[package]]

--- a/crates/kubelet/Cargo.toml
+++ b/crates/kubelet/Cargo.toml
@@ -33,6 +33,7 @@ tokio-tls = "0.3"
 thiserror = "1.0"
 lazy_static = "1.4"
 oci-distribution = { path = "../oci-distribution", version = "0.1.0" }
+rpassword = "4.0"
 
 [features]
 cli = ["structopt"]

--- a/crates/kubelet/src/config.rs
+++ b/crates/kubelet/src/config.rs
@@ -6,6 +6,8 @@
 use std::net::IpAddr;
 use std::net::ToSocketAddrs;
 use std::path::PathBuf;
+
+use rpassword;
 #[cfg(feature = "cli")]
 use structopt::StructOpt;
 
@@ -97,7 +99,11 @@ impl Config {
             .unwrap_or_else(|| sanitize_hostname(&hostname));
         let port = opts.port;
         let pfx_path = opts.pfx_path.unwrap_or_else(default_pfx_path);
-        let pfx_password = opts.pfx_password.unwrap_or_default();
+
+        let pfx_password = opts
+            .pfx_password
+            .unwrap_or_else(|| read_password_from_tty());
+
         let data_dir = opts
             .data_dir
             .unwrap_or_else(|| default_data_dir().expect("unable to get default directory"));
@@ -259,4 +265,9 @@ fn is_same_ip_family(first: &IpAddr, second: &IpAddr) -> bool {
         IpAddr::V4(_) => second.is_ipv4(),
         IpAddr::V6(_) => second.is_ipv6(),
     }
+}
+
+fn read_password_from_tty() -> String {
+    let password = rpassword::read_password_from_tty(Some("PFX file password: ")).unwrap();
+    return password;
 }


### PR DESCRIPTION
If no password is provided as a flag, prompt for one. Passewords are mandatory for PFX bundles, so there's no need to wrap this in an `Option`.

closes #141 

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>