### PR TITLE
posix-compatible lowercasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,8 @@ jobs:
 
       - name: lowercase the runner OS name
         run: |
-          OS=${{ runner.os }}
-          echo ::set-env name=RUNNER_OS::${OS,,}
+          OS=$(echo "${{ runner.os }}" | tr '[:upper:]' '[:lower:]')
+          echo ::set-env name=RUNNER_OS::$OS
 
       - name: build release
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
The bash substitution is not portable and will not work on macOS runners (old version of bash?). Using `tr` is portable and should work across both POSIX systems.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>