### PR TITLE
fix(docs): use /dev/urandom for generating token secrets

### DIFF
--- a/docs/howto/assets/bootstrap.sh
+++ b/docs/howto/assets/bootstrap.sh
@@ -4,8 +4,7 @@ set -euo pipefail
 export LC_CTYPE=C
 
 token_id="$(</dev/urandom tr -dc a-z0-9 | head -c "${1:-6}";echo;)"
-# This needs to use /dev/random so it is cryptographically safe
-token_secret="$(</dev/random tr -dc a-z0-9 | head -c "${1:-16}";echo;)"
+token_secret="$(< /dev/urandom tr -dc a-z0-9 | head -c "${1:-16}";echo;)"
 
 # support gnu and BSD date command
 expiration=$(date -u "+%Y-%m-%dT%H:%M:%SZ" --date "1 hour" 2>/dev/null ||

--- a/docs/howto/bootstrapping.md
+++ b/docs/howto/bootstrapping.md
@@ -6,7 +6,7 @@ certificates. This document describes how the functionality works.
 ## Initialization
 Krustlet follows the same [initialization
 flow](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/#initialization-process)
-as Kubelet (with the exception of automatic renewal of certs that are close to expiry). 
+as Kubelet (with the exception of automatic renewal of certs that are close to expiry).
 
 ## Instructions
 
@@ -24,18 +24,18 @@ kubeconfig that has access to create `Secrets` in the `kube-system` namespace an
 
 ### Generating a token and kubeconfig
 
-We have a useful bootstrapping [bash script](../../hack/bootstrap.sh) that can be used for
+We have a useful bootstrapping [bash script](./assets/bootstrap.sh) that can be used for
 generating a token and creating a bootstrap kubeconfig file. If you have cloned the repo, you can
 run:
 
 ```bash
-$ ./hack/bootstrap.sh
+$ ./docs/howto/assets/bootstrap.sh
 ```
 
 If you are the trusting sort, you can pipe it in from the internet:
 
 ```bash
-$ bash <(curl https://raw.githubusercontent.com/deislabs/krustlet/master/hack/bootstrap.sh)
+$ bash <(curl https://raw.githubusercontent.com/deislabs/krustlet/master/docs/howto/assets/bootstrap.sh)
 ```
 
 This will output a ready-to-use bootstrap config to `$HOME/.krustlet/config/bootstrap.conf`
@@ -60,8 +60,7 @@ string. The token will look something like this: `ke3uxh.vhxb3ttj1nquno5t`. That
 generate a token with a simple bash command like so:
 
 ```bash
-# The second one needs to use /dev/random so it is cryptographically safe
-$ echo "$(< /dev/urandom tr -dc a-z0-9 | head -c${1:-6};echo;).$(< /dev/random tr -dc a-z0-9 | head -c${1:-16};echo;)"
+$ echo "$(< /dev/urandom tr -dc a-z0-9 | head -c${1:-6};echo;).$(< /dev/urandom tr -dc a-z0-9 | head -c${1:-16};echo;)"
 ```
 
 ##### Creating the secret
@@ -97,7 +96,7 @@ several pieces of information:
 - The generated bootstrap token
 
 You can either assemble a kubeconfig by hand or use similar steps to what is found in the [bootstrap
-script](../../hack/bootstrap.sh)
+script](./assets/bootstrap.sh)
 
 ##### An example bootstrap config
 This is an example of a bootstrap config file for reference if creating your own workflow

--- a/justfile
+++ b/justfile
@@ -25,5 +25,5 @@ run-wasi: bootstrap
 bootstrap:
     @# This is to get around an issue with the default function returning a string that gets escaped
     @mkdir -p $(eval echo $CONFIG_DIR)
-    @test -f  $(eval echo $CONFIG_DIR)/bootstrap.conf || CONFIG_DIR=$(eval echo $CONFIG_DIR) ./hack/bootstrap.sh
+    @test -f  $(eval echo $CONFIG_DIR)/bootstrap.conf || CONFIG_DIR=$(eval echo $CONFIG_DIR) ./docs/howto/assets/bootstrap.sh
     @chmod 600 $(eval echo $CONFIG_DIR)/*


### PR DESCRIPTION
As these are hack scripts to help spin up a development environment, we should lean towards usability over security.

WSL does not have enough entropy available to generate a random seed with /dev/random.
Using /dev/urandom is less cryptographically secure, but it enables users on WSL to utilize the hack script.

closes #276

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>