### PR TITLE
Don't watch files under ./target in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "files.watcherExclude": {
+        "**/.git/objects/**": true,
+        "**/.git/subtree-cache/**": true,
+        "**/node_modules/**": true,
+        "**/.hg/store/**": true,
+        "**/target/**": true
+    }
+}


### PR DESCRIPTION
In the default Ubuntu configuration, VS Code displays a "too many files to watch" warning when opening the Krustlet directory.  Rather than updating a global setting that could consume a lot of memory, we can tell VS Code not to watch the `target` directory.