### PR TITLE
fix(ci): add dependency on publish action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,20 +47,6 @@ jobs:
           name: krustlet
           path: _dist/krustlet-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.arch }}.tar.gz
 
-  crates:
-    name: publish to crates.io
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags')
-    steps:
-      - uses: actions/checkout@v2
-      # OCI distribution needs to go first because kubelet has a dependency on it
-      - name: publish oci-distribution to crates.io
-        working-directory: ./crates/oci-distribution
-        run: cargo publish --token ${{ secrets.CargoToken }}
-      - name: publish kubelet to crates.io
-        working-directory: ./crates/kubelet
-        run: cargo publish --token ${{ secrets.CargoToken }}
-
   publish:
     name: publish release assets
     runs-on: ubuntu-latest
@@ -90,3 +76,18 @@ jobs:
           source_dir: krustlet
           container_name: releases
           connection_string: ${{ secrets.AzureStorageConnectionString }}
+
+  crates:
+    name: publish to crates.io
+    runs-on: ubuntu-latest
+    needs: publish
+    if: startsWith(github.ref, 'refs/tags')
+    steps:
+      - uses: actions/checkout@v2
+      # OCI distribution needs to go first because kubelet has a dependency on it
+      - name: publish oci-distribution to crates.io
+        working-directory: ./crates/oci-distribution
+        run: cargo publish --token ${{ secrets.CargoToken }}
+      - name: publish kubelet to crates.io
+        working-directory: ./crates/kubelet
+        run: cargo publish --token ${{ secrets.CargoToken }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: set the release version (tag)
-        if: startsWith(github.ref, 'refs/tags')
+        if: startsWith(github.ref, 'refs/tags/v')
         run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF/refs\/tags\//}
 
       - name: set the release version (master)
@@ -53,7 +53,7 @@ jobs:
     needs: build
     steps:
       - name: set the release version
-        if: startsWith(github.ref, 'refs/tags')
+        if: startsWith(github.ref, 'refs/tags/v')
         run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF/refs\/tags\//}
 
       - name: set the release version
@@ -81,7 +81,7 @@ jobs:
     name: publish to crates.io
     runs-on: ubuntu-latest
     needs: publish
-    if: startsWith(github.ref, 'refs/tags')
+    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v2
       # OCI distribution needs to go first because kubelet has a dependency on it


### PR DESCRIPTION
This way the `crates` job won't start until krustlet is built and uploaded to Azure.

addresses the first point in #263

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>