### PR TITLE
fix(kubelet): Adds per pod queuing

### DIFF
--- a/crates/kubelet/src/kubelet.rs
+++ b/crates/kubelet/src/kubelet.rs
@@ -2,14 +2,20 @@
 ///! Kubelet with a specific handler (called a `Provider`)
 use crate::config::Config;
 use crate::node::{create_node, update_node};
+use crate::queue::PodQueue;
 use crate::server::start_webserver;
+use crate::status::Phase;
 use crate::Provider;
 
 use futures::{StreamExt, TryStreamExt};
 use k8s_openapi::api::core::v1::Pod as KubePod;
-use kube::{api::ListParams, runtime::Informer, Api};
-use log::{debug, warn};
-use tokio::sync::Mutex;
+use kube::{
+    api::{ListParams, Meta, PatchParams, Resource},
+    runtime::Informer,
+    Api,
+};
+use log::{debug, error, warn};
+use tokio::sync::mpsc;
 
 use std::sync::Arc;
 
@@ -26,7 +32,7 @@ use std::sync::Arc;
 /// run one (instance of a) Provider. So a provider may be passed around from
 /// thread to thread during the course of the Kubelet's lifetime.
 pub struct Kubelet<P> {
-    provider: Arc<Mutex<P>>,
+    provider: Arc<P>,
     kube_config: kube::Config,
     config: Config,
 }
@@ -36,7 +42,7 @@ impl<T: 'static + Provider + Sync + Send> Kubelet<T> {
     /// and a kubelet configuration
     pub fn new(provider: T, kube_config: kube::Config, config: Config) -> Self {
         Self {
-            provider: Arc::new(Mutex::new(provider)),
+            provider: Arc::new(provider),
             kube_config,
             config,
         }
@@ -63,8 +69,53 @@ impl<T: 'static + Provider + Sync + Send> Kubelet<T> {
             }
         });
 
