### PR TITLE
fix(*): Fixes Rustls builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1658,9 +1658,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.34.0"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa1b018930b98da87122377ee0f5093d3fb25df762db489c1a321d92e0177afb"
+checksum = "2c0578635e15e33e500d784ce9bdb82b2a0cd18eda82fdc88108eba405b02709"
 dependencies = [
  "Inflector",
  "base64 0.12.1",
@@ -1674,6 +1674,7 @@ dependencies = [
  "k8s-openapi",
  "log 0.4.8",
  "openssl",
+ "pem 0.8.1",
  "reqwest",
  "rustls 0.17.0",
  "serde",
@@ -2158,6 +2159,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59698ea79df9bf77104aefd39cc3ec990cb9693fb59c3b0a70ddf2646fdffb4b"
+dependencies = [
+ "base64 0.12.1",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2509,7 +2521,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c4c907ce15a2c29b03fb48c62a1c965b2d59ce2cbbd737373a01ab041f7217a"
 dependencies = [
  "chrono",
- "pem",
+ "pem 0.7.0",
  "ring",
  "yasna",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ rustls-tls = ["kube/rustls-tls", "kubelet/rustls-tls", "wasi-provider/rustls-tls
 [dependencies]
 anyhow = "1.0"
 tokio = { version = "0.2", features = ["macros"] }
-kube = { version= "0.34", default-features = false }
+kube = { version= "0.35", default-features = false }
 env_logger = "0.7"
 kubelet = { path = "./crates/kubelet", version = "0.3", default-features = false, features = ["cli"] }
 wascc-provider = { path = "./crates/wascc-provider", version = "0.3", default-features = false }

--- a/crates/kubelet/Cargo.toml
+++ b/crates/kubelet/Cargo.toml
@@ -27,8 +27,8 @@ maintenance = { status = "actively-developed" }
 
 [features]
 default = ["kube-native-tls"]
-kube-native-tls = ["kube/native-tls", "oci-distribution/native-tls"]
-rustls-tls = ["kube/rustls-tls", "oci-distribution/rustls-tls"]
+kube-native-tls = ["kube/native-tls", "oci-distribution/native-tls", "reqwest/native-tls"]
+rustls-tls = ["kube/rustls-tls", "oci-distribution/rustls-tls", "reqwest/rustls-tls"]
 cli = ["structopt"]
 docs = ["cli"]
 
@@ -43,9 +43,9 @@ serde_json = "1.0"
 serde_yaml = "0.8"
 hyper = { version = "0.13", default-features = false, features = ["stream"] }
 log = "0.4"
-reqwest = "0.10"
+reqwest = { version = "0.10", default-features = false, features = ["json", "stream"]}
 tokio  = { version = "0.2", features = ["fs", "stream", "macros", "signal"] }
-kube = { version= "0.34", default-features = false }
+kube = { version= "0.35", default-features = false }
 k8s-openapi = { version = "0.8", default-features = false, features = ["v1_17"] }
 chrono = { version = "0.4", features = ["serde"] }
 structopt = { version = "0.3", features = ["wrap_help"], optional = true }

--- a/crates/wascc-provider/Cargo.toml
+++ b/crates/wascc-provider/Cargo.toml
@@ -26,7 +26,7 @@ log = "0.4"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-kube = { version= "0.34", default-features = false }
+kube = { version= "0.35", default-features = false }
 kubelet = { path = "../kubelet", version = "0.3", default-features = false }
 tokio = { version = "0.2", features = ["fs", "macros"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/wasi-provider/Cargo.toml
+++ b/crates/wasi-provider/Cargo.toml
@@ -21,7 +21,7 @@ rustls-tls = ["kube/rustls-tls", "kubelet/rustls-tls"]
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-kube = { version= "0.34", default-features = false }
+kube = { version= "0.35", default-features = false }
 log = "0.4"
 wasmtime = "0.16"
 wasmtime-wasi = "0.16"

--- a/justfile
+++ b/justfile
@@ -16,11 +16,11 @@ test:
 test-e2e:
     cargo test --test integration_tests
 
-run-wascc: bootstrap
-    KUBECONFIG=$(eval echo $CONFIG_DIR)/kubeconfig-wascc cargo run --bin krustlet-wascc -- --node-name krustlet-wascc --port 3000 --bootstrap-file $(eval echo $CONFIG_DIR)/bootstrap.conf --cert-file $(eval echo $CONFIG_DIR)/krustlet-wascc.crt --private-key-file $(eval echo $CONFIG_DIR)/krustlet-wascc.key
+run-wascc +FLAGS='': bootstrap
+    KUBECONFIG=$(eval echo $CONFIG_DIR)/kubeconfig-wascc cargo run --bin krustlet-wascc {{FLAGS}} -- --node-name krustlet-wascc --port 3000 --bootstrap-file $(eval echo $CONFIG_DIR)/bootstrap.conf --cert-file $(eval echo $CONFIG_DIR)/krustlet-wascc.crt --private-key-file $(eval echo $CONFIG_DIR)/krustlet-wascc.key
 
-run-wasi: bootstrap
-    KUBECONFIG=$(eval echo $CONFIG_DIR)/kubeconfig-wasi cargo run --bin krustlet-wasi -- --node-name krustlet-wasi --port 3001 --bootstrap-file $(eval echo $CONFIG_DIR)/bootstrap.conf --cert-file $(eval echo $CONFIG_DIR)/krustlet-wasi.crt --private-key-file $(eval echo $CONFIG_DIR)/krustlet-wasi.key
+run-wasi +FLAGS='': bootstrap
+    KUBECONFIG=$(eval echo $CONFIG_DIR)/kubeconfig-wasi cargo run --bin krustlet-wasi {{FLAGS}} -- --node-name krustlet-wasi --port 3001 --bootstrap-file $(eval echo $CONFIG_DIR)/bootstrap.conf --cert-file $(eval echo $CONFIG_DIR)/krustlet-wasi.crt --private-key-file $(eval echo $CONFIG_DIR)/krustlet-wasi.key
 
 bootstrap:
     @# This is to get around an issue with the default function returning a string that gets escaped


### PR DESCRIPTION
We were missing some feature enablement on the reqwest dependency.
I also took the time to update us to the latest version of the `kube`
crate. This has been tested against a "real" (AKS in this instance)
Kubernetes cluster and works great. There are still problems with
running it with minikube, kind, and any other cluster that doesn't
have an actual FQDN. This is an upstream issue that we'll need to
tackle separately

This is part of the work for #20 