### PR TITLE
fix(*): Fixes issues with running multiple providers in dev

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,11 +57,11 @@ jobs:
         run: |
           just bootstrap
           just build
-          ./target/debug/krustlet-wascc --node-name krustlet-wascc --port 3000 --tls-cert-file ./config/krustlet-wascc.crt --tls-private-key-file ./config/krustlet-wascc.key &
+          KUBECONFIG=${CONFIG_DIR}/kubeconfig-wascc ./target/debug/krustlet-wascc --node-name krustlet-wascc --port 3000 --bootstrap-file ${CONFIG_DIR}/bootstrap.conf --tls-cert-file ./config/krustlet-wascc.crt --tls-private-key-file ./config/krustlet-wascc.key &
           # Wait for things to start before approving certs and then delete so we don't overlap with the same hostname
           sleep 5 && kubectl certificate approve $(hostname)-tls
           sleep 2 && kubectl delete csr $(hostname)-tls 
-          ./target/debug/krustlet-wasi --node-name krustlet-wasi --port 3001 --tls-cert-file ./config/krustlet-wasi.crt --tls-private-key-file ./config/krustlet-wasi.key &
+          KUBECONFIG=${CONFIG_DIR}/kubeconfig-wasi ./target/debug/krustlet-wasi --node-name krustlet-wasi --port 3001 --bootstrap-file ${CONFIG_DIR}/bootstrap.conf --tls-cert-file ./config/krustlet-wasi.crt --tls-private-key-file ./config/krustlet-wasi.key &
           sleep 5 && kubectl certificate approve $(hostname)-tls
           sleep 2 && kubectl delete csr $(hostname)-tls 
           just test-e2e

--- a/justfile
+++ b/justfile
@@ -16,14 +16,14 @@ test:
 test-e2e:
     cargo test --test integration_tests
 
-run-wascc: (bootstrap "bootstrap-wascc.conf")
-    KUBECONFIG=$(eval echo $CONFIG_DIR)/kubeconfig cargo run --bin krustlet-wascc -- --node-name krustlet-wascc --port 3000 --bootstrap-file $(eval echo $CONFIG_DIR)/bootstrap-wascc.conf --tls-cert-file $(eval echo $CONFIG_DIR)/krustlet-wascc.crt --tls-private-key-file $(eval echo $CONFIG_DIR)/krustlet-wascc.key
+run-wascc: bootstrap
+    KUBECONFIG=$(eval echo $CONFIG_DIR)/kubeconfig-wascc cargo run --bin krustlet-wascc -- --node-name krustlet-wascc --port 3000 --bootstrap-file $(eval echo $CONFIG_DIR)/bootstrap.conf --tls-cert-file $(eval echo $CONFIG_DIR)/krustlet-wascc.crt --tls-private-key-file $(eval echo $CONFIG_DIR)/krustlet-wascc.key
 
-run-wasi: (bootstrap "bootstrap-wasi.conf")
-    KUBECONFIG=$(eval echo $CONFIG_DIR)/kubeconfig cargo run --bin krustlet-wasi -- --node-name krustlet-wasi --port 3001 --bootstrap-file $(eval echo $CONFIG_DIR)/bootstrap-wasi.conf --tls-cert-file $(eval echo $CONFIG_DIR)/krustlet-wasi.crt --tls-private-key-file $(eval echo $CONFIG_DIR)/krustlet-wasi.key
+run-wasi: bootstrap
+    KUBECONFIG=$(eval echo $CONFIG_DIR)/kubeconfig-wasi cargo run --bin krustlet-wasi -- --node-name krustlet-wasi --port 3001 --bootstrap-file $(eval echo $CONFIG_DIR)/bootstrap.conf --tls-cert-file $(eval echo $CONFIG_DIR)/krustlet-wasi.crt --tls-private-key-file $(eval echo $CONFIG_DIR)/krustlet-wasi.key
 
-bootstrap file_name="bootstrap.conf":
+bootstrap:
     @# This is to get around an issue with the default function returning a string that gets escaped
     @mkdir -p $(eval echo $CONFIG_DIR)
-    @test -f  $(eval echo $CONFIG_DIR)/kubeconfig || CONFIG_DIR=$(eval echo $CONFIG_DIR) FILE_NAME={{file_name}} ./hack/bootstrap.sh
+    @test -f  $(eval echo $CONFIG_DIR)/bootstrap.conf || CONFIG_DIR=$(eval echo $CONFIG_DIR) ./hack/bootstrap.sh
     @chmod 600 $(eval echo $CONFIG_DIR)/*


### PR DESCRIPTION
Some of the variables were not set up in a way that they were unique. This
led to issues where if you had already bootstrapped one, you could not bootstrap
another. During this I realized you could reuse the same bootstrapping file
though! So I simplified that.

Also, we hadn't configured the tests to use bootstrapping properly. They were
still working because there was no easy way to test that bootstrapping works
and the root kubeconfig file exposed by kind gives it everything it needed
to bootstrap the root TLS certs

Huge thanks to @wangyira for finding this