### PR TITLE
Graceful shutdown. 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1748,6 +1748,7 @@ dependencies = [
  "rpassword",
  "serde",
  "serde_json",
+ "signal-hook",
  "structopt",
  "thiserror",
  "tokio",
@@ -2872,6 +2873,16 @@ dependencies = [
  "digest",
  "fake-simd",
  "opaque-debug",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ff2db2112d6c761e12522c65f7768548bd6e8cd23d2a9dae162520626629bd6"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1748,7 +1748,6 @@ dependencies = [
  "rpassword",
  "serde",
  "serde_json",
- "signal-hook",
  "structopt",
  "thiserror",
  "tokio",
@@ -2873,16 +2872,6 @@ dependencies = [
  "digest",
  "fake-simd",
  "opaque-debug",
-]
-
-[[package]]
-name = "signal-hook"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff2db2112d6c761e12522c65f7768548bd6e8cd23d2a9dae162520626629bd6"
-dependencies = [
- "libc",
- "signal-hook-registry",
 ]
 
 [[package]]

--- a/crates/kubelet/Cargo.toml
+++ b/crates/kubelet/Cargo.toml
@@ -22,7 +22,7 @@ serde_json = "1.0"
 hyper = { version = "0.13", default-features = false, features = ["stream"] }
 log = "0.4"
 reqwest = "0.10"
-tokio  = { version = "0.2", features = ["fs", "stream", "macros"] }
+tokio  = { version = "0.2", features = ["fs", "stream", "macros", "signal"] }
 kube = "0.33" 
 k8s-openapi = { version = "0.7", default-features = false, features = ["v1_17"] }
 chrono = { version = "0.4", features = ["serde"] }
@@ -35,7 +35,6 @@ lazy_static = "1.4"
 oci-distribution = { path = "../oci-distribution", version = "0.1.0" }
 rpassword = "4.0"
 url = "2.1"
-signal-hook = "0.1"
 
 [features]
 cli = ["structopt"]

--- a/crates/kubelet/Cargo.toml
+++ b/crates/kubelet/Cargo.toml
@@ -35,6 +35,7 @@ lazy_static = "1.4"
 oci-distribution = { path = "../oci-distribution", version = "0.1.0" }
 rpassword = "4.0"
 url = "2.1"
+signal-hook = "0.1"
 
 [features]
 cli = ["structopt"]

--- a/crates/kubelet/src/config.rs
+++ b/crates/kubelet/src/config.rs
@@ -7,7 +7,6 @@ use std::net::IpAddr;
 use std::net::ToSocketAddrs;
 use std::path::PathBuf;
 
-use rpassword;
 #[cfg(feature = "cli")]
 use structopt::StructOpt;
 

--- a/crates/kubelet/src/kubelet.rs
+++ b/crates/kubelet/src/kubelet.rs
@@ -139,7 +139,7 @@ impl<T: 'static + Provider + Sync + Send> Kubelet<T> {
         let webserver = start_webserver(self.provider.clone(), &self.config.server_config);
 
         let term = Arc::new(AtomicBool::new(false));
-        signal_hook::flag::register(signal_hook::SIGTERM, Arc::clone(&term))?;
+        signal_hook::flag::register(signal_hook::SIGINT, Arc::clone(&term))?;
         let node_name = self.config.node_name.clone();
         let signal_handler = tokio::task::spawn(async move {
             let duration = std::time::Duration::from_millis(100);

--- a/crates/kubelet/src/kubelet.rs
+++ b/crates/kubelet/src/kubelet.rs
@@ -1,11 +1,12 @@
 ///! This library contains code for running a kubelet. Use this to create a new
 ///! Kubelet with a specific handler (called a `Provider`)
 use crate::config::Config;
-use crate::node::{cordon_node, create_node, update_node};
+use crate::node::{create_node, delete_node, drain_node, update_node};
 use crate::queue::PodQueue;
 use crate::server::start_webserver;
 use crate::status::{update_pod_status, Phase};
 use crate::Provider;
+use futures::future::FutureExt;
 use futures::{StreamExt, TryStreamExt};
 use k8s_openapi::api::core::v1::Pod as KubePod;
 use kube::{
@@ -53,116 +54,77 @@ impl<T: 'static + Provider + Sync + Send> Kubelet<T> {
     /// events, which it will handle.
     pub async fn start(&self) -> anyhow::Result<()> {
         let client = kube::Client::new(self.kube_config.clone());
-        let handler_client = client.clone();
+
         // Create the node. If it already exists, "adopt" the node definition
         create_node(&client, &self.config, self.provider.clone()).await;
 
-        // Get the node name for use in the update loop
-        let node_name = self.config.node_name.clone();
-        // Start updating the node lease periodically
-        let update_client = client.clone();
-        let node_updater = tokio::task::spawn(async move {
-            let sleep_interval = std::time::Duration::from_secs(10);
-            loop {
-                update_node(&update_client, &node_name).await;
-                tokio::time::delay_for(sleep_interval).await;
-            }
-        });
-
-        // TODO: How should we configure this value? We should eventually have a max pods setting
-        // just like a normal kubelet, so maybe that?
-        let (error_sender, mut error_receiver) = mpsc::channel::<(KubePod, anyhow::Error)>(200);
-        let client_clone = client.clone();
-        let error_handler = tokio::task::spawn(async move {
-            let client = client_clone;
-            while let Some((pod, err)) = error_receiver.recv().await {
-                let json_status = serde_json::json!(
-                    {
-                        "metadata": {
-                            "resourceVersion": "",
-                        },
-                        "status": {
-                            "phase": Phase::Failed,
-                            "message": format!("{}", err),
-                        }
-                    }
-                );
-
-                debug!(
-                    "Setting pod status for {} using {:?}",
-                    pod.name(),
-                    json_status
-                );
-                let pod_name = pod.name();
-                match update_pod_status(
-                    client.clone(),
-                    &pod.namespace().unwrap_or_default(),
-                    &pod_name,
-                    &json_status,
-                )
-                .await
-                {
-                    Ok(_) => (),
-                    Err(e) => error!(
-                        "Unable to patch status during pod failure for {}: {}",
-                        pod_name, e
-                    ),
-                }
-            }
-        });
-
-        // Create a queue that locks on events per pod
-        let mut queue = PodQueue::new(self.provider.clone(), error_sender);
-
-        let node_selector = format!("spec.nodeName={}", self.config.node_name);
-        let pod_informer = tokio::task::spawn(async move {
-            // Create our informer and start listening.
-            let params = ListParams {
-                field_selector: Some(node_selector),
-                ..Default::default()
-            };
-            let api = Api::<KubePod>::all(client);
-            let informer = Informer::new(api).params(params);
-            loop {
-                let mut stream = informer.poll().await.expect("informer poll failed").boxed();
-                while let Some(event) = stream.try_next().await.unwrap() {
-                    debug!("Handling Kubernetes pod event: {:?}", event);
-                    match queue.enqueue(event).await {
-                        Ok(()) => debug!("Enqueued event for processing"),
-                        Err(e) => warn!("Error enqueuing pod event: {}", e),
-                    };
-                }
-            }
-        });
+        // Flag to indicate graceful shutdown has started.
+        let signal = Arc::new(AtomicBool::new(false));
+        signal_hook::flag::register(signal_hook::SIGINT, Arc::clone(&signal))?;
 
         // Start the webserver
-        let webserver = start_webserver(self.provider.clone(), &self.config.server_config);
+        let webserver = start_webserver(self.provider.clone(), &self.config.server_config).fuse();
 
-        let term = Arc::new(AtomicBool::new(false));
-        signal_hook::flag::register(signal_hook::SIGINT, Arc::clone(&term))?;
-        let node_name = self.config.node_name.clone();
-        let signal_handler = tokio::task::spawn(async move {
-            let duration = std::time::Duration::from_millis(100);
-            loop {
-                if term.load(Ordering::Relaxed) {
-                    warn!("Signal caught.");
-                    cordon_node(&handler_client, &node_name).await;
-                    // TODO: Evict Pods
-                    // TODO: Delete node
-                    break;
+        let (error_sender, error_receiver) =
+            mpsc::channel::<(KubePod, anyhow::Error)>(self.config.max_pods as usize);
+        let error_handler = start_error_handler(error_receiver, client.clone()).fuse();
+
+        // Start updating the node lease periodically
+        let node_updater = start_node_updater(
+            Arc::clone(&signal),
+            client.clone(),
+            self.config.node_name.clone(),
+        )
+        .fuse();
+
+        // If any of these tasks fail, we can initiate graceful shutdown.
+        let services = async {
+            futures::pin_mut!(webserver, error_handler, node_updater);
+
+            futures::select! {
+                res = error_handler => error!("Error handler task completed with result: {:?}", &res),
+                res = webserver => error!("Webserver task completed with result {:?}", &res),
+                res = node_updater => if let Err(e) = res {
+                    error!("Node updater task completed with error {:?}", &e);
                 }
-                tokio::time::delay_for(duration).await;
-            }
-        });
-
-        let threads = async {
-            futures::try_join!(node_updater, pod_informer, error_handler, signal_handler)?;
-            Ok(())
+            };
+            signal.store(true, Ordering::Relaxed);
+            Ok::<(), anyhow::Error>(())
         };
 
-        // Return an error as soon as either the webserver or the threads error
-        futures::try_join!(webserver, threads)?;
+        // Periodically checks for shutdown signal and cleans up resources gracefully if caught.
+        let signal_handler = start_signal_handler(
+            Arc::clone(&signal),
+            client.clone(),
+            self.config.node_name.clone(),
+        )
+        .fuse();
 
+        // Create a queue that locks on events per pod
+        let queue = PodQueue::new(self.provider.clone(), error_sender);
+        let pod_informer =
+            start_pod_informer::<T>(client.clone(), self.config.node_name.clone(), queue).fuse();
+
+        // These must all be running for graceful shutdown. An error here exits ungracefully.
+        let core = async {
+            futures::pin_mut!(pod_informer, signal_handler);
+
+            futures::select! {
+                res = signal_handler => res.map_err(|e| {
+                    error!("Signal handler task joined with error {:?}", &e);
+                    e.into()
+                }),
+                res = pod_informer => res.map_err(|e| {
+                    error!("Pod informer task joined with error {:?}", &e);
+                    e.into()
+                })
+            }
+        };
+
+        // Services will not return an error, so this will wait for both to return, or core to
+        // return an error. Services will return if signal is set because node_updater checks this
+        // and will exit.
+        futures::try_join!(core, services)?;
         Ok(())
     }
 }
@@ -177,6 +139,107 @@ impl<P> Clone for Kubelet<P> {
             config: self.config.clone(),
         }
     }
+}
+
+/// Listens for updates to pods on this node and forwards them to queue.
+async fn start_pod_informer<P: 'static + Provider + Sync + Send>(
+    client: kube::Client,
+    node_name: String,
+    mut queue: PodQueue<P>,
+) -> anyhow::Result<()> {
+    let node_selector = format!("spec.nodeName={}", node_name);
+    let params = ListParams {
+        field_selector: Some(node_selector),
+        ..Default::default()
+    };
+    let api = Api::<KubePod>::all(client);
+    let informer = Informer::new(api).params(params);
+    loop {
+        // TODO Should these results be ignored if Err? It seems reasonable to just keep trying,
+        // especially since this function is critical for a graceful shutdown.
+        let mut stream = informer.poll().await?.boxed();
+        while let Some(event) = stream.try_next().await? {
+            debug!("Handling Kubernetes pod event: {:?}", event);
+            match queue.enqueue(event).await {
+                Ok(()) => debug!("Enqueued event for processing"),
+                Err(e) => warn!("Error enqueuing pod event: {}", e),
+            };
+        }
+    }
+}
+
+/// Periodically renew node lease. Exits if signal is caught.
+async fn start_node_updater(
+    signal: Arc<AtomicBool>,
+    client: kube::Client,
+    node_name: String,
+) -> anyhow::Result<()> {
+    let sleep_interval = std::time::Duration::from_secs(10);
+    while !signal.load(Ordering::Relaxed) {
+        update_node(&client, &node_name).await;
+        tokio::time::delay_for(sleep_interval).await;
+    }
+    Ok(())
+}
+
+/// Checks for shutdown signal and cleans up resources gracefully.
+async fn start_signal_handler(
+    signal: Arc<AtomicBool>,
+    client: kube::Client,
+    node_name: String,
+) -> anyhow::Result<()> {
+    let duration = std::time::Duration::from_millis(100);
+    loop {
+        if signal.load(Ordering::Relaxed) {
+            warn!("Signal caught.");
+            drain_node(&client, &node_name).await?;
+            delete_node(&client, &node_name).await?;
+            break Ok(());
+        }
+        tokio::time::delay_for(duration).await;
+    }
+}
+
+/// Consumes error channel and notifies API server of pod failures.
+async fn start_error_handler(
+    mut rx: mpsc::Receiver<(KubePod, anyhow::Error)>,
+    client: kube::Client,
+) -> anyhow::Result<()> {
+    while let Some((pod, err)) = rx.recv().await {
+        let json_status = serde_json::json!(
+            {
+                "metadata": {
+                    "resourceVersion": "",
+                },
+                "status": {
+                    "phase": Phase::Failed,
+                    "message": format!("{}", err),
+                }
+            }
+        );
+
+        debug!(
+            "Setting pod status for {} using {:?}",
+            pod.name(),
+            json_status
+        );
+        let pod_name = pod.name();
+        match update_pod_status(
+            client.clone(),
+            &pod.namespace().unwrap_or_default(),
+            &pod_name,
+            &json_status,
+        )
+        .await
+        {
+            Ok(_) => (),
+            Err(e) => error!(
+                "Unable to patch status during pod failure for {}: {}",
+                pod_name, e
+            ),
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/kubelet/src/pod.rs
+++ b/crates/kubelet/src/pod.rs
@@ -95,9 +95,8 @@ impl Pod {
     pub fn is_daemonset(&self) -> bool {
         if let Some(owners) = &self.0.meta().owner_references {
             for owner in owners {
-                match owner.kind.as_ref() {
-                    "DaemonSet" => return true,
-                    _ => (),
+                if owner.kind == "DaemonSet" {
+                    return true;
                 }
             }
         }

--- a/crates/kubelet/src/pod.rs
+++ b/crates/kubelet/src/pod.rs
@@ -84,6 +84,26 @@ impl Pod {
             .unwrap_or_else(|| &EMPTY_MAP)
     }
 
+    /// Indicate if this pod is a static pod.
+    /// TODO: A missing owner_references field was an indication of static pod in my testing but I
+    /// dont know how reliable this is.
+    pub fn is_static(&self) -> bool {
+        self.0.meta().owner_references.is_none()
+    }
+
+    /// Indicate if this pod is part of a Daemonset
+    pub fn is_daemonset(&self) -> bool {
+        if let Some(owners) = &self.0.meta().owner_references {
+            for owner in owners {
+                match owner.kind.as_ref() {
+                    "DaemonSet" => return true,
+                    _ => (),
+                }
+            }
+        }
+        false
+    }
+
     ///  Get a specific annotation from the pod
     pub fn get_annotation(&self, key: &str) -> Option<&str> {
         Some(self.annotations().get(key)?.as_str())


### PR DESCRIPTION
I wanted to invite comments on what I have been working on:

* Catch sigterm and certain errors and trigger graceful shutdown.
* Graceful shutdown cordons node and evicts pods, before deregistering it with the apiserver.
* Refactor kubelet futures for readability.
* Rework the combinators used for kubelet futures to enable graceful error handling.

This seems to do a good job of allowing Kubernetes to reschedule pods, rather than leaving zombie pods, and it gives the provider an opportunity to properly clean up pod resources as they are deleted. I'm not totally sure if all of this is desired behavior so I wanted to get some feedback before continuing. 
