### PR TITLE
add cross-compile target config

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,5 @@
+[target.armv7-unknown-linux-gnueabihf]
+linker = "arm-linux-gnueabihf-gcc"
+
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"


### PR DESCRIPTION
This is necessary for compiling krustlet-wasi and krustlet-wascc for 64-bit ARM devices (and eventually 32-bit ARM as well, though that is currently not supported).

TODO:

- [ ] add documentation for cross-compiling

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>