### PR TITLE
chore(howto): remove empty HOWTO guide for EKS

### DIFF
--- a/docs/howto/krustlet-on-eks.md
+++ b/docs/howto/krustlet-on-eks.md
@@ -1,24 +1,29 @@
 # Running Krustlet on Amazon Elastic Kubernetes Service (EKS)
 
-Currently, [EKS does not support](https://github.com/aws/containers-roadmap/issues/741) running managed node groups with custom Amazon Machine Images (AMI).
+Currently, [EKS does not support](https://github.com/aws/containers-roadmap/issues/741) running
+managed node groups with custom Amazon Machine Images (AMI).
 
 However, it does appear the feature might be coming soon.
 
-Until that time, we can use [eksctl](https://eksctl.io/) to create and manage a node group with a custom Krustlet-based AMI.
+Until that time, we can use [eksctl](https://eksctl.io/) to create and manage a node group with a
+custom Krustlet-based AMI.
 
 ## Prerequisites
 
 The following tools are needed to complete this walkthrough:
 
-* [Amazon CLI](https://aws.amazon.com/cli/) - *use `aws configure` to set your access keys and default region*
+* [Amazon CLI](https://aws.amazon.com/cli/) - *use `aws configure` to set your access keys and
+  default region*
 * [Packer](https://packer.io/)
-* [eksctl](https://eksctl.io/) 
+* [eksctl](https://eksctl.io/)
 
 # Building the Krustlet-based AMI
 
 We will be using [Packer](https://packer.io/) to spin up an EC2 instance to build the AMI.
 
-There is a Makefile in `docs/howto/assets/eks` that will run `packer` for you.  It will use a `c5.2xlarge` EC2 instance to build the AMI with.  Use the `instance_type` variable to `make` to change the type of the EC2 instance used.
+There is a Makefile in `docs/howto/assets/eks` that will run `packer` for you.  It will use a
+`c5.2xlarge` EC2 instance to build the AMI with.  Use the `instance_type` variable to `make` to
+change the type of the EC2 instance used.
 
 Run `make` to build the AMI:
 
@@ -34,10 +39,10 @@ $ cd docs/howto/assets/eks
 $ KRUSTLET_VERSION=$(git rev-parse --short HEAD) KRUSTLET_SRC=https://github.com/jingweno/krustlet/archive/$(git rev-parse --short HEAD).tar.gz make krustlet
 ```
 
-This command will take a while to build Krustlet from source on the EC2 instance.
-In the future, a prebuilt binary for Amazon Linux 2 might be available that would speed up the AMI creation process.
+This command will take a while to build Krustlet from source on the EC2 instance. In the future, a
+prebuilt binary for Amazon Linux 2 might be available that would speed up the AMI creation process.
 
-If everything works correctly, you should see the command complete with output similar to: 
+If everything works correctly, you should see the command complete with output similar to:
 
 ```bash
 ...
@@ -48,13 +53,15 @@ us-west-2: ami-07adf9ce893885a3d
 --> amazon-ebs:
 ```
 
-Make note of the AMI identifier (in the example output above it would be `ami-07adf9ce893885a3d`) as it will be used to create the EKS cluster.
+Make note of the AMI identifier (in the example output above it would be `ami-07adf9ce893885a3d`) as
+it will be used to create the EKS cluster.
 
 ## Creating the EKS cluster
 
 We will be using [eksctl](https://eksctl.io/) to deploy the EKS cluster.
 
-Create a file named `cluster.yaml` with the following contents, replacing the `region` and `ami` fields with your values:
+Create a file named `cluster.yaml` with the following contents, replacing the `region` and `ami`
+fields with your values:
 
 ```yaml
 apiVersion: eksctl.io/v1alpha5
@@ -77,9 +84,11 @@ nodeGroups:
     overrideBootstrapCommand: /etc/eks/bootstrap.sh --krustlet-node-labels "alpha.eksctl.io/cluster-name=krustlet-demo,alpha.eksctl.io/nodegroup-name=krustlet"
 ```
 
-This will create a EKS cluster named `krustlet-demo` with a single unmanaged node group named `krustlet` with two `t3.small` nodes.
+This will create a EKS cluster named `krustlet-demo` with a single unmanaged node group named
+`krustlet` with two `t3.small` nodes.
 
-Be aware that the `overrideBootstrapCommand` setting is required to properly boot the nodes.  Without it, the Krustlet service will not be started and the nodes will not automatically join the cluster.
+Be aware that the `overrideBootstrapCommand` setting is required to properly boot the nodes. Without
+it, the Krustlet service will not be started and the nodes will not automatically join the cluster.
 
 Use `eksctl` to create the cluster:
 
@@ -149,7 +158,8 @@ $ eksctl delete cluster --name krustlet-demo
 
 ## Deleting the Krustlet AMI
 
-Determine the snapshot identifier of the AMI, where `$AMI_ID` is the identifier of your Krustlet AMI:
+Determine the snapshot identifier of the AMI, where `$AMI_ID` is the identifier of your Krustlet
+AMI:
 
 ```bash
 $ aws ec2 describe-images --image-ids $AMI_ID | grep SnapshotId

--- a/docs/howto/krustlet-on-kind.md
+++ b/docs/howto/krustlet-on-kind.md
@@ -92,8 +92,8 @@ this address), check which IP address you have for the `en0` network:
 $ ifconfig en0
 en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
         options=400<CHANNEL_IO>
-        ether 78:4f:43:8d:4f:55 
-        inet6 fe80::1c20:1e66:6322:6ae9%en0 prefixlen 64 secured scopeid 0x5 
+        ether 78:4f:43:8d:4f:55
+        inet6 fe80::1c20:1e66:6322:6ae9%en0 prefixlen 64 secured scopeid 0x5
         inet 192.168.1.167 netmask 0xffffff00 broadcast 192.168.1.255
         nd6 options=201<PERFORMNUD,DAD>
         media: autoselect
@@ -104,8 +104,8 @@ In this example, I should use `192.168.1.167`.
 
 ### Special note: Docker on Hyper-V Linux VMs
 
-For Docker running on a Linux VM on a Windows host under Hyper-V, the default gateway
-is usually `172.18.0.1`.
+For Docker running on a Linux VM on a Windows host under Hyper-V, the default gateway is usually
+`172.18.0.1`.
 
 ## Step 3: Install and run Krustlet
 

--- a/docs/howto/krustlet-on-wsl2.md
+++ b/docs/howto/krustlet-on-wsl2.md
@@ -1,9 +1,11 @@
 # Running Krustlet on WSL2 with Docker Desktop
 
-This how-to guide demonstrates how to boot a Krustlet node in Docker Desktop for Windows with WSL2 backend.
+This how-to guide demonstrates how to boot a Krustlet node in Docker Desktop for Windows with WSL2
+backend.
 
 ## Information
-This tutorial will work on current Windows 10 Insider Slow ring and Docker Desktop for Windows stable release.
+This tutorial will work on current Windows 10 Insider Slow ring and Docker Desktop for Windows
+stable release.
 
 Concerning Windows, this tutorial should work on the Production ring once it will be available.
 
@@ -11,19 +13,21 @@ Last but not least, this will work on Windows 10 Home edition.
 
 ## Prerequisites
 
-You will require a WSL2 distro and Docker Desktop for Windows for this how-to. The WSL2 backend and Kubernetes features will need to be also enabled.
-See the [Docker Desktop for Windows > Getting started > Kubernetes](https://docs.docker.com/docker-for-windows/#kubernetes) howto for more information.
+You will require a WSL2 distro and Docker Desktop for Windows for this how-to. The WSL2 backend and
+Kubernetes features will need to be also enabled. See the [Docker Desktop for Windows > Getting
+started > Kubernetes](https://docs.docker.com/docker-for-windows/#kubernetes) howto for more
+information.
 
-This specific tutorial will be running Krustlet on your WSL2 distro and will explain how to access it from Windows.
+This specific tutorial will be running Krustlet on your WSL2 distro and will explain how to access
+it from Windows.
 
 ## Step 1: Determine the default gateway
 
-The default gateway for most Docker containers is generally `172.17.0.1`.
-This IP is only reachable, by default, from the WSL2 distro.
-However, the `eth0` host network is accessible from Windows, so we can use this IP address to connect to the WSL2 distro (where Krustlet is running). 
+The default gateway for most Docker containers is generally `172.17.0.1`. This IP is only reachable,
+by default, from the WSL2 distro. However, the `eth0` host network is accessible from Windows, so we
+can use this IP address to connect to the WSL2 distro (where Krustlet is running).
 
-If this was changed, check `ifconfig eth0` from
-the host OS to determine the default gateway:
+If this was changed, check `ifconfig eth0` from the host OS to determine the default gateway:
 
 ```console
 $ ifconfig eth0
@@ -45,7 +49,8 @@ In this example, I should use `172.26.47.208`.
 $ export mainIP=$(ifconfig eth0 | grep "inet " | awk '{ print $2 }')
 ```
 
-The hostname being "applied" from Windows, the default hostname will not resolve to this address, therefore you need to pass the `--node-ip` and `--node-name` flag to Krustlet.
+The hostname being "applied" from Windows, the default hostname will not resolve to this address,
+therefore you need to pass the `--node-ip` and `--node-name` flag to Krustlet.
 
 ## Step 2: Install and run Krustlet
 
@@ -80,7 +85,8 @@ krustlet      Ready    agent    34s     v1.17.0   172.26.47.208   <none>        
 ```
 
 ## Optional: Delete the Krustlet node
-Once you will no more need the Krustlet node, you can remove it from your cluster with the following `kubectl delete node` command:
+Once you will no more need the Krustlet node, you can remove it from your cluster with the following
+`kubectl delete node` command:
 
 ```shell
 $ kubectl delete node krustlet

--- a/docs/howto/kubernetes-on-eks.md
+++ b/docs/howto/kubernetes-on-eks.md
@@ -1,3 +1,0 @@
-# Running Kubernetes on Amazon Elastic Kubnernetes Service (EKS)
-
-TODO: https://github.com/deislabs/krustlet/issues/130

--- a/docs/howto/kubernetes-on-minikube.md
+++ b/docs/howto/kubernetes-on-minikube.md
@@ -2,9 +2,10 @@
 
 This tutorial will focus on using a tool called [minikube](https://github.com/kubernetes/minikube).
 
-If you haven't installed them already, go ahead and [install VirtualBox 5.2 or higher](https://www.virtualbox.org/),
-[install minikube](https://minikube.sigs.k8s.io/docs/start/linux/), and
-[install kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
+If you haven't installed them already, go ahead and [install VirtualBox 5.2 or
+higher](https://www.virtualbox.org/), [install
+minikube](https://minikube.sigs.k8s.io/docs/start/linux/), and [install
+kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 
 You'll need `kubectl` to interact with the cluster once it's created.
 
@@ -18,8 +19,10 @@ $ egrep -q 'vmx|svm' /proc/cpuinfo && echo yes || echo no
 
 If the above command outputs “no”:
 
-- If you are running within a VM, your hypervisor does not allow nested virtualization. You will need to use the *None (bare-metal)* driver
-- If you are running on a physical machine, ensure that your BIOS has hardware virtualization enabled
+- If you are running within a VM, your hypervisor does not allow nested virtualization. You will
+  need to use the *None (bare-metal)* driver
+- If you are running on a physical machine, ensure that your BIOS has hardware virtualization
+  enabled
 
 ## Create a cluster
 


### PR DESCRIPTION
The guide for running Krustlet on EKS describes how to spin up an EKS cluster, so this guide can be removed.

I also word-wrapped everything to 100 characters in a separate commit.