### PR TITLE
fix(*): Updates justfile and config to work with new cert setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build and Test
 on:
   pull_request:
     paths-ignore:
-      - 'docs/**'
+      - "docs/**"
 jobs:
   build:
     runs-on: ${{ matrix.config.os }}
@@ -30,7 +30,7 @@ jobs:
           url: ${{ matrix.config.url }}
           pathInArchive: ${{ matrix.config.pathInArchive }}
       # hack(bacongobbler): install rustfmt to work around darwin toolchain issues
-      - name: '(macOS) install dev tools'
+      - name: "(macOS) install dev tools"
         if: runner.os == 'macOS'
         run: |
           rustup component add rustfmt --toolchain stable-x86_64-apple-darwin
@@ -58,6 +58,6 @@ jobs:
         run: |
           just bootstrap-ssl
           just build
-          ./target/debug/krustlet-wascc --node-name krustlet-wascc --port 3000 --tls-cert-file ./config/host.cert --tls-private-key-file ./config/host.key &
-          ./target/debug/krustlet-wasi --node-name krustlet-wasi --port 3001 --tls-cert-file ./config/host.cert --tls-private-key-file ./config/host.key &
+          ./target/debug/krustlet-wascc --node-name krustlet-wascc --port 3000 --tls-cert-file ./config/krustlet.crt --tls-private-key-file ./config/krustlet.key &
+          ./target/debug/krustlet-wasi --node-name krustlet-wasi --port 3001 --tls-cert-file ./config/krustlet.crt --tls-private-key-file ./config/krustlet.key &
           just test-e2e

--- a/docs/howto/assets/eks/files/krustlet.service
+++ b/docs/howto/assets/eks/files/krustlet.service
@@ -5,8 +5,8 @@ Description=Krustlet - a kubelet implementation for running WebAssembly
 # Global and static parameters: NODE_LABELS
 EnvironmentFile=/etc/eksctl/krustlet.local.env
 Environment=KUBECONFIG=/etc/eksctl/kubeconfig.yaml
-Environment=PFX_PATH=/etc/krustlet/cert.pfx
-Environment=PFX_PASSWORD=krustlet
+Environment=TLS_CERT_FILE=/etc/krustlet/krustlet.crt
+Environment=TLS_PRIVATE_KEY_FILE=/etc/krustlet/krustlet.key
 Environment=KRUSTLET_DATA_DIR=/var/cache/krustlet
 Environment=RUST_LOG=wascc_provider=info,wasi_provider=info,main=info
 ExecStart=/usr/local/bin/krustlet

--- a/docs/howto/assets/krustlet.service
+++ b/docs/howto/assets/krustlet.service
@@ -5,8 +5,8 @@ Description=Krustlet, a kubelet implementation for running WASM
 Restart=on-failure
 RestartSec=5s
 Environment=KUBECONFIG=/etc/krustlet/kubeconfig-sa
-Environment=PFX_PATH=/etc/krustlet/krustlet.pfx
-Environment=PFX_PASSWORD=password
+Environment=TLS_CERT_FILE=/etc/krustlet/krustlet.crt
+Environment=TLS_PRIVATE_KEY_FILE=/etc/krustlet/krustlet.key
 Environment=KRUSTLET_DATA_DIR=/etc/krustlet
 Environment=RUST_LOG=wascc_provider=info,wasi_provider=info,main=info
 ExecStart=/usr/local/bin/krustlet-wasi

--- a/docs/howto/krustlet-on-kind.md
+++ b/docs/howto/krustlet-on-kind.md
@@ -62,13 +62,6 @@ After approval, you can download the cert like so:
 $ kubectl get csr krustlet -o jsonpath='{.status.certificate}' | base64 --decode > krustlet.crt
 ```
 
-Lastly, combine the key and the cert into a PFX bundle, choosing your own password instead of
-"password":
-
-```shell
-$ openssl pkcs12 -export -out certificate.pfx -inkey krustlet.key -in krustlet.crt -password "pass:password"
-```
-
 ## Step 2: Determine the default gateway
 
 The default gateway for most Docker containers (including your KinD host) is generally `172.17.0.1`.
@@ -114,7 +107,7 @@ First, install the latest release of Krustlet following [the install guide](../i
 Once you have done that, run the following commands to run Krustlet's WASI provider:
 
 ```shell
-$ krustlet-wasi --node-ip 172.17.0.1 --pfx-password password
+$ krustlet-wasi --node-ip 172.17.0.1 --tls-cert-file=./krustlet.crt --tls-private-key-file=./krustlet.key
 ```
 
 In another terminal, run `kubectl get nodes -o wide` and you should see output that looks similar to

--- a/docs/howto/krustlet-on-microk8s.md
+++ b/docs/howto/krustlet-on-microk8s.md
@@ -104,13 +104,6 @@ $ microk8s.kubectl get csr krustlet --output=jsonpath='{.status.certificate}' \
     | base64 --decode > krustlet.crt
 ```
 
-Lastly, combine the key and the cert into a PFX bundle, choosing your own password instead of
-"password":
-
-```shell
-$ openssl pkcs12 -export -out krustlet.pfx -inkey krustlet.key -in krustlet.crt -password "pass:password"
-```
-
 ## Step 3: Install and configure Krustlet
 
 Install the latest release of Krustlet following [the install guide](../intro/install.md).
