### PR TITLE
Fix tiny typo in error message

### DIFF
--- a/crates/kubelet/src/volumes.rs
+++ b/crates/kubelet/src/volumes.rs
@@ -126,7 +126,7 @@ async fn configure(
         populate_from_secret(
             &s.secret_name
                 .as_ref()
-                .ok_or_else(|| anyhow::anyhow!("no configmap name was given"))?,
+                .ok_or_else(|| anyhow::anyhow!("no secret name was given"))?,
             namespace,
             client,
             path,


### PR DESCRIPTION
I found a tiny typo in error message.