-        // This informer listens for pod events.
-        let provider = self.provider.clone();
+        // TODO: How should we configure this value? We should eventually have a max pods setting
+        // just like a normal kubelet, so maybe that?
+        let (error_sender, mut error_receiver) = mpsc::channel::<(KubePod, anyhow::Error)>(200);
+        let client_clone = client.clone();
+        let error_handler = tokio::task::spawn(async move {
+            let client = client_clone;
+            while let Some(e) = error_receiver.recv().await {
+                let (pod, err) = e;
+                let json_status = serde_json::json!(
+                    {
+                        "metadata": {
+                            "resourceVersion": "",
+                        },
+                        "status": {
+                            "phase": Phase::Failed,
+                            "message": format!("{}", err),
+                        }
+                    }
+                );
+
+                debug!(
+                    "Setting pod status for {} using {:?}",
+                    pod.name(),
+                    json_status
+                );
+
+                let data = serde_json::to_vec(&json_status).expect("Should always serialize");
+                let pod_resource =
+                    Resource::namespaced::<KubePod>(&pod.namespace().unwrap_or_default());
+                let pod_name = pod.name();
+                match pod_resource.patch_status(&pod_name, &PatchParams::default(), data) {
+                    Ok(req) => {
+                        if let Err(e) = client.request::<KubePod>(req).await {
+                            error!(
+                                "Unable to patch status during pod failure for {}: {}",
+                                pod_name, e
+                            )
+                        }
+                    }
+                    Err(e) => error!("Unable to generate pod request for {}: {}", pod_name, e),
+                }
+            }
+        });
+
+        // Create a queue that locks on events per pod
+        let mut queue = PodQueue::new(self.provider.clone(), error_sender);
+
         let node_selector = format!("spec.nodeName={}", self.config.node_name);
         let pod_informer = tokio::task::spawn(async move {
             // Create our informer and start listening.
@@ -78,9 +129,9 @@ impl<T: 'static + Provider + Sync + Send> Kubelet<T> {
                 let mut stream = informer.poll().await.expect("informer poll failed").boxed();
                 while let Some(event) = stream.try_next().await.unwrap() {
                     debug!("Handling Kubernetes pod event: {:?}", event);
-                    match provider.lock().await.handle_event(event).await {
-                        Ok(()) => debug!("Handled Kubernetes event successfully"),
-                        Err(e) => warn!("Error handling pod event: {}", e),
+                    match queue.enqueue(event).await {
+                        Ok(()) => debug!("Enqueued event for processing"),
+                        Err(e) => warn!("Error enqueuing pod event: {}", e),
                     };
                 }
             }
@@ -89,10 +140,8 @@ impl<T: 'static + Provider + Sync + Send> Kubelet<T> {
         // Start the webserver
         let webserver = start_webserver(self.provider.clone(), &self.config.server_config);
 
-        // FIXME: If any of these dies, we should crash the Kubelet and let it restart.
-        // A Future that will complete as soon as either spawned task fails
         let threads = async {
-            futures::try_join!(node_updater, pod_informer)?;
+            futures::try_join!(node_updater, pod_informer, error_handler)?;
             Ok(())
         };
 

--- a/crates/kubelet/src/lib.rs
+++ b/crates/kubelet/src/lib.rs
@@ -48,6 +48,7 @@
 mod kubelet;
 mod node;
 mod pod;
+mod queue;
 mod server;
 
 pub mod config;

--- a/crates/kubelet/src/queue.rs
+++ b/crates/kubelet/src/queue.rs
@@ -1,0 +1,114 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use k8s_openapi::api::core::v1::Pod as KubePod;
+use kube::api::{Meta, WatchEvent};
+use log::{debug, error};
+use tokio::sync::{mpsc::Sender, watch, Mutex};
+use tokio::task::JoinHandle;
+
+use crate::handle::pod_key;
+use crate::Provider;
+
+/// A per-pod queue that takes incoming Kubernetes events and broadcasts them to the correct queue
+/// for that pod. It will also send a error out on the given sender that can be handled in another
+/// process (namely the main kubelet process). This queue will only handle the latest update. So if
+/// a modify comes in while it is still handling a create and then another modify comes in after,
+/// only the second modify will be handled, which is ok given that each event contains the whole pod
+/// object
+pub struct PodQueue<P> {
+    provider: Arc<P>,
+    handlers: Mutex<HashMap<String, Worker>>,
+    error_sender: Sender<(KubePod, anyhow::Error)>,
+}
+
+struct Worker {
+    sender: watch::Sender<WatchEvent<KubePod>>,
+    _worker: JoinHandle<()>,
+}
+
+impl Worker {
+    fn create<P>(
+        initial_event: WatchEvent<KubePod>,
+        provider: Arc<P>,
+        mut error_sender: Sender<(KubePod, anyhow::Error)>,
+    ) -> Self
+    where
+        P: 'static + Provider + Sync + Send,
+    {
+        let (sender, mut receiver) = watch::channel(initial_event);
+        let worker = tokio::spawn(async move {
+            while let Some(event) = receiver.recv().await {
+                // Watch errors are handled before an event ever gets here, so it should always have
+                // a pod
+                let pod = pod_from_event(&event).unwrap();
+                if let Err(e) = provider.handle_event(event).await {
+                    if let Err(e) = error_sender.send((pod, e)).await {
+                        error!("Unable to send error to status updater: {:?}", e)
+                    }
+                }
+            }
+        });
+        Worker {
+            sender,
+            _worker: worker,
+        }
+    }
+}
+
+impl<P: 'static + Provider + Sync + Send> PodQueue<P> {
+    pub fn new(provider: Arc<P>, error_sender: Sender<(KubePod, anyhow::Error)>) -> Self {
+        PodQueue {
+            provider,
+            handlers: Mutex::new(HashMap::new()),
+            error_sender,
+        }
+    }
+
+    pub async fn enqueue(&mut self, event: WatchEvent<KubePod>) -> anyhow::Result<()> {
+        match &event {
+            WatchEvent::Added(pod)
+            | WatchEvent::Bookmark(pod)
+            | WatchEvent::Deleted(pod)
+            | WatchEvent::Modified(pod) => {
+                let mut handlers = self.handlers.lock().await;
+                let pod_name = pod.name();
+                let pod_namespace = pod.namespace().unwrap_or_default();
+                let entry = handlers
+                    .entry(pod_key(&pod_namespace, &pod_name))
+                    .or_insert_with(|| {
+                        Worker::create(
+                            event.clone(),
+                            self.provider.clone(),
+                            self.error_sender.clone(),
+                        )
+                    });
+                // TODO: There is a possible condition where we get two modifies right in a row and
+                // the 1st one locks/broadcasts after the second one. This shouldn't matter too much
+                // right now, but we should fix that possibility in the future
+                match entry.sender.broadcast(event) {
+                    Ok(_) => debug!(
+                        "successfully sent event to handler for pod {} in namespace {}",
+                        pod_name, pod_namespace
+                    ),
+                    Err(e) => error!(
+                        "error while sending event. Will retry on next event: {:?}",
+                        e
+                    ),
+                }
+                Ok(())
+            }
+            WatchEvent::Error(e) => Err(e.clone().into()),
+        }
+    }
+}
+
+fn pod_from_event(event: &WatchEvent<KubePod>) -> Option<KubePod> {
+    match event {
+        WatchEvent::Added(pod)
+        | WatchEvent::Bookmark(pod)
+        | WatchEvent::Deleted(pod)
+        | WatchEvent::Modified(pod) => Some(pod.clone()),
+        WatchEvent::Error(_) => None,
+    }
+}


### PR DESCRIPTION
Our old event handling method locked the provider for any pod until event
handling was complete, essentially limiting us to one action at a time.
This introduces a new queuing method that creates a per pod queue that
only handles the latest sent event.