### PR TITLE
feat(*): Update dependencies to use rustls instead of openssl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1501,12 +1501,25 @@ dependencies = [
  "ct-logs",
  "futures-util",
  "hyper",
- "log",
- "rustls",
+ "log 0.4.8",
+ "rustls 0.17.0",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.13.0",
  "webpki",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3adcd308402b9553630734e9c36b77a7e48b3821251ca2493e8cd596763aafaa"
+dependencies = [
+ "bytes 0.5.4",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-tls",
 ]
 
 [[package]]
@@ -1621,12 +1634,9 @@ dependencies = [
  "base64 0.12.1",
  "bytes 0.5.4",
  "chrono",
- "http 0.2.1",
- "percent-encoding 2.1.0",
  "serde",
  "serde-value",
  "serde_json",
- "url 2.1.1",
 ]
 
 [[package]]
@@ -1676,11 +1686,11 @@ dependencies = [
  "futures",
  "futures-util",
  "http 0.2.1",
- "k8s-openapi 0.8.0",
+ "k8s-openapi",
  "log 0.4.8",
  "openssl",
  "reqwest",
- "rustls",
+ "rustls 0.17.0",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2585,6 +2595,7 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "js-sys",
  "lazy_static",
  "log 0.4.8",
@@ -2593,13 +2604,14 @@ dependencies = [
  "native-tls",
  "percent-encoding 2.1.0",
  "pin-project-lite",
- "rustls",
+ "rustls 0.17.0",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "time 0.1.43",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.13.0",
+ "tokio-tls",
  "url 2.1.1",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -2698,6 +2710,31 @@ dependencies = [
  "ring",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rustls"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0d4a31f5d68413404705d6982529b0e11a9aacd4839d1d6222ee3b8cb4015e1"
+dependencies = [
+ "base64 0.11.0",
+ "log 0.4.8",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75ffeb84a6bd9d014713119542ce415db3a3e4748f0bfce1e1416cd224a23a5"
+dependencies = [
+ "openssl-probe",
+ "rustls 0.17.0",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -3332,7 +3369,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "141afec0978abae6573065a48882c6bae44c5cc61db9b511ac4abf6a09bfd9cc"
 dependencies = [
  "futures-core",
- "rustls",
+ "rustls 0.16.0",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4adb8b3e5f86b707f1b54e7c15b6de52617a823608ccda98a15d3a24222f265a"
+dependencies = [
+ "futures-core",
+ "rustls 0.17.0",
  "tokio",
  "webpki",
 ]
@@ -3674,7 +3723,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.12.2",
  "tokio-tungstenite",
  "tower-service",
  "urlencoding",
@@ -4114,6 +4163,15 @@ checksum = "f1f50e1972865d6b1adb54167d1c8ed48606004c2c9d0ea5f1eeb34d95e863ef"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91cd5736df7f12a964a5067a12c62fa38e1bd8080aff1f80bc29be7c80d19ab4"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,15 +135,16 @@ dependencies = [
 
 [[package]]
 name = "actix-rt"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20066d9200ef8d441ac156c76dd36c3f1e9a15976c34e69ae97f7f570b331882"
+checksum = "143fcc2912e0d1de2bcf4e2f720d2a60c28652ab4179685a1ee159e0fb3db227"
 dependencies = [
  "actix-macros",
  "actix-threadpool",
  "copyless",
  "futures-channel",
  "futures-util",
+ "smallvec",
  "tokio",
 ]
 
@@ -288,6 +289,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456d75cbb82da1ad150c8a9d97285ffcd21c9931dcb11e995903e7d75141b38b"
+dependencies = [
+ "gimli 0.21.0",
+]
+
+[[package]]
 name = "adler32"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,15 +323,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.28"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a60d744a80c30fcb657dfe2c1b22bcb3e814c1a1e3674f32bf5820b570fbff"
+checksum = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
 
 [[package]]
 name = "arc-swap"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d663a8e9a99154b5fb793032533f6328da35e23aac63d5c152279aa8ba356825"
+checksum = "b585a98a234c46fc563103e9278c9391fde1f4e6850334da895d27edb9580f62"
 
 [[package]]
 name = "arrayref"
@@ -337,9 +347,9 @@ checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 
 [[package]]
 name = "async-compression"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be3e94dc198f93aa4107649e68fbb7f4d759398643d36f498eb72a2ee8256652"
+checksum = "ae84766bab9f774e32979583ba56d6af8c701288c6dc99144819d5d2ee0b170f"
 dependencies = [
  "bytes 0.5.4",
  "flate2",
@@ -350,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da71fef07bc806586090247e971229289f64c210a278ee5ae419314eb386b31d"
+checksum = "26c4f3195085c36ea8d24d32b2f828d23296a9370a28aa39d111f6f16bef9f3b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -407,24 +417,15 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.46"
+version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e692897359247cc6bb902933361652380af0f1b7651ae5c5013407f30e109e"
+checksum = "0df2f85c8a2abbe3b7d7e748052fdd9b76a0458fdeb16ad4223f5eca78c7c130"
 dependencies = [
- "backtrace-sys",
+ "addr2line",
  "cfg-if",
  "libc",
+ "object 0.19.0",
  "rustc-demangle",
-]
-
-[[package]]
-name = "backtrace-sys"
-version = "0.1.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78848718ee1255a2485d1309ad9cdecfc2e7d0362dd11c6829364c6b35ae1bc7"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -450,9 +451,9 @@ checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
 name = "base64"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5ca2cd0adc3f48f9e9ea5a6bbdf9ccc0bfade884847e484d452414c7ccffb3"
+checksum = "53d1ccbaf7d9ec9537465a97bf19edc1a4e158ecb49fc16178202238c569cc42"
 
 [[package]]
 name = "bincode"
@@ -534,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.2.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ae9db68ad7fac5fe51304d20f016c911539251075a214f8e663babefa35187"
+checksum = "5356f1d23ee24a1f785a56d1d1a5f0fd5b0f6a0c0fb2412ce11da71649ab78f6"
 
 [[package]]
 name = "byte-tools"
@@ -577,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.50"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
+checksum = "7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311"
 dependencies = [
  "jobserver",
 ]
@@ -613,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.0"
+version = "2.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
+checksum = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
 dependencies = [
  "ansi_term",
  "atty",
@@ -703,7 +704,7 @@ dependencies = [
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
  "cranelift-entity",
- "gimli",
+ "gimli 0.20.0",
  "log 0.4.8",
  "regalloc",
  "serde",
@@ -978,9 +979,9 @@ checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8d03faa7fe0c1431609dfad7bbe827af30f82e1e2ae6f7ee4fca6bd764bc28"
+checksum = "e8ac63f94732332f44fe654443c46f6375d1939684c17b0afb6cb56b0456e171"
 dependencies = [
  "cfg-if",
 ]
@@ -1061,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "failure"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8529c2421efa3066a5cbd8063d2244603824daccb6936b079010bb2aa89464b"
+checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
 dependencies = [
  "backtrace",
  "failure_derive",
@@ -1071,9 +1072,9 @@ dependencies = [
 
 [[package]]
 name = "failure_derive"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
+checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1129,9 +1130,9 @@ dependencies = [
 
 [[package]]
 name = "fnv"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
@@ -1172,9 +1173,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c329ae8753502fb44ae4fc2b622fa2a94652c41e795143765ba0927f92ab780"
+checksum = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1187,9 +1188,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c77d04ce8edd9cb903932b608268b3fffec4163dc053b3b402bf47eac1f1a8"
+checksum = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1197,15 +1198,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25592f769825e89b92358db00d26f965761e094951ac44d3663ef25b7ac464a"
+checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f674f3e1bcb15b37284a90cedf55afdba482ab061c407a9c0ebbd0f3109741ba"
+checksum = "10d6bb888be1153d3abeb9006b11b02cf5e9b209fda28693c31ae1e4e012e314"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1214,15 +1215,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a638959aa96152c7a4cddf50fcb1e3fede0583b27157c26e67d6f99904090dc6"
+checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
+checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -1232,21 +1233,24 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3466821b4bc114d95b087b850a724c6f83115e929bc88f1fa98a3304a944c8a6"
+checksum = "3f2032893cb734c7a05d85ce0cc8b8c4075278e93b24b66f9de99d6eb0fa8acc"
 
 [[package]]
 name = "futures-task"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0a34e53cf6cdcd0178aa573aed466b646eb3db769570841fda0c7ede375a27"
+checksum = "bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "futures-util"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22766cf25d64306bedf0384da004d05c9974ab104fcc4528f1236181c18004c5"
+checksum = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1255,6 +1259,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
+ "pin-project",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1311,6 +1316,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,9 +1340,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377038bf3c89d18d6ca1431e7a5027194fbd724ca10592b9487ede5e8e144f42"
+checksum = "79b7246d7e4b979c03fa093da39cfb3617a96bbeee6310af63991668d7e843ff"
 dependencies = [
  "bytes 0.5.4",
  "fnv",
@@ -1352,7 +1363,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed18eb2459bf1a09ad2d6b1547840c3e5e62882fa09b9a6a20b1de8e3228848f"
 dependencies = [
- "base64 0.12.0",
+ "base64 0.12.1",
  "bitflags",
  "bytes 0.5.4",
  "headers-core",
@@ -1382,9 +1393,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d737e0f947a1864e93d33fdef4af8445a00d1ed8dc0c8ddb73139ea6abf15"
+checksum = "91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71"
 dependencies = [
  "libc",
 ]
@@ -1580,9 +1591,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.37"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a27d435371a2fa5b6d2b028a74bbdb1234f308da363226a2854ca3ff8ba7055"
+checksum = "fa5a448de267e7358beaf4a5d849518fe9a0c13fce7afd44b06e68550e5562a7"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1594,6 +1605,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96affb18356fc998baa692c2185d198095ffdf6e6fff3bc9efb4927952f86851"
 dependencies = [
  "base64 0.11.0",
+ "bytes 0.5.4",
+ "chrono",
+ "http 0.2.1",
+ "percent-encoding 2.1.0",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "url 2.1.1",
+]
+
+[[package]]
+name = "k8s-openapi"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae6d236dfb2b60d27cdbcb3d20511713aff6d23f9bf2f3d6b594c232ea99e04"
+dependencies = [
+ "base64 0.12.1",
  "bytes 0.5.4",
  "chrono",
  "http 0.2.1",
@@ -1622,7 +1650,7 @@ dependencies = [
  "dirs",
  "env_logger 0.7.1",
  "futures",
- "k8s-openapi",
+ "k8s-openapi 0.7.1",
  "kube",
  "kubelet",
  "oci-distribution",
@@ -1638,12 +1666,12 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e753b759a9d9a36bd435c22ec9d31b6c8b89c452e5fd7932abf374ede02cc028"
+checksum = "aa1b018930b98da87122377ee0f5093d3fb25df762db489c1a321d92e0177afb"
 dependencies = [
  "Inflector",
- "base64 0.12.0",
+ "base64 0.12.1",
  "bytes 0.5.4",
  "chrono",
  "dirs",
@@ -1651,7 +1679,7 @@ dependencies = [
  "futures",
  "futures-util",
  "http 0.2.1",
- "k8s-openapi",
+ "k8s-openapi 0.8.0",
  "log 0.4.8",
  "openssl",
  "reqwest",
@@ -1659,7 +1687,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "thiserror",
- "time 0.2.10",
+ "time 0.2.16",
  "tokio",
  "url 2.1.1",
 ]
@@ -1676,7 +1704,7 @@ dependencies = [
  "hostname",
  "http 0.2.1",
  "hyper",
- "k8s-openapi",
+ "k8s-openapi 0.8.0",
  "kube",
  "lazy_static",
  "log 0.4.8",
@@ -1713,9 +1741,9 @@ checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 
 [[package]]
 name = "libc"
-version = "0.2.69"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
+checksum = "3baa92041a6fec78c687fa0cc2b3fae8884f743d672cf551bed1d6dac6988d0f"
 
 [[package]]
 name = "libloading"
@@ -1728,9 +1756,9 @@ dependencies = [
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
+checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
 
 [[package]]
 name = "lock_api"
@@ -1859,9 +1887,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f"
+checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
 dependencies = [
  "cfg-if",
  "fuchsia-zircon",
@@ -1878,9 +1906,9 @@ dependencies = [
 
 [[package]]
 name = "mio-uds"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
+checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
  "iovec",
  "libc",
@@ -1943,9 +1971,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
+checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2018,6 +2046,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2"
+
+[[package]]
 name = "oci-distribution"
 version = "0.1.0"
 dependencies = [
@@ -2031,6 +2065,12 @@ dependencies = [
  "tokio",
  "www-authenticate",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
 
 [[package]]
 name = "opaque-debug"
@@ -2060,9 +2100,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.55"
+version = "0.9.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7717097d810a0f2e2323f9e5d11e71608355e24828410b55b9d4f18aa5f9a5d8"
+checksum = "f02309a7f127000ed50594f0b50ecc69e7c654e16d41b4e8156d1b3df8e0b52e"
 dependencies = [
  "autocfg 1.0.0",
  "cc",
@@ -2163,18 +2203,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.9"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f6a7f5eee6292c559c793430c55c00aea9d3b3d1905e855806ca4d7253426a2"
+checksum = "edc93aeee735e60ecb40cf740eb319ff23eab1c5748abfdb5c180e4ce49f7791"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.9"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8988430ce790d8682672117bc06dda364c0be32d3abd738234f19f3240bad99a"
+checksum = "e58db2081ba5b4c93bd6be09c40fd36cb9193a8336c384f3b40012e531aa7e40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2183,15 +2223,15 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "237844750cfbb86f67afe27eee600dfbbcb6188d734139b534cbfbf4f96792ae"
+checksum = "f7505eeebd78492e0f6108f7171c4948dbb120ee8119d9d77d0afa5469bef67f"
 
 [[package]]
 name = "pin-utils"
-version = "0.1.0-alpha.4"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -2207,9 +2247,9 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
 name = "proc-macro-error"
@@ -2251,9 +2291,9 @@ checksum = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.10"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
+checksum = "53f5ffe53a6b28e37c9c1ce74893477864d64f74778a93a4beb43c8fa167f639"
 dependencies = [
  "unicode-xid",
 ]
@@ -2266,9 +2306,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.3"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
+checksum = "54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea"
 dependencies = [
  "proc-macro2",
 ]
@@ -2580,13 +2620,13 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.12"
+version = "0.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba5a8ec64ee89a76c98c549af81ff14813df09c3e6dc4766c3856da48597a0c"
+checksum = "703516ae74571f24b465b4a1431e81e2ad51336cb0ded733a55a1aa3eccac196"
 dependencies = [
  "cc",
- "lazy_static",
  "libc",
+ "once_cell",
  "spin",
  "untrusted",
  "web-sys",
@@ -2661,21 +2701,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bba175698996010c4f6dce5e7f173b6eb781fce25d2cfc45e27091ce0b79f6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "ryu"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
+checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
 
 [[package]]
 name = "safemem"
@@ -2737,9 +2766,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572dfa3a0785509e7a44b5b4bebcf94d41ba34e9ed9eb9df722545c3b3c4144a"
+checksum = "64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2750,9 +2779,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb15a5fec93b7021b8a9e96009c5d8d51c15673569f7c0f6b7204e5b7b404f"
+checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2794,9 +2823,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325a073952621257820e7a3469f55ba4726d8b28657e7e36653d1c36dc2c84ae"
+checksum = "3bf487fbf5c6239d7ea2ff8b10cb6b811cd4b5080d1c2aeed1dec18753c06e10"
 dependencies = [
  "serde",
 ]
@@ -2837,9 +2866,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "691b17f19fc1ec9d94ec0b5864859290dff279dbd7b03f017afda54eb36c3c35"
+checksum = "16c7a592a1ec97c9c1c68d75b6e537dcbf60c7618e038e7841e00af1d9ccf0c4"
 dependencies = [
  "dtoa",
  "linked-hash-map",
@@ -2946,9 +2975,9 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smallvec"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05720e22615919e4734f6a99ceae50d00226c3c5aca406e102ebc33298214e0a"
+checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
 
 [[package]]
 name = "socket2"
@@ -2976,9 +3005,9 @@ checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 
 [[package]]
 name = "standback"
-version = "0.2.3"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96eca17d57aac1688897d4c5e519ed600fc6f28aeabc7b1abb188e945deb0732"
+checksum = "47e4b8c631c998468961a9ea159f064c5c8499b95b5e4a34b77849d45949d540"
 
 [[package]]
 name = "stdweb"
@@ -3046,9 +3075,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6da2e8d107dfd7b74df5ef4d205c6aebee0706c647f6bc6a2d5789905c00fb"
+checksum = "863246aaf5ddd0d6928dfeb1a9ca65f505599e4e1b399935ef7e75107516b4ef"
 dependencies = [
  "clap",
  "lazy_static",
@@ -3057,9 +3086,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a489c87c08fbaf12e386665109dd13470dcc9c4583ea3e10dd2b4523e5ebd9ac"
+checksum = "d239ca4b13aee7a2142e6795cbd69e457665ff8037aed33b3effdc430d2f927a"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -3085,9 +3114,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.17"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
+checksum = "95b5f192649e48a5302a13f2feb224df883b98933222369e4b3b0fe2a5447269"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3179,18 +3208,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b3d3d2ff68104100ab257bb6bb0cb26c901abe4bd4ba15961f3bf867924012"
+checksum = "5976891d6950b4f68477850b5b9e5aa64d955961466f9e174363f573e54e8ca7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca972988113b7715266f91250ddb98070d033c62a011fa0fcc57434a649310dd"
+checksum = "ab81dbd1cd69cd2ce22ecfbdd3bdb73334ba25350649408cc6c085f46d89573d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3227,16 +3256,16 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.10"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cacbd5ebf7b211db6d9500b8b033c20b6e333a68368a9e8d3a1d073bb1f0a12a"
+checksum = "3a51cadc5b1eec673a685ff7c33192ff7b7603d0b75446fb354939ee615acb15"
 dependencies = [
  "cfg-if",
  "libc",
- "rustversion",
  "standback",
  "stdweb",
  "time-macros",
+ "version_check 0.9.1",
  "winapi 0.3.8",
 ]
 
@@ -3265,9 +3294,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.18"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ef16d072d2b6dc8b4a56c70f5c5ced1a37752116f8e7c1e80c659aa7cb6713"
+checksum = "d099fa27b9702bed751524694adbe393e18b36b204da91eb1cbbbbb4a5ee2d58"
 dependencies = [
  "bytes 0.5.4",
  "fnv",
@@ -3310,9 +3339,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tls"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bde02a3a5291395f59b06ec6945a3077602fac2b07eeeaf0dee2122f3619828"
+checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
 dependencies = [
  "native-tls",
  "tokio",
@@ -3525,9 +3554,9 @@ checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "untrusted"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60369ef7a31de49bcb3f6ca728d4ba7300d9a1658f94c727d4cab8c8d9f4aece"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
@@ -3581,9 +3610,9 @@ checksum = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
 
 [[package]]
 name = "vec_map"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -3752,7 +3781,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "k8s-openapi",
+ "k8s-openapi 0.8.0",
  "kube",
  "kubelet",
  "log 0.4.8",
@@ -3805,7 +3834,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "futures",
- "k8s-openapi",
+ "k8s-openapi 0.8.0",
  "kube",
  "kubelet",
  "log 0.4.8",
@@ -3820,9 +3849,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc57ce05287f8376e998cbddfb4c8cb43b84a7ec55cf4551d7c00eef317a47f"
+checksum = "e3c7d40d09cdbf0f4895ae58cf57d92e1e57a9dd8ed2e8390514b54a47cc5551"
 dependencies = [
  "cfg-if",
  "serde",
@@ -3832,9 +3861,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967d37bf6c16cca2973ca3af071d0a2523392e4a594548155d89a678f4237cd"
+checksum = "c3972e137ebf830900db522d6c8fd74d1900dcfc733462e9a12e942b00b4ac94"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3847,9 +3876,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7add542ea1ac7fdaa9dc25e031a6af33b7d63376292bd24140c637d00d1c312a"
+checksum = "8a369c5e1dfb7569e14d62af4da642a3cbc2f9a3652fe586e26ac22222aa4b04"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3859,9 +3888,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd151b63e1ea881bb742cd20e1d6127cef28399558f3b5d415289bc41eee3a4"
+checksum = "2cd85aa2c579e8892442954685f0d801f9129de24fa2136b2c6a539c76b65776"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3869,9 +3898,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68a5b36eef1be7868f668632863292e37739656a80fc4b9acec7b0bd35a4931"
+checksum = "8eb197bd3a47553334907ffd2f16507b4f4f01bbec3ac921a7719e0decdfe72a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3882,9 +3911,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf76fe7d25ac79748a37538b7daeed1c7a6867c92d3245c12c6222e4a20d639"
+checksum = "a91c2916119c17a8e316507afaaa2dd94b47646048014bbdf6bef098c1bb58ad"
 
 [[package]]
 name = "wasmparser"
@@ -3923,7 +3952,7 @@ checksum = "d39ba645aee700b29ff0093028b4123556dd142a74973f04ed6225eedb40e77d"
 dependencies = [
  "anyhow",
  "faerie",
- "gimli",
+ "gimli 0.20.0",
  "more-asserts",
  "target-lexicon",
  "thiserror",
@@ -3938,7 +3967,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed54fd9d64dfeeee7c285fd126174a6b5e6d4efc7e5a1566fdb635e60ff6a74e"
 dependencies = [
  "anyhow",
- "base64 0.12.0",
+ "base64 0.12.1",
  "bincode",
  "cranelift-codegen",
  "cranelift-entity",
@@ -3973,7 +4002,7 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "cranelift-wasm",
- "gimli",
+ "gimli 0.20.0",
  "log 0.4.8",
  "more-asserts",
  "region",
@@ -3995,10 +4024,10 @@ checksum = "4b0b0c85eda9345e1dc260c7e3e532dd3544dc0e885b0d35aab7ceb95664fd4d"
 dependencies = [
  "anyhow",
  "cfg-if",
- "gimli",
+ "gimli 0.20.0",
  "lazy_static",
  "libc",
- "object",
+ "object 0.18.0",
  "scroll",
  "serde",
  "target-lexicon",
@@ -4069,9 +4098,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.37"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6f51648d8c56c366144378a33290049eafdd784071077f6fe37dae64c1c4cb"
+checksum = "8bc359e5dd3b46cb9687a051d50a2fdd228e4ba7cf6fcf861a5365c3d671a642"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -857,6 +857,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ct-logs"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3686f5fa27dbc1d76c751300376e167c5a43387f44bb451fd1c24776e49113"
+dependencies = [
+ "sct",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1483,16 +1492,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.4.1"
+name = "hyper-rustls"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3adcd308402b9553630734e9c36b77a7e48b3821251ca2493e8cd596763aafaa"
+checksum = "ac965ea399ec3a25ac7d13b8affd4b8f39325cca00858ddf5eb29b79e6b14b08"
 dependencies = [
  "bytes 0.5.4",
+ "ct-logs",
+ "futures-util",
  "hyper",
- "native-tls",
+ "log",
+ "rustls",
+ "rustls-native-certs",
  "tokio",
- "tokio-tls",
+ "tokio-rustls",
+ "webpki",
 ]
 
 [[package]]
@@ -1600,23 +1614,6 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96affb18356fc998baa692c2185d198095ffdf6e6fff3bc9efb4927952f86851"
-dependencies = [
- "base64 0.11.0",
- "bytes 0.5.4",
- "chrono",
- "http 0.2.1",
- "percent-encoding 2.1.0",
- "serde",
- "serde-value",
- "serde_json",
- "url 2.1.1",
-]
-
-[[package]]
-name = "k8s-openapi"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae6d236dfb2b60d27cdbcb3d20511713aff6d23f9bf2f3d6b594c232ea99e04"
@@ -1650,7 +1647,7 @@ dependencies = [
  "dirs",
  "env_logger 0.7.1",
  "futures",
- "k8s-openapi 0.7.1",
+ "k8s-openapi",
  "kube",
  "kubelet",
  "oci-distribution",
@@ -1683,6 +1680,7 @@ dependencies = [
  "log 0.4.8",
  "openssl",
  "reqwest",
+ "rustls",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1704,7 +1702,7 @@ dependencies = [
  "hostname",
  "http 0.2.1",
  "hyper",
- "k8s-openapi 0.8.0",
+ "k8s-openapi",
  "kube",
  "lazy_static",
  "log 0.4.8",
@@ -2586,7 +2584,7 @@ dependencies = [
  "http 0.2.1",
  "http-body",
  "hyper",
- "hyper-tls",
+ "hyper-rustls",
  "js-sys",
  "lazy_static",
  "log 0.4.8",
@@ -2595,16 +2593,18 @@ dependencies = [
  "native-tls",
  "percent-encoding 2.1.0",
  "pin-project-lite",
+ "rustls",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "time 0.1.43",
  "tokio",
- "tokio-tls",
+ "tokio-rustls",
  "url 2.1.1",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -3781,7 +3781,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "k8s-openapi 0.8.0",
+ "k8s-openapi",
  "kube",
  "kubelet",
  "log 0.4.8",
@@ -3834,7 +3834,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "futures",
- "k8s-openapi 0.8.0",
+ "k8s-openapi",
  "kube",
  "kubelet",
  "log 0.4.8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 anyhow = "1.0"
 tokio = { version = "0.2", features = ["macros"] }
-kube = "0.33"
+kube = "0.34"
 env_logger = "0.7"
 kubelet = { path = "./crates/kubelet", version = "0.2", features = ["cli"] }
 wascc-provider = { path = "./crates/wascc-provider", version = "0.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,15 +33,20 @@ exclude = [
 [badges]
 maintenance = { status = "actively-developed" }
 
+[features]
+default = ["native-tls"]
+native-tls = ["kube/native-tls", "kubelet/kube-native-tls", "wasi-provider/native-tls", "wascc-provider/native-tls", "oci-distribution/native-tls"]
+rustls-tls = ["kube/rustls-tls", "kubelet/rustls-tls", "wasi-provider/rustls-tls", "wascc-provider/rustls-tls", "oci-distribution/rustls-tls"]
+
 [dependencies]
 anyhow = "1.0"
 tokio = { version = "0.2", features = ["macros"] }
-kube = { version= "0.34", default-features = false, features = ["rustls-tls"] }
+kube = { version= "0.34", default-features = false }
 env_logger = "0.7"
-kubelet = { path = "./crates/kubelet", version = "0.2", features = ["cli"] }
-wascc-provider = { path = "./crates/wascc-provider", version = "0.2" }
-wasi-provider = { path = "./crates/wasi-provider", version = "0.2" }
-oci-distribution = { path = "./crates/oci-distribution", version = "0.1" }
+kubelet = { path = "./crates/kubelet", version = "0.2", default-features = false, features = ["cli"] }
+wascc-provider = { path = "./crates/wascc-provider", version = "0.2", default-features = false }
+wasi-provider = { path = "./crates/wasi-provider", version = "0.2", default-features = false }
+oci-distribution = { path = "./crates/oci-distribution", version = "0.1", default-features = false }
 
 [dev-dependencies]
 futures = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 anyhow = "1.0"
 tokio = { version = "0.2", features = ["macros"] }
-kube = "0.34"
+kube = { version= "0.34", default-features = false, features = ["rustls-tls"] }
 env_logger = "0.7"
 kubelet = { path = "./crates/kubelet", version = "0.2", features = ["cli"] }
 wascc-provider = { path = "./crates/wascc-provider", version = "0.2" }
@@ -48,8 +48,8 @@ futures = "0.3"
 serde_derive = "1.0"
 serde_json = "1.0"
 serde = "1.0"
-k8s-openapi = { version = "0.7.1", default-features = false, features = ["v1_17"] }
-reqwest = "0.10"
+k8s-openapi = { version = "0.8", default-features = false, features = ["v1_17"] }
+reqwest = { version = "0.10", default-features = false }
 dirs = "2.0"
 tempfile = "3.1"
 

--- a/crates/kubelet/Cargo.toml
+++ b/crates/kubelet/Cargo.toml
@@ -25,6 +25,13 @@ keywords = [
 [badges]
 maintenance = { status = "actively-developed" }
 
+[features]
+default = ["kube-native-tls"]
+kube-native-tls = ["kube/native-tls", "oci-distribution/native-tls"]
+rustls-tls = ["kube/rustls-tls", "oci-distribution/rustls-tls"]
+cli = ["structopt"]
+docs = ["cli"]
+
 [dependencies]
 async-trait = "0.1"
 dirs = "2.0"
@@ -36,7 +43,7 @@ hyper = { version = "0.13", default-features = false, features = ["stream"] }
 log = "0.4"
 reqwest = "0.10"
 tokio  = { version = "0.2", features = ["fs", "stream", "macros", "signal"] }
-kube = { version= "0.34", default-features = false, features = ["rustls-tls"] }
+kube = { version= "0.34", default-features = false }
 k8s-openapi = { version = "0.8", default-features = false, features = ["v1_17"] }
 chrono = { version = "0.4", features = ["serde"] }
 structopt = { version = "0.3", features = ["wrap_help"], optional = true }
@@ -45,17 +52,13 @@ native-tls = "0.2"
 tokio-tls = "0.3"
 thiserror = "1.0"
 lazy_static = "1.4"
-oci-distribution = { path = "../oci-distribution", version = "0.1.0" }
+oci-distribution = { path = "../oci-distribution", version = "0.1", default-features = false }
 url = "2.1"
 warp = { version = "0.2", features = ['tls'] }
 http = "0.2"
 
 [dev-dependencies]
 reqwest = {version = "0.10", default-features = false }
-
-[features]
-cli = ["structopt"]
-docs = ["cli"]
 
 [package.metadata.docs.rs]
 features = ["docs"]

--- a/crates/kubelet/Cargo.toml
+++ b/crates/kubelet/Cargo.toml
@@ -36,8 +36,8 @@ hyper = { version = "0.13", default-features = false, features = ["stream"] }
 log = "0.4"
 reqwest = "0.10"
 tokio  = { version = "0.2", features = ["fs", "stream", "macros", "signal"] }
-kube = "0.33"
-k8s-openapi = { version = "0.7", default-features = false, features = ["v1_17"] }
+kube = "0.34" 
+k8s-openapi = { version = "0.8", default-features = false, features = ["v1_17"] }
 chrono = { version = "0.4", features = ["serde"] }
 structopt = { version = "0.3", features = ["wrap_help"], optional = true }
 hostname = "0.3"

--- a/crates/kubelet/Cargo.toml
+++ b/crates/kubelet/Cargo.toml
@@ -36,7 +36,7 @@ hyper = { version = "0.13", default-features = false, features = ["stream"] }
 log = "0.4"
 reqwest = "0.10"
 tokio  = { version = "0.2", features = ["fs", "stream", "macros", "signal"] }
-kube = "0.34" 
+kube = { version= "0.34", default-features = false, features = ["rustls-tls"] }
 k8s-openapi = { version = "0.8", default-features = false, features = ["v1_17"] }
 chrono = { version = "0.4", features = ["serde"] }
 structopt = { version = "0.3", features = ["wrap_help"], optional = true }
@@ -49,6 +49,9 @@ oci-distribution = { path = "../oci-distribution", version = "0.1.0" }
 url = "2.1"
 warp = { version = "0.2", features = ['tls'] }
 http = "0.2"
+
+[dev-dependencies]
+reqwest = {version = "0.10", default-features = false }
 
 [features]
 cli = ["structopt"]

--- a/crates/kubelet/src/server.rs
+++ b/crates/kubelet/src/server.rs
@@ -99,7 +99,7 @@ async fn post_exec<T: 'static + Provider + Send + Sync>(
 ) -> Result<Response<Body>, Infallible> {
     return_with_code(
         StatusCode::NOT_IMPLEMENTED,
-        format!("Exec not implemented."),
+        "Exec not implemented.".to_string(),
     )
 }
 

--- a/crates/oci-distribution/Cargo.toml
+++ b/crates/oci-distribution/Cargo.toml
@@ -24,7 +24,7 @@ keywords = [
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-reqwest = { version = "0.10", features = ["json", "stream"] }
+reqwest = { version = "0.10", default-features=false, features = ["json", "stream", "rustls-tls"] }
 anyhow = "1.0"
 tokio = {version  = "0.2", features = ["macros", "fs"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/oci-distribution/Cargo.toml
+++ b/crates/oci-distribution/Cargo.toml
@@ -23,10 +23,15 @@ keywords = [
 [badges]
 maintenance = { status = "actively-developed" }
 
+[features]
+default = ["native-tls"]
+native-tls = ["reqwest/native-tls"]
+rustls-tls = ["reqwest/rustls-tls"]
+
 [dependencies]
-reqwest = { version = "0.10", default-features=false, features = ["json", "stream", "rustls-tls"] }
+reqwest = { version = "0.10", default-features = false, features = ["json", "stream"] }
 anyhow = "1.0"
-tokio = {version  = "0.2", features = ["macros", "fs"] }
+tokio = { version  = "0.2", features = ["macros", "fs"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 www-authenticate = "0.3"

--- a/crates/wascc-provider/Cargo.toml
+++ b/crates/wascc-provider/Cargo.toml
@@ -13,6 +13,11 @@ authors = [
 edition = "2018"
 publish = false
 
+[features]
+default = ["native-tls"]
+native-tls = ["kube/native-tls", "kubelet/kube-native-tls"]
+rustls-tls = ["kube/rustls-tls", "kubelet/rustls-tls"]
+
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
@@ -21,8 +26,8 @@ log = "0.4"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-kube = { version= "0.34", default-features = false, features = ["rustls-tls"] }
-kubelet = { path = "../kubelet", version = "0.2" }
+kube = { version= "0.34", default-features = false }
+kubelet = { path = "../kubelet", version = "0.2", default-features = false }
 tokio = { version = "0.2", features = ["fs", "macros"] }
 chrono = { version = "0.4", features = ["serde"] }
 tempfile = "3.1"
@@ -30,7 +35,7 @@ wascc-codec = "0.6"
 wascc-fs = { version = "0.0.5", features = ["static_plugin"] }
 wascc-logging = { path = "../wascc-logging", version = "0.1", features = ["static_plugin"] }
 wascc-httpsrv = { version = "0.6", features = ["static_plugin"] }
-k8s-openapi = { version = "0.8", features = ["v1_17"] }
+k8s-openapi = { version = "0.8", default-features = false, features = ["v1_17"] }
 
 [dev-dependencies]
 oci-distribution = { path = "../oci-distribution", version = "0.1" }

--- a/crates/wascc-provider/Cargo.toml
+++ b/crates/wascc-provider/Cargo.toml
@@ -21,7 +21,7 @@ log = "0.4"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-kube = "0.34"
+kube = { version= "0.34", default-features = false, features = ["rustls-tls"] }
 kubelet = { path = "../kubelet", version = "0.2" }
 tokio = { version = "0.2", features = ["fs", "macros"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/wascc-provider/Cargo.toml
+++ b/crates/wascc-provider/Cargo.toml
@@ -21,7 +21,7 @@ log = "0.4"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-kube = "0.33"
+kube = "0.34"
 kubelet = { path = "../kubelet", version = "0.2" }
 tokio = { version = "0.2", features = ["fs", "macros"] }
 chrono = { version = "0.4", features = ["serde"] }
@@ -30,7 +30,7 @@ wascc-codec = "0.6"
 wascc-fs = { version = "0.0.5", features = ["static_plugin"] }
 wascc-logging = { path = "../wascc-logging", version = "0.1", features = ["static_plugin"] }
 wascc-httpsrv = { version = "0.6", features = ["static_plugin"] }
-k8s-openapi = { version = "0.7", features = ["v1_17"] }
+k8s-openapi = { version = "0.8", features = ["v1_17"] }
 
 [dev-dependencies]
 oci-distribution = { path = "../oci-distribution", version = "0.1" }

--- a/crates/wasi-provider/Cargo.toml
+++ b/crates/wasi-provider/Cargo.toml
@@ -16,7 +16,7 @@ publish = false
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-kube = "0.33"
+kube = "0.34" 
 log = "0.4"
 wasmtime = "0.16"
 wasmtime-wasi = "0.16"
@@ -27,7 +27,7 @@ wat = "1.0"
 tokio = { version = "0.2", features = ["fs", "stream", "macros", "io-util", "sync"] }
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
-k8s-openapi = { version = "0.7", features = ["v1_17"] }
+k8s-openapi = { version = "0.8", features = ["v1_17"] }
 
 [dev-dependencies]
 oci-distribution = { path = "../oci-distribution", version = "0.1.0" }

--- a/crates/wasi-provider/Cargo.toml
+++ b/crates/wasi-provider/Cargo.toml
@@ -13,21 +13,26 @@ authors = [
 edition = "2018"
 publish = false
 
+[features]
+default = ["native-tls"]
+native-tls = ["kube/native-tls", "kubelet/kube-native-tls"]
+rustls-tls = ["kube/rustls-tls", "kubelet/rustls-tls"]
+
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-kube = { version= "0.34", default-features = false, features = ["rustls-tls"] }
+kube = { version= "0.34", default-features = false }
 log = "0.4"
 wasmtime = "0.16"
 wasmtime-wasi = "0.16"
 wasi-common = "0.16"
 tempfile = "3.1"
-kubelet = { path = "../kubelet", version = "0.2" }
+kubelet = { path = "../kubelet", version = "0.2", default-features = false }
 wat = "1.0"
 tokio = { version = "0.2", features = ["fs", "stream", "macros", "io-util", "sync"] }
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
-k8s-openapi = { version = "0.8", features = ["v1_17"] }
+k8s-openapi = { version = "0.8", default-features = false, features = ["v1_17"] }
 
 [dev-dependencies]
 oci-distribution = { path = "../oci-distribution", version = "0.1.0" }

--- a/crates/wasi-provider/Cargo.toml
+++ b/crates/wasi-provider/Cargo.toml
@@ -16,7 +16,7 @@ publish = false
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-kube = "0.34" 
+kube = { version= "0.34", default-features = false, features = ["rustls-tls"] }
 log = "0.4"
 wasmtime = "0.16"
 wasmtime-wasi = "0.16"


### PR DESCRIPTION
This makes it so we don't have to compile against specific versions
of openssl and might make Windows easier.

This also updates our kube and openapi dependencies

Closes #247