### PR TITLE
Read settings from config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
  "pin-project",
  "rand 0.7.3",
  "regex",
- "serde",
+ "serde 1.0.110",
  "serde_json",
  "serde_urlencoded",
  "sha1",
@@ -93,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "actix-macros"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21705adc76bbe4bc98434890e73a89cd00c6015e5704a60bb6eea6c3b72316b6"
+checksum = "a60f9ba7c4e6df97f3aacb14bb5c0cd7d98a49dcbaed0d7f292912ad9a6a3ed2"
 dependencies = [
  "quote",
  "syn",
@@ -130,7 +130,7 @@ dependencies = [
  "http 0.2.1",
  "log 0.4.8",
  "regex",
- "serde",
+ "serde 1.0.110",
 ]
 
 [[package]]
@@ -150,21 +150,22 @@ dependencies = [
 
 [[package]]
 name = "actix-server"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "582a7173c281a4f46b5aa168a11e7f37183dcb71177a39312cc2264da7a632c9"
+checksum = "e6d74b464215a473c973a2d7d03a69cc10f4ce1f4b38a7659c5193dc5c675630"
 dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
  "actix-utils",
- "futures",
+ "futures-channel",
+ "futures-util",
  "log 0.4.8",
  "mio",
  "mio-uds",
- "net2",
  "num_cpus",
  "slab",
+ "socket2",
 ]
 
 [[package]]
@@ -179,24 +180,23 @@ dependencies = [
 
 [[package]]
 name = "actix-testing"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48494745b72d0ea8ff0cf874aaf9b622a3ee03d7081ee0c04edea4f26d32c911"
+checksum = "47239ca38799ab74ee6a8a94d1ce857014b2ac36f242f70f3f75a66f691e791c"
 dependencies = [
  "actix-macros",
  "actix-rt",
  "actix-server",
  "actix-service",
- "futures",
  "log 0.4.8",
- "net2",
+ "socket2",
 ]
 
 [[package]]
 name = "actix-threadpool"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4082192601de5f303013709ff84d81ca6a1bc4af7fb24f367a500a23c6e84e"
+checksum = "91164716d956745c79dcea5e66d2aa04506549958accefcede5368c70f2fd4ff"
 dependencies = [
  "derive_more",
  "futures-channel",
@@ -270,7 +270,7 @@ dependencies = [
  "net2",
  "pin-project",
  "regex",
- "serde",
+ "serde 1.0.110",
  "serde_json",
  "serde_urlencoded",
  "time 0.1.43",
@@ -279,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web-codegen"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f00371942083469785f7e28c540164af1913ee7c96a4534acb9cea92c39f057"
+checksum = "a71bf475cbe07281d0b3696abb48212db118e7e23219f13596ce865235ff5766"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -290,9 +290,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456d75cbb82da1ad150c8a9d97285ffcd21c9931dcb11e995903e7d75141b38b"
+checksum = "a49806b9dadc843c61e7c97e72490ad7f7220ae249012fbda9ad0609457c0543"
 dependencies = [
  "gimli 0.21.0",
 ]
@@ -338,6 +338,15 @@ name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
+dependencies = [
+ "nodrop",
+]
 
 [[package]]
 name = "arrayvec"
@@ -410,7 +419,7 @@ dependencies = [
  "mime 0.3.16",
  "percent-encoding 2.1.0",
  "rand 0.7.3",
- "serde",
+ "serde 1.0.110",
  "serde_json",
  "serde_urlencoded",
 ]
@@ -462,7 +471,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
 dependencies = [
  "byteorder",
- "serde",
+ "serde 1.0.110",
 ]
 
 [[package]]
@@ -478,7 +487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
 dependencies = [
  "arrayref",
- "arrayvec",
+ "arrayvec 0.5.1",
  "constant_time_eq",
 ]
 
@@ -598,8 +607,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
 dependencies = [
  "num-integer",
- "num-traits",
- "serde",
+ "num-traits 0.2.11",
+ "serde 1.0.110",
  "time 0.1.43",
 ]
 
@@ -644,6 +653,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "config"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b076e143e1d9538dde65da30f8481c2a6c44040edb8e02b9bf1351edb92ce3"
+dependencies = [
+ "lazy_static",
+ "nom",
+ "rust-ini",
+ "serde 1.0.110",
+ "serde-hjson",
+ "serde_json",
+ "toml",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -707,7 +732,7 @@ dependencies = [
  "gimli 0.20.0",
  "log 0.4.8",
  "regalloc",
- "serde",
+ "serde 1.0.110",
  "smallvec",
  "target-lexicon",
  "thiserror",
@@ -735,7 +760,7 @@ version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "926a73c432e5ba9c891171ff50b75e7d992cd76cd271f0a0a0ba199138077472"
 dependencies = [
- "serde",
+ "serde 1.0.110",
 ]
 
 [[package]]
@@ -771,7 +796,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-frontend",
  "log 0.4.8",
- "serde",
+ "serde 1.0.110",
  "thiserror",
  "wasmparser",
 ]
@@ -889,15 +914,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c0346158a19b3627234e15596f5e465c360fcdb97d817bcb255e0510f5a788"
+checksum = "72aa14c04dfae8dd7d8a2b1cb7ca2152618cd01336dbfe704b8dcbf8d41dbd69"
 
 [[package]]
 name = "derive_more"
-version = "0.99.5"
+version = "0.99.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2323f3f47db9a0e77ce7a300605d8d2098597fc451ed1a97bb1f6411bb550a7"
+checksum = "2127768764f1556535c01b5326ef94bd60ff08dcfbdc544d53e69ed155610f5d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1009,19 +1034,6 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
-dependencies = [
- "atty",
- "humantime",
- "log 0.4.8",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
@@ -1105,19 +1117,19 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "file-per-thread-logger"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505b75b31ef7285168dd237c4a7db3c1f3e0927e7d314e670bc98e854272fe9"
+checksum = "8b3937f028664bd0e13df401ba49a4567ccda587420365823242977f06609ed1"
 dependencies = [
- "env_logger 0.6.2",
+ "env_logger",
  "log 0.4.8",
 ]
 
 [[package]]
 name = "filetime"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f59efc38004c988e4201d11d263b8171f49a2e7ec0bdbb71773433f271504a5e"
+checksum = "affc17579b132fc2461adf7c575cc6e8b134ebca52c51f5411388965227dc695"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1316,7 +1328,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81dd6190aad0f05ddbbf3245c54ed14ca4aa6dd32f22312b70d8f168c3e3e633"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.5.1",
  "byteorder",
  "fallible-iterator",
  "indexmap",
@@ -1591,14 +1603,23 @@ dependencies = [
 
 [[package]]
 name = "ipconfig"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa79fa216fbe60834a9c0737d7fcd30425b32d1c58854663e24d4c4b328ed83f"
+checksum = "f7e2f18aece9709094573a9f24f483c4f65caa4298e2f7ae1b71cc65d853fad7"
 dependencies = [
  "socket2",
  "widestring",
  "winapi 0.3.8",
  "winreg",
+]
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1634,7 +1655,7 @@ dependencies = [
  "base64 0.12.1",
  "bytes 0.5.4",
  "chrono",
- "serde",
+ "serde 1.0.110",
  "serde-value",
  "serde_json",
 ]
@@ -1655,14 +1676,14 @@ version = "0.2.1"
 dependencies = [
  "anyhow",
  "dirs",
- "env_logger 0.7.1",
+ "env_logger",
  "futures",
  "k8s-openapi",
  "kube",
  "kubelet",
  "oci-distribution",
  "reqwest",
- "serde",
+ "serde 1.0.110",
  "serde_derive",
  "serde_json",
  "tempfile",
@@ -1691,7 +1712,7 @@ dependencies = [
  "openssl",
  "reqwest",
  "rustls 0.17.0",
- "serde",
+ "serde 1.0.110",
  "serde_json",
  "serde_yaml",
  "thiserror",
@@ -1707,6 +1728,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "config",
  "dirs",
  "futures",
  "hostname",
@@ -1719,7 +1741,7 @@ dependencies = [
  "native-tls",
  "oci-distribution",
  "reqwest",
- "serde",
+ "serde 1.0.110",
  "serde_json",
  "structopt",
  "thiserror",
@@ -1748,6 +1770,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 
 [[package]]
+name = "lexical-core"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7043aa5c05dd34fb73b47acb8c3708eac428de4545ea3682ed2f11293ebd890"
+dependencies = [
+ "arrayvec 0.4.12",
+ "cfg-if",
+ "rustc_version",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1760,6 +1795,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cadb8e769f070c45df05c78c7520eb4cd17061d4ab262e43cfc68b4d00ac71c"
 dependencies = [
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d262045c5b87c0861b3f004610afd0e2c851e2908d08b6c870cbb9d5f494ecd"
+dependencies = [
+ "serde 0.8.23",
+ "serde_test",
 ]
 
 [[package]]
@@ -1793,7 +1838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
  "cfg-if",
- "serde",
+ "serde 1.0.110",
 ]
 
 [[package]]
@@ -1802,7 +1847,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 dependencies = [
- "linked-hash-map",
+ "linked-hash-map 0.5.3",
 ]
 
 [[package]]
@@ -2004,6 +2049,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nom"
+version = "5.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b471253da97532da4b61552249c521e01e736071f71c1a4f7ebbfbf0a06aad6"
+dependencies = [
+ "lexical-core",
+ "memchr",
+ "version_check 0.9.2",
+]
+
+[[package]]
 name = "nuid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2020,7 +2082,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
 dependencies = [
  "autocfg 1.0.0",
- "num-traits",
+ "num-traits 0.2.11",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
+dependencies = [
+ "num-traits 0.2.11",
 ]
 
 [[package]]
@@ -2068,7 +2139,7 @@ dependencies = [
  "hyperx",
  "log 0.4.8",
  "reqwest",
- "serde",
+ "serde 1.0.110",
  "serde_json",
  "tokio",
  "www-authenticate",
@@ -2108,9 +2179,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.56"
+version = "0.9.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02309a7f127000ed50594f0b50ecc69e7c654e16d41b4e8156d1b3df8e0b52e"
+checksum = "7410fef80af8ac071d4f63755c0ab89ac3df0fd1ea91f1d1f37cf5cec4395990"
 dependencies = [
  "autocfg 1.0.0",
  "cc",
@@ -2125,7 +2196,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18869315e81473c951eb56ad5558bbc56978562d3ecfb87abb7a1e944cea4518"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.11",
 ]
 
 [[package]]
@@ -2146,9 +2217,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e136c1904604defe99ce5fd71a28d473fa60a12255d511aa78a9ddf11237aeb"
+checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 dependencies = [
  "cfg-if",
  "cloudabi",
@@ -2269,7 +2340,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "version_check 0.9.1",
+ "version_check 0.9.2",
 ]
 
 [[package]]
@@ -2282,14 +2353,14 @@ dependencies = [
  "quote",
  "syn",
  "syn-mid",
- "version_check 0.9.1",
+ "version_check 0.9.2",
 ]
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d659fe7c6d27f25e9d80a1a094c223f5246f6a6596453e09d7229bf42750b63"
+checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
 
 [[package]]
 name = "proc-macro-nested"
@@ -2299,9 +2370,9 @@ checksum = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.13"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f5ffe53a6b28e37c9c1ce74893477864d64f74778a93a4beb43c8fa167f639"
+checksum = "1502d12e458c49a4c9cbff560d0fe0060c252bc29799ed94ca2ed4bb665a0101"
 dependencies = [
  "unicode-xid",
 ]
@@ -2605,7 +2676,7 @@ dependencies = [
  "percent-encoding 2.1.0",
  "pin-project-lite",
  "rustls 0.17.0",
- "serde",
+ "serde 1.0.110",
  "serde_json",
  "serde_urlencoded",
  "time 0.1.43",
@@ -2652,7 +2723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f10b46df14cf1ee1ac7baa4d2fbc2c52c0622a4b82fa8740e37bc452ac0184f"
 dependencies = [
  "byteorder",
- "num-traits",
+ "num-traits 0.2.11",
 ]
 
 [[package]]
@@ -2663,7 +2734,7 @@ checksum = "4c1ee98f14fe8b8e9c5ea13d25da7b2a1796169202c57a09d7288de90d56222b"
 dependencies = [
  "byteorder",
  "rmp",
- "serde",
+ "serde 1.0.110",
 ]
 
 [[package]]
@@ -2677,6 +2748,12 @@ dependencies = [
  "constant_time_eq",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "rust-ini"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
 
 [[package]]
 name = "rustc-demangle"
@@ -2751,9 +2828,9 @@ checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "schannel"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "039c25b130bd8c1321ee2d7de7fde2659fa9c2744e4bb29711cfc852ea53cd19"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static",
  "winapi 0.3.8",
@@ -2782,9 +2859,9 @@ dependencies = [
 
 [[package]]
 name = "scroll_derive"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8584eea9b9ff42825b46faf46a8c24d2cff13ec152fa2a50df788b87c07ee28"
+checksum = "e367622f934864ffa1c704ba2b82280aab856e3d8213c84c5720257eb34b15b9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2841,11 +2918,30 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
+
+[[package]]
+name = "serde"
 version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99e7b308464d16b56eba9964e4972a3eee817760ab60d88c3f86e1fecb08204c"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-hjson"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a4e0ea8a88553209f6cc6cfe8724ecad22e1acf372793c27d995290fe74f8"
+dependencies = [
+ "lazy_static",
+ "linked-hash-map 0.3.0",
+ "num-traits 0.1.43",
+ "regex",
+ "serde 0.8.23",
 ]
 
 [[package]]
@@ -2855,7 +2951,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a65a7291a8a568adcae4c10a677ebcedbc6c9cec91c054dee2ce40b0e3290eb"
 dependencies = [
  "ordered-float",
- "serde",
+ "serde 1.0.110",
 ]
 
 [[package]]
@@ -2864,7 +2960,7 @@ version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf487fbf5c6239d7ea2ff8b10cb6b811cd4b5080d1c2aeed1dec18753c06e10"
 dependencies = [
- "serde",
+ "serde 1.0.110",
 ]
 
 [[package]]
@@ -2886,7 +2982,16 @@ checksum = "993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2"
 dependencies = [
  "itoa",
  "ryu",
- "serde",
+ "serde 1.0.110",
+]
+
+[[package]]
+name = "serde_test"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "110b3dbdf8607ec493c22d5d947753282f3bae73c0f56d322af1e8c78e4c23d5"
+dependencies = [
+ "serde 0.8.23",
 ]
 
 [[package]]
@@ -2897,7 +3002,7 @@ checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 dependencies = [
  "dtoa",
  "itoa",
- "serde",
+ "serde 1.0.110",
  "url 2.1.1",
 ]
 
@@ -2908,8 +3013,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16c7a592a1ec97c9c1c68d75b6e537dcbf60c7618e038e7841e00af1d9ccf0c4"
 dependencies = [
  "dtoa",
- "linked-hash-map",
- "serde",
+ "linked-hash-map 0.5.3",
+ "serde 1.0.110",
  "yaml-rust",
 ]
 
@@ -2933,9 +3038,9 @@ checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "sha2"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0"
+checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
 dependencies = [
  "block-buffer",
  "digest",
@@ -2989,9 +3094,9 @@ dependencies = [
 
 [[package]]
 name = "simplelog"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcacac97349a890d437921dfb23cbec52ab5b4752551cb637df2721371acd467"
+checksum = "3cf9a002ccce717d066b3ccdb8a28829436249867229291e91b25d99bd723f0d"
 dependencies = [
  "chrono",
  "log 0.4.8",
@@ -3047,6 +3152,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e4b8c631c998468961a9ea159f064c5c8499b95b5e4a34b77849d45949d540"
 
 [[package]]
+name = "static_assertions"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3"
+
+[[package]]
 name = "stdweb"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3068,7 +3179,7 @@ checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "serde",
+ "serde 1.0.110",
  "serde_derive",
  "syn",
 ]
@@ -3082,7 +3193,7 @@ dependencies = [
  "base-x",
  "proc-macro2",
  "quote",
- "serde",
+ "serde 1.0.110",
  "serde_derive",
  "serde_json",
  "sha1",
@@ -3101,7 +3212,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd710eadff449a1531351b0e43eb81ea404336fa2f56c777427ab0e32a4cf183"
 dependencies = [
- "serde",
+ "serde 1.0.110",
 ]
 
 [[package]]
@@ -3151,9 +3262,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b5f192649e48a5302a13f2feb224df883b98933222369e4b3b0fe2a5447269"
+checksum = "f87bc5b2815ebb664de0392fdf1b95b6d10e160f86d9f64ff65e5679841ca06a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3215,13 +3326,12 @@ dependencies = [
 
 [[package]]
 name = "term_size"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327"
+checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
 dependencies = [
- "kernel32-sys",
  "libc",
- "winapi 0.2.8",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -3245,18 +3355,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5976891d6950b4f68477850b5b9e5aa64d955961466f9e174363f573e54e8ca7"
+checksum = "b13f926965ad00595dd129fa12823b04bbf866e9085ab0a5f2b05b850fbfc344"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab81dbd1cd69cd2ce22ecfbdd3bdb73334ba25350649408cc6c085f46d89573d"
+checksum = "893582086c2f98cde18f906265a65b5030a074b1046c674ae898be6519a7f479"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3274,9 +3384,9 @@ dependencies = [
 
 [[package]]
 name = "threadpool"
-version = "1.7.1"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2f0c90a5f3459330ac8bc0d2f879c693bb7a2f59689c1083fc4ef83834da865"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
 ]
@@ -3302,7 +3412,7 @@ dependencies = [
  "standback",
  "stdweb",
  "time-macros",
- "version_check 0.9.1",
+ "version_check 0.9.2",
  "winapi 0.3.8",
 ]
 
@@ -3364,9 +3474,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "141afec0978abae6573065a48882c6bae44c5cc61db9b511ac4abf6a09bfd9cc"
+checksum = "3068d891551949b37681724d6b73666787cc63fa8e255c812a41d2513aff9775"
 dependencies = [
  "futures-core",
  "rustls 0.16.0",
@@ -3443,7 +3553,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 dependencies = [
- "serde",
+ "serde 1.0.110",
 ]
 
 [[package]]
@@ -3562,7 +3672,7 @@ version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
- "version_check 0.9.1",
+ "version_check 0.9.2",
 ]
 
 [[package]]
@@ -3648,7 +3758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
 dependencies = [
  "rand 0.7.3",
- "serde",
+ "serde 1.0.110",
 ]
 
 [[package]]
@@ -3671,9 +3781,9 @@ checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "version_check"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
+checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "want"
@@ -3692,9 +3802,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f717b1f26ee0e4d5a737c9efd72a6b010e946af2ae711805a00f2b3add788f48"
 dependencies = [
  "anyhow",
- "env_logger 0.7.1",
+ "env_logger",
  "log 0.4.8",
- "serde",
+ "serde 1.0.110",
  "serde_derive",
  "serde_json",
  "wasi-common",
@@ -3704,9 +3814,9 @@ dependencies = [
 
 [[package]]
 name = "warp"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54cd1e2b3eb3539284d88b76a9afcf5e20f2ef2fab74db5b21a1c30d7d945e82"
+checksum = "0e95175b7a927258ecbb816bdada3cc469cb68593e7940b96a60f4af366a9970"
 dependencies = [
  "bytes 0.5.4",
  "futures",
@@ -3719,11 +3829,11 @@ dependencies = [
  "multipart",
  "pin-project",
  "scoped-tls",
- "serde",
+ "serde 1.0.110",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-rustls 0.12.2",
+ "tokio-rustls 0.12.3",
  "tokio-tungstenite",
  "tower-service",
  "urlencoding",
@@ -3739,14 +3849,14 @@ dependencies = [
  "chrono",
  "chrono-humanize",
  "data-encoding",
- "env_logger 0.7.1",
+ "env_logger",
  "lazy_static",
  "log 0.4.8",
  "nkeys",
  "nuid",
  "parity-wasm",
  "ring",
- "serde",
+ "serde 1.0.110",
  "serde_derive",
  "serde_json",
 ]
@@ -3759,7 +3869,7 @@ checksum = "e7b7d2d6a8e5de8318d6525399a155e5cb0e8d1ec547b8d780ad3c03da6e6d1f"
 dependencies = [
  "log 0.4.8",
  "rmp-serde",
- "serde",
+ "serde 1.0.110",
  "serde_bytes",
  "serde_derive",
  "serde_json",
@@ -3771,7 +3881,7 @@ version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb4c4288d6d2932f66c842dc54ffb03741fb7ac59e6577b6a13babd3be3add90"
 dependencies = [
- "env_logger 0.7.1",
+ "env_logger",
  "log 0.4.8",
  "wascc-codec",
 ]
@@ -3785,7 +3895,7 @@ dependencies = [
  "crossbeam",
  "crossbeam-channel",
  "crossbeam-utils",
- "env_logger 0.7.1",
+ "env_logger",
  "libloading",
  "log 0.4.8",
  "rand 0.7.3",
@@ -3807,7 +3917,7 @@ dependencies = [
  "crossbeam",
  "crossbeam-channel",
  "crossbeam-utils",
- "env_logger 0.7.1",
+ "env_logger",
  "futures",
  "log 0.4.8",
  "wascc-codec",
@@ -3835,7 +3945,7 @@ dependencies = [
  "kubelet",
  "log 0.4.8",
  "oci-distribution",
- "serde",
+ "serde 1.0.110",
  "serde_derive",
  "serde_json",
  "tempfile",
@@ -3903,7 +4013,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c7d40d09cdbf0f4895ae58cf57d92e1e57a9dd8ed2e8390514b54a47cc5551"
 dependencies = [
  "cfg-if",
- "serde",
+ "serde 1.0.110",
  "serde_json",
  "wasm-bindgen-macro",
 ]
@@ -4029,7 +4139,7 @@ dependencies = [
  "log 0.4.8",
  "more-asserts",
  "rayon",
- "serde",
+ "serde 1.0.110",
  "sha2",
  "thiserror",
  "toml",
@@ -4078,7 +4188,7 @@ dependencies = [
  "libc",
  "object 0.18.0",
  "scroll",
- "serde",
+ "serde 1.0.110",
  "target-lexicon",
  "wasmtime-environ",
  "wasmtime-runtime",
@@ -4129,20 +4239,20 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "14.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b11c94c63d5365a76ea287f8e6e5b6050233fae4b2423aea2a1e126a385e17"
+checksum = "5a0e1c36b928fca33dbaf96235188f5fad22ee87100e26cc606bd0fbabdf1932"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03db18bc33cff3859c296efbefdcc00763a644539feeadca3415a1cee8a2835d"
+checksum = "2b50f9e5e5c81e6fd987ae6997a9f4bbb751df2dec1d8cadb0b5778f1ec13bbe"
 dependencies = [
- "wast 14.0.0",
+ "wast 17.0.0",
 ]
 
 [[package]]
@@ -4331,7 +4441,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d"
 dependencies = [
- "linked-hash-map",
+ "linked-hash-map 0.5.3",
 ]
 
 [[package]]
@@ -4355,18 +4465,18 @@ checksum = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
 
 [[package]]
 name = "zstd"
-version = "0.5.1+zstd.1.4.4"
+version = "0.5.2+zstd.1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5d978b793ae64375b80baf652919b148f6a496ac8802922d9999f5a553194f"
+checksum = "644352b10ce7f333d6e0af85bd4f5322dc449416dc1211c6308e95bca8923db4"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "2.0.3+zstd.1.4.4"
+version = "2.0.4+zstd.1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee25eac9753cfedd48133fa1736cbd23b774e253d89badbeac7d12b23848d3f"
+checksum = "7113c0c9aed2c55181f2d9f5b0a36e7d2c0183b11c058ab40b35987479efe4d7"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -4374,11 +4484,12 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.4.15+zstd.1.4.4"
+version = "1.4.16+zstd.1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89719b034dc22d240d5b407fb0a3fe6d29952c181cff9a9f95c0bd40b4f8f7d8"
+checksum = "c442965efc45353be5a9b9969c9b0872fff6828c7e06d118dda2cb2d0bb11d5a"
 dependencies = [
  "cc",
  "glob",
+ "itertools",
  "libc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
  "pin-project",
  "rand 0.7.3",
  "regex",
- "serde 1.0.110",
+ "serde",
  "serde_json",
  "serde_urlencoded",
  "sha1",
@@ -130,7 +130,7 @@ dependencies = [
  "http 0.2.1",
  "log 0.4.8",
  "regex",
- "serde 1.0.110",
+ "serde",
 ]
 
 [[package]]
@@ -270,7 +270,7 @@ dependencies = [
  "net2",
  "pin-project",
  "regex",
- "serde 1.0.110",
+ "serde",
  "serde_json",
  "serde_urlencoded",
  "time 0.1.43",
@@ -338,15 +338,6 @@ name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
-
-[[package]]
-name = "arrayvec"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
-dependencies = [
- "nodrop",
-]
 
 [[package]]
 name = "arrayvec"
@@ -419,7 +410,7 @@ dependencies = [
  "mime 0.3.16",
  "percent-encoding 2.1.0",
  "rand 0.7.3",
- "serde 1.0.110",
+ "serde",
  "serde_json",
  "serde_urlencoded",
 ]
@@ -471,7 +462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
 dependencies = [
  "byteorder",
- "serde 1.0.110",
+ "serde",
 ]
 
 [[package]]
@@ -487,7 +478,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
 dependencies = [
  "arrayref",
- "arrayvec 0.5.1",
+ "arrayvec",
  "constant_time_eq",
 ]
 
@@ -607,8 +598,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
 dependencies = [
  "num-integer",
- "num-traits 0.2.11",
- "serde 1.0.110",
+ "num-traits",
+ "serde",
  "time 0.1.43",
 ]
 
@@ -653,22 +644,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "config"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b076e143e1d9538dde65da30f8481c2a6c44040edb8e02b9bf1351edb92ce3"
-dependencies = [
- "lazy_static",
- "nom",
- "rust-ini",
- "serde 1.0.110",
- "serde-hjson",
- "serde_json",
- "toml",
- "yaml-rust",
 ]
 
 [[package]]
@@ -732,7 +707,7 @@ dependencies = [
  "gimli 0.20.0",
  "log 0.4.8",
  "regalloc",
- "serde 1.0.110",
+ "serde",
  "smallvec",
  "target-lexicon",
  "thiserror",
@@ -760,7 +735,7 @@ version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "926a73c432e5ba9c891171ff50b75e7d992cd76cd271f0a0a0ba199138077472"
 dependencies = [
- "serde 1.0.110",
+ "serde",
 ]
 
 [[package]]
@@ -796,7 +771,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-frontend",
  "log 0.4.8",
- "serde 1.0.110",
+ "serde",
  "thiserror",
  "wasmparser",
 ]
@@ -1328,7 +1303,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81dd6190aad0f05ddbbf3245c54ed14ca4aa6dd32f22312b70d8f168c3e3e633"
 dependencies = [
- "arrayvec 0.5.1",
+ "arrayvec",
  "byteorder",
  "fallible-iterator",
  "indexmap",
@@ -1655,7 +1630,7 @@ dependencies = [
  "base64 0.12.1",
  "bytes 0.5.4",
  "chrono",
- "serde 1.0.110",
+ "serde",
  "serde-value",
  "serde_json",
 ]
@@ -1683,7 +1658,7 @@ dependencies = [
  "kubelet",
  "oci-distribution",
  "reqwest",
- "serde 1.0.110",
+ "serde",
  "serde_derive",
  "serde_json",
  "tempfile",
@@ -1712,7 +1687,7 @@ dependencies = [
  "openssl",
  "reqwest",
  "rustls 0.17.0",
- "serde 1.0.110",
+ "serde",
  "serde_json",
  "serde_yaml",
  "thiserror",
@@ -1728,7 +1703,6 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "config",
  "dirs",
  "futures",
  "hostname",
@@ -1741,7 +1715,7 @@ dependencies = [
  "native-tls",
  "oci-distribution",
  "reqwest",
- "serde 1.0.110",
+ "serde",
  "serde_json",
  "structopt",
  "thiserror",
@@ -1770,19 +1744,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 
 [[package]]
-name = "lexical-core"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7043aa5c05dd34fb73b47acb8c3708eac428de4545ea3682ed2f11293ebd890"
-dependencies = [
- "arrayvec 0.4.12",
- "cfg-if",
- "rustc_version",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1795,16 +1756,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cadb8e769f070c45df05c78c7520eb4cd17061d4ab262e43cfc68b4d00ac71c"
 dependencies = [
  "winapi 0.3.8",
-]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d262045c5b87c0861b3f004610afd0e2c851e2908d08b6c870cbb9d5f494ecd"
-dependencies = [
- "serde 0.8.23",
- "serde_test",
 ]
 
 [[package]]
@@ -1838,7 +1789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
  "cfg-if",
- "serde 1.0.110",
+ "serde",
 ]
 
 [[package]]
@@ -1847,7 +1798,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 dependencies = [
- "linked-hash-map 0.5.3",
+ "linked-hash-map",
 ]
 
 [[package]]
@@ -2049,23 +2000,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
-
-[[package]]
-name = "nom"
-version = "5.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b471253da97532da4b61552249c521e01e736071f71c1a4f7ebbfbf0a06aad6"
-dependencies = [
- "lexical-core",
- "memchr",
- "version_check 0.9.2",
-]
-
-[[package]]
 name = "nuid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2082,16 +2016,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
 dependencies = [
  "autocfg 1.0.0",
- "num-traits 0.2.11",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
-dependencies = [
- "num-traits 0.2.11",
+ "num-traits",
 ]
 
 [[package]]
@@ -2139,7 +2064,7 @@ dependencies = [
  "hyperx",
  "log 0.4.8",
  "reqwest",
- "serde 1.0.110",
+ "serde",
  "serde_json",
  "tokio",
  "www-authenticate",
@@ -2196,7 +2121,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18869315e81473c951eb56ad5558bbc56978562d3ecfb87abb7a1e944cea4518"
 dependencies = [
- "num-traits 0.2.11",
+ "num-traits",
 ]
 
 [[package]]
@@ -2676,7 +2601,7 @@ dependencies = [
  "percent-encoding 2.1.0",
  "pin-project-lite",
  "rustls 0.17.0",
- "serde 1.0.110",
+ "serde",
  "serde_json",
  "serde_urlencoded",
  "time 0.1.43",
@@ -2723,7 +2648,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f10b46df14cf1ee1ac7baa4d2fbc2c52c0622a4b82fa8740e37bc452ac0184f"
 dependencies = [
  "byteorder",
- "num-traits 0.2.11",
+ "num-traits",
 ]
 
 [[package]]
@@ -2734,7 +2659,7 @@ checksum = "4c1ee98f14fe8b8e9c5ea13d25da7b2a1796169202c57a09d7288de90d56222b"
 dependencies = [
  "byteorder",
  "rmp",
- "serde 1.0.110",
+ "serde",
 ]
 
 [[package]]
@@ -2748,12 +2673,6 @@ dependencies = [
  "constant_time_eq",
  "crossbeam-utils",
 ]
-
-[[package]]
-name = "rust-ini"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
 
 [[package]]
 name = "rustc-demangle"
@@ -2918,30 +2837,11 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
-
-[[package]]
-name = "serde"
 version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99e7b308464d16b56eba9964e4972a3eee817760ab60d88c3f86e1fecb08204c"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-hjson"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a4e0ea8a88553209f6cc6cfe8724ecad22e1acf372793c27d995290fe74f8"
-dependencies = [
- "lazy_static",
- "linked-hash-map 0.3.0",
- "num-traits 0.1.43",
- "regex",
- "serde 0.8.23",
 ]
 
 [[package]]
@@ -2951,7 +2851,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a65a7291a8a568adcae4c10a677ebcedbc6c9cec91c054dee2ce40b0e3290eb"
 dependencies = [
  "ordered-float",
- "serde 1.0.110",
+ "serde",
 ]
 
 [[package]]
@@ -2960,7 +2860,7 @@ version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf487fbf5c6239d7ea2ff8b10cb6b811cd4b5080d1c2aeed1dec18753c06e10"
 dependencies = [
- "serde 1.0.110",
+ "serde",
 ]
 
 [[package]]
@@ -2982,16 +2882,7 @@ checksum = "993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2"
 dependencies = [
  "itoa",
  "ryu",
- "serde 1.0.110",
-]
-
-[[package]]
-name = "serde_test"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110b3dbdf8607ec493c22d5d947753282f3bae73c0f56d322af1e8c78e4c23d5"
-dependencies = [
- "serde 0.8.23",
+ "serde",
 ]
 
 [[package]]
@@ -3002,7 +2893,7 @@ checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 dependencies = [
  "dtoa",
  "itoa",
- "serde 1.0.110",
+ "serde",
  "url 2.1.1",
 ]
 
@@ -3013,8 +2904,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16c7a592a1ec97c9c1c68d75b6e537dcbf60c7618e038e7841e00af1d9ccf0c4"
 dependencies = [
  "dtoa",
- "linked-hash-map 0.5.3",
- "serde 1.0.110",
+ "linked-hash-map",
+ "serde",
  "yaml-rust",
 ]
 
@@ -3152,12 +3043,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e4b8c631c998468961a9ea159f064c5c8499b95b5e4a34b77849d45949d540"
 
 [[package]]
-name = "static_assertions"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3"
-
-[[package]]
 name = "stdweb"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3179,7 +3064,7 @@ checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "serde 1.0.110",
+ "serde",
  "serde_derive",
  "syn",
 ]
@@ -3193,7 +3078,7 @@ dependencies = [
  "base-x",
  "proc-macro2",
  "quote",
- "serde 1.0.110",
+ "serde",
  "serde_derive",
  "serde_json",
  "sha1",
@@ -3212,7 +3097,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd710eadff449a1531351b0e43eb81ea404336fa2f56c777427ab0e32a4cf183"
 dependencies = [
- "serde 1.0.110",
+ "serde",
 ]
 
 [[package]]
@@ -3553,7 +3438,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 dependencies = [
- "serde 1.0.110",
+ "serde",
 ]
 
 [[package]]
@@ -3758,7 +3643,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
 dependencies = [
  "rand 0.7.3",
- "serde 1.0.110",
+ "serde",
 ]
 
 [[package]]
@@ -3804,7 +3689,7 @@ dependencies = [
  "anyhow",
  "env_logger",
  "log 0.4.8",
- "serde 1.0.110",
+ "serde",
  "serde_derive",
  "serde_json",
  "wasi-common",
@@ -3829,7 +3714,7 @@ dependencies = [
  "multipart",
  "pin-project",
  "scoped-tls",
- "serde 1.0.110",
+ "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
@@ -3856,7 +3741,7 @@ dependencies = [
  "nuid",
  "parity-wasm",
  "ring",
- "serde 1.0.110",
+ "serde",
  "serde_derive",
  "serde_json",
 ]
@@ -3869,7 +3754,7 @@ checksum = "e7b7d2d6a8e5de8318d6525399a155e5cb0e8d1ec547b8d780ad3c03da6e6d1f"
 dependencies = [
  "log 0.4.8",
  "rmp-serde",
- "serde 1.0.110",
+ "serde",
  "serde_bytes",
  "serde_derive",
  "serde_json",
@@ -3945,7 +3830,7 @@ dependencies = [
  "kubelet",
  "log 0.4.8",
  "oci-distribution",
- "serde 1.0.110",
+ "serde",
  "serde_derive",
  "serde_json",
  "tempfile",
@@ -4013,7 +3898,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c7d40d09cdbf0f4895ae58cf57d92e1e57a9dd8ed2e8390514b54a47cc5551"
 dependencies = [
  "cfg-if",
- "serde 1.0.110",
+ "serde",
  "serde_json",
  "wasm-bindgen-macro",
 ]
@@ -4139,7 +4024,7 @@ dependencies = [
  "log 0.4.8",
  "more-asserts",
  "rayon",
- "serde 1.0.110",
+ "serde",
  "sha2",
  "thiserror",
  "toml",
@@ -4188,7 +4073,7 @@ dependencies = [
  "libc",
  "object 0.18.0",
  "scroll",
- "serde 1.0.110",
+ "serde",
  "target-lexicon",
  "wasmtime-environ",
  "wasmtime-runtime",
@@ -4441,7 +4326,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d"
 dependencies = [
- "linked-hash-map 0.5.3",
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/crates/kubelet/Cargo.toml
+++ b/crates/kubelet/Cargo.toml
@@ -56,6 +56,7 @@ oci-distribution = { path = "../oci-distribution", version = "0.1", default-feat
 url = "2.1"
 warp = { version = "0.2", features = ['tls'] }
 http = "0.2"
+# TODO: select specific features
 config_file = { package = "config", version = "0.10.0" }
 
 [dev-dependencies]

--- a/crates/kubelet/Cargo.toml
+++ b/crates/kubelet/Cargo.toml
@@ -56,6 +56,7 @@ oci-distribution = { path = "../oci-distribution", version = "0.1", default-feat
 url = "2.1"
 warp = { version = "0.2", features = ['tls'] }
 http = "0.2"
+config_file = { package = "config", version = "0.10.0" }
 
 [dev-dependencies]
 reqwest = {version = "0.10", default-features = false }

--- a/crates/kubelet/Cargo.toml
+++ b/crates/kubelet/Cargo.toml
@@ -56,8 +56,6 @@ oci-distribution = { path = "../oci-distribution", version = "0.1", default-feat
 url = "2.1"
 warp = { version = "0.2", features = ['tls'] }
 http = "0.2"
-# TODO: select specific features
-config_file = { package = "config", version = "0.10.0" }
 
 [dev-dependencies]
 reqwest = {version = "0.10", default-features = false }

--- a/crates/kubelet/src/config.rs
+++ b/crates/kubelet/src/config.rs
@@ -137,7 +137,7 @@ impl Config {
     /// Parses the specified config file and sets the proper defaults.
     /// If the specified file does not exist, this function panics.
     /// It is up to callers of the function to ensure any file they specify exists.
-    pub fn new_from_file_only(filename: PathBuf) -> Self {
+    pub fn new_from_file(filename: PathBuf) -> Self {
         let builder = ConfigBuilder::from_config_file(filename).unwrap();
         Config::new_from_builder(builder)
     }
@@ -146,7 +146,7 @@ impl Config {
     /// of your application should be passed to set the proper version for the CLI
     #[cfg(any(feature = "cli", feature = "docs"))]
     #[cfg_attr(feature = "docs", doc(cfg(feature = "cli")))]
-    pub fn new_from_flags_only(version: &str) -> Self {
+    pub fn new_from_flags(version: &str) -> Self {
         let app = Opts::clap().version(version);
         let opts = Opts::from_clap(&app.get_matches());
         let builder = ConfigBuilder::from_opts(opts);
@@ -172,7 +172,7 @@ impl Config {
                 if default_path.exists() {
                     Config::new_from_file_and_flags_impl(version, default_path)
                 } else {
-                    Config::new_from_flags_only(version)
+                    Config::new_from_flags(version)
                 }
             }
             Some(path) => Config::new_from_file_and_flags_impl(version, path),

--- a/crates/kubelet/src/config.rs
+++ b/crates/kubelet/src/config.rs
@@ -1,7 +1,15 @@
 //! Configuration for a Kubelet
 //!
-//! The best way to configure the kubelet is by using [`Config::default_config`]
-//! or by turning on the "cli" feature and using [`Config::new_from_flags`].
+//! You must provide a Config when instantiating a kubelet. Although you can create a Config
+//! directly, it is usually easier to use one of the following functions:
+//!
+//! * [`Config::default_config`] - use the defaults for everything
+//! * [`Config::new_from_file`] - use the values in the specified file
+//! * [`Config::new_from_flags`] - use the values specified on the command line or in
+//!   environment variables (requires you to turn on the "cli" feature)
+//! * [`Config::new_from_file_and_flags`] - use the values specified on the command line
+//!   or in environment variables, but falling back to the specified configuration file
+//!   (requires you to turn on the "cli" feature)
 
 use std::iter::FromIterator;
 use std::net::IpAddr;

--- a/crates/kubelet/src/config.rs
+++ b/crates/kubelet/src/config.rs
@@ -245,8 +245,7 @@ impl ConfigBuilder {
 
     fn from_config_source<T>(source: T) -> anyhow::Result<ConfigBuilder>
     where
-        T: 'static,
-        T: config_file::Source + Send + Sync,
+        T: 'static + config_file::Source + Send + Sync,
     {
         let mut settings = config_file::Config::default();
         match settings.merge(source) {

--- a/crates/kubelet/src/config.rs
+++ b/crates/kubelet/src/config.rs
@@ -71,16 +71,16 @@ struct ConfigBuilder {
     pub server_tls_private_key_file: Option<PathBuf>,
 }
 
-const NODE_IP_CONFIG_KEY: &str = "node_ip";
+const NODE_IP_CONFIG_KEY: &str = "nodeIP";
 const HOSTNAME_CONFIG_KEY: &str = "hostname";
-const NODE_NAME_CONFIG_KEY: &str = "node_name";
-const DATA_DIR_CONFIG_KEY: &str = "data_dir";
-const NODE_LABELS_CONFIG_KEY: &str = "node_labels";
-const MAX_PODS_CONFIG_KEY: &str = "max_pods";
-const SERVER_ADDR_CONFIG_KEY: &str = "addr";
-const SERVER_PORT_CONFIG_KEY: &str = "port";
-const SERVER_TLS_CERT_FILE_CONFIG_KEY: &str = "tls_cert_file";
-const SERVER_TLS_PRIVATE_KEY_FILE_CONFIG_KEY: &str = "tls_private_key_file";
+const NODE_NAME_CONFIG_KEY: &str = "nodeName";
+const DATA_DIR_CONFIG_KEY: &str = "dataDir";
+const NODE_LABELS_CONFIG_KEY: &str = "nodeLabels";
+const MAX_PODS_CONFIG_KEY: &str = "maxPods";
+const SERVER_ADDR_CONFIG_KEY: &str = "listenerAddress";
+const SERVER_PORT_CONFIG_KEY: &str = "listenerPort";
+const SERVER_TLS_CERT_FILE_CONFIG_KEY: &str = "tlsCertificateFile";
+const SERVER_TLS_PRIVATE_KEY_FILE_CONFIG_KEY: &str = "tlsPrivateKeyFile";
 
 struct ConfigBuilderFallbacks {
     hostname: fn() -> String,
@@ -570,19 +570,19 @@ mod test {
     fn config_file_inputs_are_respected_if_present() {
         let config_builder = builder_from_json_string(
             r#"{
-            "port": "1234",
-            "addr": "172.182.192.1",
+            "listenerPort": "1234",
+            "listenerAddress": "172.182.192.1",
             "hostname": "krusty-host",
-            "data_dir": "/krusty/data/dir",
-            "max_pods": "400",
-            "node_ip": "173.183.193.2",
-            "node_labels": {
+            "dataDir": "/krusty/data/dir",
+            "maxPods": "400",
+            "nodeIP": "173.183.193.2",
+            "nodeLabels": {
                 "label1": "val1",
                 "label2": "val2"
             },
-            "node_name": "krusty-node",
-            "tls_cert_file": "/my/secure/cert.pfx",
-            "tls_private_key_file": "/the/key"
+            "nodeName": "krusty-node",
+            "tlsCertificateFile": "/my/secure/cert.pfx",
+            "tlsPrivateKeyFile": "/the/key"
         }"#,
         );
         let config = config_builder.unwrap().build(fallbacks()).unwrap();
@@ -609,12 +609,12 @@ mod test {
     fn config_fallbacks_are_respected() {
         let config_builder = builder_from_json_string(
             r#"{
-            "port": "2345",
-            "addr": "173.183.193.2",
-            "node_labels": {
+            "listenerPort": "2345",
+            "listenerAddress": "173.183.193.2",
+            "nodeLabels": {
                 "label": "val"
             },
-            "node_name": "krustsome-node"
+            "nodeName": "krustsome-node"
         }"#,
         );
         let config = config_builder.unwrap().build(fallbacks()).unwrap();
@@ -676,34 +676,34 @@ mod test {
     fn merging_overrides_all_values() {
         let base_values = builder_from_json_string(
             r#"{
-            "port": "1234",
-            "addr": "172.182.192.1",
+            "listenerPort": "1234",
+            "listenerAddress": "172.182.192.1",
             "hostname": "krusty-host",
-            "data_dir": "/krusty/data/dir",
-            "node_ip": "173.183.193.2",
-            "node_labels": {
+            "dataDir": "/krusty/data/dir",
+            "nodeIP": "173.183.193.2",
+            "nodeLabels": {
                 "label1": "val1",
                 "label2": "val2"
             },
-            "node_name": "krusty-node",
-            "tls_cert_file": "/my/secure/cert.pfx",
-            "tls_private_key_file": "/the/key"
+            "nodeName": "krusty-node",
+            "tlsCertificateFile": "/my/secure/cert.pfx",
+            "tlsPrivateKeyFile": "/the/key"
         }"#,
         );
         let override_values = builder_from_json_string(
             r#"{
-            "port": "5678",
-            "addr": "171.181.191.21",
+            "listenerPort": "5678",
+            "listenerAddress": "171.181.191.21",
             "hostname": "krusty-host-2",
-            "data_dir": "/krusty/data/dir/2",
-            "node_ip": "173.183.193.22",
-            "node_labels": {
+            "dataDir": "/krusty/data/dir/2",
+            "nodeIP": "173.183.193.22",
+            "nodeLabels": {
                 "label21": "val21",
                 "label22": "val22"
             },
-            "node_name": "krusty-node-2",
-            "tls_cert_file": "/my/secure/cert-2.pfx",
-            "tls_private_key_file": "/the/2nd/key"
+            "nodeName": "krusty-node-2",
+            "tlsCertificateFile": "/my/secure/cert-2.pfx",
+            "tlsPrivateKeyFile": "/the/2nd/key"
         }"#,
         );
         let config_builder = base_values.unwrap().with_override(override_values.unwrap());
@@ -733,25 +733,25 @@ mod test {
     fn merging_respects_non_overridden_values() {
         let base_values = builder_from_json_string(
             r#"{
-            "port": "1234",
-            "addr": "172.182.192.1",
+            "listenerPort": "1234",
+            "listenerAddress": "172.182.192.1",
             "hostname": "krusty-host",
-            "data_dir": "/krusty/data/dir",
-            "node_ip": "173.183.193.2",
-            "node_labels": {
+            "dataDir": "/krusty/data/dir",
+            "nodeIP": "173.183.193.2",
+            "nodeLabels": {
                 "label1": "val1",
                 "label2": "val2"
             },
-            "node_name": "krusty-node",
-            "tls_cert_file": "/my/secure/cert.pfx",
-            "tls_private_key_file": "/the/key"
+            "nodeName": "krusty-node",
+            "tlsCertificateFile": "/my/secure/cert.pfx",
+            "tlsPrivateKeyFile": "/the/key"
         }"#,
         );
         let override_values = builder_from_json_string(
             r#"{
-            "port": "2345",
-            "node_name": "krusterrific-node",
-            "tls_private_key_file": "/the/other/key"
+            "listenerPort": "2345",
+            "nodeName": "krusterrific-node",
+            "tlsPrivateKeyFile": "/the/other/key"
         }"#,
         );
         let config_builder = base_values.unwrap().with_override(override_values.unwrap());
@@ -778,9 +778,9 @@ mod test {
     fn malformed_config_file_is_reported() {
         let config_builder = builder_from_json_string(
             r#"{
-            "port": "2345",
-            "addr": "173.183.193.2",
-            "node_name": "krustsome-node",
+            "listenerPort": "2345",
+            "listenerAddress": "173.183.193.2",
+            "nodeName": "krustsome-node",
         }"#,
         );
         let error =
@@ -795,9 +795,9 @@ mod test {
     fn malformed_config_value_is_reported() {
         let config_builder = builder_from_json_string(
             r#"{
-            "port": "qqqqqqqqqqq",
-            "addr": "173.183.193.2",
-            "node_name": "krustsome-node"
+            "listenerPort": "qqqqqqqqqqq",
+            "listenerAddress": "173.183.193.2",
+            "nodeName": "krustsome-node"
         }"#,
         );
         let error = config_builder
@@ -814,9 +814,9 @@ mod test {
     fn malformed_config_value_says_which_value() {
         let config_builder = builder_from_json_string(
             r#"{
-            "port": "qqqqqqqqqqq",
-            "addr": "173.183.193.2",
-            "node_name": "krustsome-node"
+            "listenerPort": "qqqqqqqqqqq",
+            "listenerAddress": "173.183.193.2",
+            "nodeName": "krustsome-node"
         }"#,
         );
         let error = config_builder
@@ -830,9 +830,9 @@ mod test {
     fn out_of_range_config_value_is_reported() {
         let config_builder = builder_from_json_string(
             r#"{
-            "port": "8675309",
-            "addr": "173.183.193.2",
-            "node_name": "krustsome-node"
+            "listenerPort": "8675309",
+            "listenerAddress": "173.183.193.2",
+            "nodeName": "krustsome-node"
         }"#,
         );
         let error = config_builder
@@ -849,13 +849,13 @@ mod test {
     fn if_invalid_config_value_is_overridden_by_valid_one_it_is_not_an_error() {
         let config_builder_1 = builder_from_json_string(
             r#"{
-            "port": "8675309"
+            "listenerPort": "8675309"
         }"#,
         )
         .unwrap();
         let config_builder_2 = builder_from_json_string(
             r#"{
-            "port": "1234"
+            "listenerPort": "1234"
         }"#,
         )
         .unwrap();
@@ -872,13 +872,13 @@ mod test {
     fn if_invalid_config_value_is_not_overridden_it_is_still_an_error() {
         let config_builder_1 = builder_from_json_string(
             r#"{
-            "port": "qqqqqqqq"
+            "listenerPort": "qqqqqqqq"
         }"#,
         )
         .unwrap();
         let config_builder_2 = builder_from_json_string(
             r#"{
-            "node_name": "krustsome-node"
+            "nodeName": "krustsome-node"
         }"#,
         )
         .unwrap();

--- a/crates/kubelet/src/config.rs
+++ b/crates/kubelet/src/config.rs
@@ -419,7 +419,7 @@ pub struct Opts {
         short = "n",
         long = "node-ip",
         env = "KRUSTLET_NODE_IP",
-        help = "The IP address of the node registered with the Kubernetes master. Defaults to the IP address of the node name in DNS as a best effort try at a default"
+        help = "The IP address of the node registered with the Kubernetes master. Defaults to the IP address of the host name in DNS as a best effort try at a default"
     )]
     node_ip: Option<IpAddr>,
 

--- a/crates/kubelet/src/config.rs
+++ b/crates/kubelet/src/config.rs
@@ -71,6 +71,17 @@ struct ConfigBuilder {
     pub server_tls_private_key_file: Option<PathBuf>,
 }
 
+const NODE_IP_CONFIG_KEY: &str = "node_ip";
+const HOSTNAME_CONFIG_KEY: &str = "hostname";
+const NODE_NAME_CONFIG_KEY: &str = "node_name";
+const DATA_DIR_CONFIG_KEY: &str = "data_dir";
+const NODE_LABELS_CONFIG_KEY: &str = "node_labels";
+const MAX_PODS_CONFIG_KEY: &str = "max_pods";
+const SERVER_ADDR_CONFIG_KEY: &str = "addr";
+const SERVER_PORT_CONFIG_KEY: &str = "port";
+const SERVER_TLS_CERT_FILE_CONFIG_KEY: &str = "tls_cert_file";
+const SERVER_TLS_PRIVATE_KEY_FILE_CONFIG_KEY: &str = "tls_private_key_file";
+
 struct ConfigBuilderFallbacks {
     hostname: fn() -> String,
     data_dir: fn() -> PathBuf,
@@ -246,34 +257,42 @@ impl ConfigBuilder {
 
     fn from_config_settings(settings: config_file::Config) -> ConfigBuilder {
         let port = settings
-            .get_str("port")
+            .get_str(SERVER_PORT_CONFIG_KEY)
             .ok()
             .map(|s| s.parse::<u16>().map_err(anyhow::Error::new));
         let max_pods = settings
-            .get_str("max_pods")
+            .get_str(MAX_PODS_CONFIG_KEY)
             .ok()
             .map(|s| s.parse::<u16>().map_err(anyhow::Error::new));
-        let node_labels: Option<HashMap<String, String>> =
-            settings.get_table("node_labels").map(stringise_values).ok();
+        let node_labels: Option<HashMap<String, String>> = settings
+            .get_table(NODE_LABELS_CONFIG_KEY)
+            .map(stringise_values)
+            .ok();
 
         ConfigBuilder {
-            hostname: settings.get_str("hostname").ok(),
-            data_dir: settings.get_str("data_dir").map(PathBuf::from).ok(),
+            hostname: settings.get_str(HOSTNAME_CONFIG_KEY).ok(),
+            data_dir: settings
+                .get_str(DATA_DIR_CONFIG_KEY)
+                .map(PathBuf::from)
+                .ok(),
             node_ip: settings
-                .get_str("node_ip")
+                .get_str(NODE_IP_CONFIG_KEY)
                 .ok()
                 .map(|s| s.parse().map_err(anyhow::Error::new)),
             node_labels,
-            node_name: settings.get_str("node_name").ok(),
+            node_name: settings.get_str(NODE_NAME_CONFIG_KEY).ok(),
             max_pods,
             server_addr: settings
-                .get_str("addr")
+                .get_str(SERVER_ADDR_CONFIG_KEY)
                 .ok()
                 .map(|s| s.parse().map_err(anyhow::Error::new)),
             server_port: port,
-            server_tls_cert_file: settings.get_str("tls_cert_file").map(PathBuf::from).ok(),
+            server_tls_cert_file: settings
+                .get_str(SERVER_TLS_CERT_FILE_CONFIG_KEY)
+                .map(PathBuf::from)
+                .ok(),
             server_tls_private_key_file: settings
-                .get_str("tls_private_key_file")
+                .get_str(SERVER_TLS_PRIVATE_KEY_FILE_CONFIG_KEY)
                 .map(PathBuf::from)
                 .ok(),
         }

--- a/crates/kubelet/src/config.rs
+++ b/crates/kubelet/src/config.rs
@@ -327,14 +327,14 @@ impl ConfigBuilder {
         let server_tls_private_key_file = self
             .server_tls_private_key_file
             .unwrap_or_else(|| (fallbacks.key_path)(&data_dir));
-        let server_port = self.server_port.unwrap_or(Ok(3000))?;
+        let server_port = self.server_port.unwrap_or(Ok(DEFAULT_PORT))?;
         let node_ip = self
             .node_ip
             .unwrap_or_else(|| Ok((fallbacks.node_ip)(&mut hostname.clone(), &server_addr)))?;
         let node_name = self
             .node_name
             .unwrap_or_else(|| sanitize_hostname(&hostname));
-        let max_pods = self.max_pods.unwrap_or(Ok(110))?;
+        let max_pods = self.max_pods.unwrap_or(Ok(DEFAULT_MAX_PODS))?;
 
         Ok(Config {
             node_ip,

--- a/demos/wascc/fileserver/Cargo.lock
+++ b/demos/wascc/fileserver/Cargo.lock
@@ -59,18 +59,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.10"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
+checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.3"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
+checksum = "54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea"
 dependencies = [
  "proc-macro2",
 ]
@@ -98,30 +98,30 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "serde"
-version = "1.0.106"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399"
+checksum = "c9124df5b40cbd380080b2cc6ab894c040a3070d995f5c9dc77e18c34a8ae37d"
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325a073952621257820e7a3469f55ba4726d8b28657e7e36653d1c36dc2c84ae"
+checksum = "3bf487fbf5c6239d7ea2ff8b10cb6b811cd4b5080d1c2aeed1dec18753c06e10"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.106"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
+checksum = "3f2c3ac8e6ca1e9c80b8be1023940162bf81ae3cffbb1809474152f2ce1eb250"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.51"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da07b57ee2623368351e9a0488bb0b261322a15a6e0ae53e243cbdc0f4208da9"
+checksum = "993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2"
 dependencies = [
  "itoa",
  "ryu",
@@ -141,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.17"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
+checksum = "93a56fabc59dce20fe48b6c832cc249c713e7ed88fa28b0ee0a3bfcaae5fe4e2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/docs/topics/README.md
+++ b/docs/topics/README.md
@@ -4,4 +4,5 @@ Introductions to all the key components of Krustlet in more detail:
 
 - [Krustlet architecture](architecture.md)
 - [Providers](providers.md)
+- [Configuration](configuration.md)
 - [Glossary](glossary.md)

--- a/docs/topics/configuration.md
+++ b/docs/topics/configuration.md
@@ -8,15 +8,15 @@ environment variables.
 | Command line | Environment variable | Configuration file | Description |
 |--------------|----------------------|--------------------|-------------|
 | -a, --addr   | KRUSTLET_ADDRESS     | addr               | The address on which the kubelet should listen |
-| --data-dir    | KRUSTLET_DATA_DIR   | data_dir           | The path under which the kubelet should store data (e.g. logs, container images, etc.) |
-| --hostname    | KRUSTLET_HOSTNAME   | hostname           | The name of the host where the kubelet runs. Pass this if the name in TLS certificate does not match the actual machine name |
-| --max-pods   | MAX_PODS             | max_pods           | The maximum number of pods to schedule on the kubelet at any one time |
-| -n, --node-ip | KRUSTLET_NODE_IP    | node_ip            | The IP address of the node registered with the Kubernetes master |
+| --data-dir    | KRUSTLET_DATA_DIR   | data_dir           | The path under which the kubelet should store data (e.g. logs, container images, etc.). The default is `$HOME/.krustlet` |
+| --hostname    | KRUSTLET_HOSTNAME   | hostname           | The name of the host where the kubelet runs. Defaults to the hostname of the machine where the kubelet is running; pass this if the name in the TLS certificate does not match the actual machine name |
+| --max-pods   | MAX_PODS             | max_pods           | The maximum number of pods to schedule on the kubelet at any one time. The default is 110 |
+| -n, --node-ip | KRUSTLET_NODE_IP    | node_ip            | The IP address of the node registered with the Kubernetes master. Defaults to the IP address of the kubelet hostname, as obtained from DNS |
 | --node-labels | NODE_LABELS         | node_labels        | The labels to apply to the node when it registers in the cluster. See below for format |
-| --node-name   | KRUSTLET_NODE_NAME  | node_name          | The name by which to refer to the kubelet node in Kubernetes |
-| -p, --port   | KRUSTLET_PORT        | port               | The port on which the kubelet should listen |
-| --tls-cert-file | TLS_CERT_FILE     | tls_cert_file      | The path to the TLS certificate for the kubelet |
-| --tls-private-key-file | TLS_PRIVATE_KEY_FILE     | tls_private_key_file      | The path to the private key for the TLS certificate |
+| --node-name   | KRUSTLET_NODE_NAME  | node_name          | The name by which to refer to the kubelet node in Kubernetes. Defaults to the hostname |
+| -p, --port   | KRUSTLET_PORT        | port               | The port on which the kubelet should listen. The default is 3000 |
+| --tls-cert-file | TLS_CERT_FILE     | tls_cert_file      | The path to the TLS certificate for the kubelet. The default is `(data directory)/config/krustlet.crt` |
+| --tls-private-key-file | TLS_PRIVATE_KEY_FILE     | tls_private_key_file      | The path to the private key for the TLS certificate. The default is `(data directory)/config/krustlet.key` |
 
 ## Node labels format
 

--- a/docs/topics/configuration.md
+++ b/docs/topics/configuration.md
@@ -1,0 +1,62 @@
+# Configuration
+
+The kubelet can be configured via the command line, configuration file or
+environment variables.
+
+## Configuration values
+
+| Command line | Environment variable | Configuration file | Description |
+|--------------|----------------------|--------------------|-------------|
+| -a, --addr   | KRUSTLET_ADDRESS     | addr               | The address on which the kubelet should listen |
+| --data-dir    | KRUSTLET_DATA_DIR   | data_dir           | The path under which the kubelet should store data (e.g. logs, container images, etc.) |
+| --hostname    | KRUSTLET_HOSTNAME   | hostname           | The name of the host where the kubelet runs. Pass this if the name in TLS certificate does not match the actual machine name |
+| --max-pods   | MAX_PODS             | max_pods           | The maximum number of pods to schedule on the kubelet at any one time |
+| -n, --node-ip | KRUSTLET_NODE_IP    | node_ip            | The IP address of the node registered with the Kubernetes master |
+| --node-labels | NODE_LABELS         | node_labels        | The labels to apply to the node when it registers in the cluster. See below for format |
+| --node-name   | KRUSTLET_NODE_NAME  | node_name          | The name by which to refer to the kubelet node in Kubernetes |
+| -p, --port   | KRUSTLET_PORT        | port               | The port on which the kubelet should listen |
+| --tls-cert-file | TLS_CERT_FILE     | tls_cert_file      | The path to the TLS certificate for the kubelet |
+| --tls-private-key-file | TLS_PRIVATE_KEY_FILE     | tls_private_key_file      | The path to the private key for the TLS certificate |
+
+## Node labels format
+
+If you specify node labels on the command line or in an environment variable,
+the format is a comma-separated list of `name=value` pairs. For example:
+
+```
+--node-labels mylabel=foo,myotherlabel=bar
+```
+
+If you specify node labels in the configuration file, the format is key-value
+pairs. For example:
+
+```json
+{
+    "node_labels": {
+        "mylabel": "foo",
+        "myotherlabel": "bar"
+    }
+}
+```
+
+## Configuration file location
+
+The configuration file is located at `$HOME/.krustlet/config/config.json`.
+
+**TODO: define how to override this.**
+
+## Precedence
+
+If you specify the same setting in multiple places - for example, both in
+the configuration file and on the command line - then the precedence is:
+
+* Command line flags take precedence over environment variables
+* Environment variables take precedence over the configuration file
+
+This allows you to conveniently override individual settings from a
+configuration file, for example by writing `MAX_PODS=200 krustlet-wascc` or
+`krustlet-wascc --max-pods 200`.
+
+If you specify node labels in multiple places, the collections are _not_
+combined: the place with the highest precedence takes effect and all others
+are ignored.

--- a/docs/topics/configuration.md
+++ b/docs/topics/configuration.md
@@ -1,22 +1,27 @@
 # Configuration
 
-The kubelet can be configured via the command line, configuration file or
+The `kubelet` crate supports configuration via the command line, configuration file or
 environment variables.
+
+**NOTE:** Custom kubelets built using the `kubelet` crate can choose which of
+these methods to support, or may choose to bypass `kubelet`'s built-in
+configuration system in favour of their own. `krustlet-wascc` and
+`krustlet-wasi` use standard configuration and support all configuration methods.
 
 ## Configuration values
 
 | Command line | Environment variable | Configuration file | Description |
 |--------------|----------------------|--------------------|-------------|
 | -a, --addr   | KRUSTLET_ADDRESS     | listenerAddress    | The address on which the kubelet should listen |
-| --data-dir    | KRUSTLET_DATA_DIR   | dataDir            | The path under which the kubelet should store data (e.g. logs, container images, etc.). The default is `$HOME/.krustlet` |
-| --hostname    | KRUSTLET_HOSTNAME   | hostname           | The name of the host where the kubelet runs. Defaults to the hostname of the machine where the kubelet is running; pass this if the name in the TLS certificate does not match the actual machine name |
+| --data-dir   | KRUSTLET_DATA_DIR    | dataDir            | The path under which the kubelet should store data (e.g. logs, container images, etc.). The default is `$HOME/.krustlet` |
+| --hostname   | KRUSTLET_HOSTNAME    | hostname           | The name of the host where the kubelet runs. Defaults to the hostname of the machine where the kubelet is running; pass this if the name in the TLS certificate does not match the actual machine name |
 | --max-pods   | MAX_PODS             | maxPods            | The maximum number of pods to schedule on the kubelet at any one time. The default is 110 |
 | -n, --node-ip | KRUSTLET_NODE_IP    | nodeIP             | The IP address of the node registered with the Kubernetes master. Defaults to the IP address of the kubelet hostname, as obtained from DNS |
 | --node-labels | NODE_LABELS         | nodeLabels         | The labels to apply to the node when it registers in the cluster. See below for format |
-| --node-name   | KRUSTLET_NODE_NAME  | nodeName           | The name by which to refer to the kubelet node in Kubernetes. Defaults to the hostname |
+| --node-name  | KRUSTLET_NODE_NAME   | nodeName           | The name by which to refer to the kubelet node in Kubernetes. Defaults to the hostname |
 | -p, --port   | KRUSTLET_PORT        | listenerPort       | The port on which the kubelet should listen. The default is 3000 |
 | --tls-cert-file | TLS_CERT_FILE     | tlsCertificateFile | The path to the TLS certificate for the kubelet. The default is `(data directory)/config/krustlet.crt` |
-| --tls-private-key-file | TLS_PRIVATE_KEY_FILE     | tlsPrivateKeyFile      | The path to the private key for the TLS certificate. The default is `(data directory)/config/krustlet.key` |
+| --tls-private-key-file | TLS_PRIVATE_KEY_FILE | tlsPrivateKeyFile | The path to the private key for the TLS certificate. The default is `(data directory)/config/krustlet.key` |
 
 ## Node labels format
 
@@ -41,9 +46,14 @@ pairs. For example:
 
 ## Configuration file location
 
-The configuration file is located at `$HOME/.krustlet/config/config.json`.
+By default, the configuration file is located at `$HOME/.krustlet/config/config.json`.
+The `kubelet` crate does not define a common way to override this.  However,
+custom kubelets built on `kubelet` may provide such a mechanism.
 
-**TODO: define how to override this.**
+The `krustlet-wascc` and `krustlet-wasi` kubelets do not currently provide
+a way to override the default location.
+
+**TODO: should we build in a standard way of overriding the file location?**
 
 ## Precedence
 

--- a/docs/topics/configuration.md
+++ b/docs/topics/configuration.md
@@ -7,16 +7,16 @@ environment variables.
 
 | Command line | Environment variable | Configuration file | Description |
 |--------------|----------------------|--------------------|-------------|
-| -a, --addr   | KRUSTLET_ADDRESS     | addr               | The address on which the kubelet should listen |
-| --data-dir    | KRUSTLET_DATA_DIR   | data_dir           | The path under which the kubelet should store data (e.g. logs, container images, etc.). The default is `$HOME/.krustlet` |
+| -a, --addr   | KRUSTLET_ADDRESS     | listenerAddress    | The address on which the kubelet should listen |
+| --data-dir    | KRUSTLET_DATA_DIR   | dataDir            | The path under which the kubelet should store data (e.g. logs, container images, etc.). The default is `$HOME/.krustlet` |
 | --hostname    | KRUSTLET_HOSTNAME   | hostname           | The name of the host where the kubelet runs. Defaults to the hostname of the machine where the kubelet is running; pass this if the name in the TLS certificate does not match the actual machine name |
-| --max-pods   | MAX_PODS             | max_pods           | The maximum number of pods to schedule on the kubelet at any one time. The default is 110 |
-| -n, --node-ip | KRUSTLET_NODE_IP    | node_ip            | The IP address of the node registered with the Kubernetes master. Defaults to the IP address of the kubelet hostname, as obtained from DNS |
-| --node-labels | NODE_LABELS         | node_labels        | The labels to apply to the node when it registers in the cluster. See below for format |
-| --node-name   | KRUSTLET_NODE_NAME  | node_name          | The name by which to refer to the kubelet node in Kubernetes. Defaults to the hostname |
-| -p, --port   | KRUSTLET_PORT        | port               | The port on which the kubelet should listen. The default is 3000 |
-| --tls-cert-file | TLS_CERT_FILE     | tls_cert_file      | The path to the TLS certificate for the kubelet. The default is `(data directory)/config/krustlet.crt` |
-| --tls-private-key-file | TLS_PRIVATE_KEY_FILE     | tls_private_key_file      | The path to the private key for the TLS certificate. The default is `(data directory)/config/krustlet.key` |
+| --max-pods   | MAX_PODS             | maxPods            | The maximum number of pods to schedule on the kubelet at any one time. The default is 110 |
+| -n, --node-ip | KRUSTLET_NODE_IP    | nodeIP             | The IP address of the node registered with the Kubernetes master. Defaults to the IP address of the kubelet hostname, as obtained from DNS |
+| --node-labels | NODE_LABELS         | nodeLabels         | The labels to apply to the node when it registers in the cluster. See below for format |
+| --node-name   | KRUSTLET_NODE_NAME  | nodeName           | The name by which to refer to the kubelet node in Kubernetes. Defaults to the hostname |
+| -p, --port   | KRUSTLET_PORT        | listenerPort       | The port on which the kubelet should listen. The default is 3000 |
+| --tls-cert-file | TLS_CERT_FILE     | tlsCertificateFile | The path to the TLS certificate for the kubelet. The default is `(data directory)/config/krustlet.crt` |
+| --tls-private-key-file | TLS_PRIVATE_KEY_FILE     | tlsPrivateKeyFile      | The path to the private key for the TLS certificate. The default is `(data directory)/config/krustlet.key` |
 
 ## Node labels format
 

--- a/src/krustlet-wascc.rs
+++ b/src/krustlet-wascc.rs
@@ -7,7 +7,7 @@ use wascc_provider::WasccProvider;
 async fn main() -> anyhow::Result<()> {
     // The provider is responsible for all the "back end" logic. If you are creating
     // a new Kubelet, all you need to implement is a provider.
-    let config = Config::new_from_flags(env!("CARGO_PKG_VERSION"));
+    let config = Config::new_from_file_and_flags(env!("CARGO_PKG_VERSION"), ".krustletconfig");
 
     let kubeconfig = kube::Config::infer().await?;
 

--- a/src/krustlet-wascc.rs
+++ b/src/krustlet-wascc.rs
@@ -7,7 +7,7 @@ use wascc_provider::WasccProvider;
 async fn main() -> anyhow::Result<()> {
     // The provider is responsible for all the "back end" logic. If you are creating
     // a new Kubelet, all you need to implement is a provider.
-    let config = Config::new_from_file_and_flags(env!("CARGO_PKG_VERSION"), ".krustletconfig");
+    let config = Config::new_from_file_and_flags(env!("CARGO_PKG_VERSION"), None);
 
     let kubeconfig = kube::Config::infer().await?;
 

--- a/src/krustlet-wasi.rs
+++ b/src/krustlet-wasi.rs
@@ -7,7 +7,7 @@ use wasi_provider::WasiProvider;
 async fn main() -> anyhow::Result<()> {
     // The provider is responsible for all the "back end" logic. If you are creating
     // a new Kubelet, all you need to implement is a provider.
-    let config = Config::new_from_flags(env!("CARGO_PKG_VERSION"));
+    let config = Config::new_from_file_and_flags(env!("CARGO_PKG_VERSION"), ".krustletconfig");
 
     let kubeconfig = kube::Config::infer().await?;
 

--- a/src/krustlet-wasi.rs
+++ b/src/krustlet-wasi.rs
@@ -7,7 +7,7 @@ use wasi_provider::WasiProvider;
 async fn main() -> anyhow::Result<()> {
     // The provider is responsible for all the "back end" logic. If you are creating
     // a new Kubelet, all you need to implement is a provider.
-    let config = Config::new_from_file_and_flags(env!("CARGO_PKG_VERSION"), ".krustletconfig");
+    let config = Config::new_from_file_and_flags(env!("CARGO_PKG_VERSION"), None);
 
     let kubeconfig = kube::Config::infer().await?;
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -318,7 +318,6 @@ async fn clean_up_wasi_test_resources() -> () {
     let client = kube::Client::try_default()
         .await
         .expect("Failed to create client");
-    println!("did first await");
     let pods: Api<Pod> = Api::namespaced(client.clone(), "default");
     pods.delete("hello-wasi", &DeleteParams::default())
         .await


### PR DESCRIPTION
Fixes #202.

With this PR, the kubelet configuration can be read from a config file as well as from the CLI.  If an option is specified in both the CLI and the config file, the CLI takes precedence.

The initial version of this PR is rather prototype-y and the following things remain to be refined:

* ~Agree better names for the config file keys~ I have now agreed these. With myself.
* ~Agree default config file path~ Ditto
* How to override default config file path e.g. environment variable and/or command line flag
* Default config file should probably be YAML rather than JSON though we hates them all precious
* ~Improve error messages for invalid config file entries~ They're not going to win any prizes but they're less worse than they were I think
* Agree on-error behaviour - currently panics on bad config value unless overridden on CLI
* Should `config.rs` be broken up?  It has grown quite large...
* ~Documentation (not so much needing to be refined as, er, created)~ I maded some

Something to consider:

* Should we, instead of dealing with this specific case, instead build a standalone crate that bridges `config-rs` and `structopt` and if so can I call it `frankenconfig` please?