@@ -131,8 +124,8 @@ $ KUBECONFIG=/var/snap/microk8s/current/credentials/client.config \
 ./krustlet-wasi \
 --node-ip=127.0.0.1 \
 --node-name=krustlet \
---pfx-password="password" \
---pfx-path=./krustlet.pfx
+--tls-cert-file=./krustlet.crt \
+--tls-private-key-file=./krustlet.key
 ```
 
 In another terminal:

--- a/docs/howto/krustlet-on-minikube.md
+++ b/docs/howto/krustlet-on-minikube.md
@@ -66,13 +66,6 @@ After approval, you can download the cert like so:
 $ kubectl get csr krustlet -o jsonpath='{.status.certificate}' | base64 --decode > krustlet.crt
 ```
 
-Lastly, combine the key and the cert into a PFX bundle, choosing your own password instead of
-"password":
-
-```shell
-$ openssl pkcs12 -export -out certificate.pfx -inkey krustlet.key -in krustlet.crt -password "pass:password"
-```
-
 ## Step 2: Determine the default gateway
 
 The default gateway when you [set up minikube with the VirtualBox driver](kubernetes-on-minikube.md)
@@ -87,7 +80,7 @@ First, install the latest release of Krustlet following [the install guide](../i
 Once you have done that, run the following commands to run Krustlet's WASI provider:
 
 ```shell
-$ krustlet-wasi --node-ip 10.0.2.2 --pfx-password password
+$ krustlet-wasi --node-ip 10.0.2.2 --pfx-password password --tls-cert-file=./krustlet.crt --tls-private-key-file=./krustlet.key
 ```
 
 In another terminal, run `kubectl get nodes -o wide` and you should see output that looks similar to

--- a/docs/howto/krustlet-with-inlets.md
+++ b/docs/howto/krustlet-with-inlets.md
@@ -103,13 +103,6 @@ $ kubectl get csr krustlet -o jsonpath='{.status.certificate}' \
     | base64 --decode > krustlet.crt
 ```
 
-Lastly, combine the key and the cert into a PFX bundle, choosing your own password instead of
-"password":
-
-```shell
-$ openssl pkcs12 -export -out krustlet.pfx -inkey krustlet.key -in krustlet.crt -password "pass:password"
-```
-
 ## Step 3: Setup inlets server
 
 Create a Kubernetes secret for the inlets server:
@@ -234,7 +227,7 @@ export NODE_IP=$(kubectl get service inlets -o jsonpath="{.spec.clusterIP}")
 ## Step 5: Run the `krustlet` and verify the node is available
 
 ```shell
-krustlet-wasi --node-ip $NODE_IP --pfx-password password
+krustlet-wasi --node-ip $NODE_IP --pfx-password password --tls-cert-file=./krustlet.crt --tls-private-key-file=./krustlet.key
 ```
 
 Show that the krustlet node has joined the cluster:

--- a/justfile
+++ b/justfile
@@ -16,18 +16,14 @@ test:
 test-e2e:
     cargo test --test integration_tests
 
-run-wascc: _cleanup_kube bootstrap-ssl
+run-wascc: bootstrap-ssl
     cargo run --bin krustlet-wascc -- --node-name krustlet-wascc --port 3000
 
-run-wasi: _cleanup_kube bootstrap-ssl
+run-wasi: bootstrap-ssl
     cargo run --bin krustlet-wasi -- --node-name krustlet-wasi --port 3001
 
 bootstrap-ssl:
     @# This is to get around an issue with the default function returning a string that gets escaped
     @mkdir -p $(eval echo $KEY_DIR)
-    @test -f  $(eval echo $KEY_DIR)/host.key && test -f $(eval echo $KEY_DIR)/host.cert || openssl req -x509 -sha256 -newkey rsa:2048 -keyout $(eval echo $KEY_DIR)/host.key -out $(eval echo $KEY_DIR)/host.cert -days 365 -nodes -subj "/C=AU/ST=./L=./O=./OU=./CN=."
-    @test -f $(eval echo $KEY_DIR)/certificate.pfx || openssl pkcs12 -export -out  $(eval echo $KEY_DIR)/certificate.pfx -inkey  $(eval echo $KEY_DIR)/host.key -in  $(eval echo $KEY_DIR)/host.cert -password "pass:${PFX_PASSWORD}"
+    @test -f  $(eval echo $KEY_DIR)/krustlet.key && test -f $(eval echo $KEY_DIR)/krustlet.crt || openssl req -x509 -sha256 -newkey rsa:2048 -keyout $(eval echo $KEY_DIR)/krustlet.key -out $(eval echo $KEY_DIR)/krustlet.crt -days 365 -nodes -subj "/C=AU/ST=./L=./O=./OU=./CN=."
     @chmod 400 $(eval echo $KEY_DIR)/*
-
-_cleanup_kube:
-    kubectl delete --all pods --namespace=default || true


### PR DESCRIPTION
A recent change switched things back to a separate cert and key. However
the `just bootstrap` target was not updated to reflect this. I also noticed
some inconsistencies with how we were setting the default file path for
the cert and key and corrected those.

This also updates all of the docs to reflect the change