### PR TITLE
Allow building Krustlet from a different repo for EKS

### DIFF
--- a/docs/howto/assets/eks/Makefile
+++ b/docs/howto/assets/eks/Makefile
@@ -1,5 +1,5 @@
 PACKER_BINARY ?= packer
-PACKER_VARIABLES := aws_region ami_name krustlet_version source_ami_id source_ami_owners arch instance_type security_group_id
+PACKER_VARIABLES := aws_region ami_name krustlet_version krustlet_src source_ami_id source_ami_owners arch instance_type security_group_id
 
 aws_region ?= $(AWS_DEFAULT_REGION)
 ami_name ?= amazon-eks-node-krustlet-$(KRUSTLET_VERSION)-v$(shell date +'%Y%m%d')
@@ -13,6 +13,11 @@ endif
 ifeq ($(aws_region), cn-northwest-1)
 source_ami_owners ?= 141808717104
 endif
+
+KRUSTLET_VERSION ?= 0.1.0
+krustlet_version ?= $(KRUSTLET_VERSION)
+KRUSTLET_SRC ?= https://github.com/deislabs/krustlet/archive/v$(krustlet_version).tar.gz
+krustlet_src ?= $(KRUSTLET_SRC)
 
 T_RED := \e[0;31m
 T_GREEN := \e[0;32m

--- a/docs/howto/assets/eks/eks-worker-al2.json
+++ b/docs/howto/assets/eks/eks-worker-al2.json
@@ -11,6 +11,7 @@
     "aws_session_token": "{{env `AWS_SESSION_TOKEN`}}",
 
     "krustlet_version": "0.1.0",
+    "krustlet_src": "https://github.com/deislabs/krustlet/archive/v{{ user `krustlet_version`}}.tar.gz",
 
     "source_ami_id": "",
     "source_ami_owners": "137112412989",
@@ -105,6 +106,7 @@
       "script": "{{template_dir}}/scripts/install-worker.sh",
       "environment_vars": [
         "KRUSTLET_VERSION={{user `krustlet_version`}}",
+        "KRUSTLET_SRC={{user `krustlet_src`}}",
         "AWS_ACCESS_KEY_ID={{user `aws_access_key_id`}}",
         "AWS_SECRET_ACCESS_KEY={{user `aws_secret_access_key`}}",
         "AWS_SESSION_TOKEN={{user `aws_session_token`}}"

--- a/docs/howto/assets/eks/scripts/install-worker.sh
+++ b/docs/howto/assets/eks/scripts/install-worker.sh
@@ -22,6 +22,7 @@ validate_env_set() {
 }
 
 validate_env_set KRUSTLET_VERSION
+validate_env_set KRUSTLET_SRC
 
 ################################################################################
 ### Machine Architecture #######################################################
@@ -105,11 +106,16 @@ export PATH=$PATH:$HOME/.cargo/bin
 # Build krustlet to link against the system libssl
 # Amazon Linux has an older openssl version than the krustlet release binary
 # TODO: make the krustlet to build (wasi or wascc) configurable
+echo "Downloading Krustlet source from $KRUSTLET_SRC"
+curl $KRUSTLET_SRC -L -o /tmp/krustlet.tar.gz
+
+echo "Unzipping Krustlet source"
 mkdir /tmp/krustlet
-git clone https://github.com/deislabs/krustlet /tmp/krustlet
+tar xvzf /tmp/krustlet.tar.gz --strip=1 -C /tmp/krustlet
+
 cargo build --release --manifest-path /tmp/krustlet/Cargo.toml --bin krustlet-wasi
 sudo mv /tmp/krustlet/target/release/krustlet-wasi /usr/local/bin/krustlet
-rm -rf /tmp/krustlet
+rm -rf /tmp/krustlet /tmp/krustlet.tar.gz
 sudo chown root:root /usr/local/bin/krustlet
 sudo chmod 755 /usr/local/bin/krustlet
 

--- a/docs/howto/krustlet-on-eks.md
+++ b/docs/howto/krustlet-on-eks.md
@@ -27,6 +27,13 @@ $ cd docs/howto/assets/eks
 $ make
 ```
 
+You can also build the AMI with a different version of Krustlet from a forked repo. For example:
+
+```bash
+$ cd docs/howto/assets/eks
+$ KRUSTLET_VERSION=$(git rev-parse --short HEAD) KRUSTLET_SRC=https://github.com/jingweno/krustlet/archive/$(git rev-parse --short HEAD).tar.gz make krustlet
+```
+
 This command will take a while to build Krustlet from source on the EC2 instance.
 In the future, a prebuilt binary for Amazon Linux 2 might be available that would speed up the AMI creation process.
 


### PR DESCRIPTION
Allow passing in `KRUSTLET_VERSION` & `KRUSTLET_SRC` when building Krustlet AMI with packer. This allows building an AMI for changes in a forked repo.