### PR TITLE
Fix typo and Bootstrapping clarification

### DIFF
--- a/demos/wasi/simpleserver/README.md
+++ b/demos/wasi/simpleserver/README.md
@@ -35,6 +35,6 @@ You will need to log into your container registry to do this. At this time, Dock
 
 Update the `simpleserver.yaml` to point to the image that you pushed in the previous step.
 
-Use `kubetcl apply -f simpleserver.yaml`
+Use `kubectl apply -f simpleserver.yaml`
 
 From there, you can check on the pod with `kubectl logs simpleserver`. You should see log messages written to the console every five seconds or so.

--- a/docs/howto/bootstrapping.md
+++ b/docs/howto/bootstrapping.md
@@ -131,7 +131,7 @@ Once you have the bootstrap config in place, you can run Krustlet:
 $ KUBECONFIG=~/.krustlet/config/kubeconfig krustlet-wasi --port 3000 --bootstrap-file /path/to/your/bootstrap.conf
 ```
 
-Krustlet will begin the bootstraping process, and then **await manual certificate approval** (described below) before launching.
+Krustlet will begin the bootstrapping process, and then **await manual certificate approval** (described below) before launching.
 
 A couple important notes here. `KUBECONFIG` should almost always be set, especially in
 developer/local machine situations. During the bootstrap process, Krustlet will generate a

--- a/docs/howto/bootstrapping.md
+++ b/docs/howto/bootstrapping.md
@@ -131,6 +131,8 @@ Once you have the bootstrap config in place, you can run Krustlet:
 $ KUBECONFIG=~/.krustlet/config/kubeconfig krustlet-wasi --port 3000 --bootstrap-file /path/to/your/bootstrap.conf
 ```
 
+Krustlet will begin the bootstraping process, and then **await manual certificate approval** (described below) before launching.
+
 A couple important notes here. `KUBECONFIG` should almost always be set, especially in
 developer/local machine situations. During the bootstrap process, Krustlet will generate a
 kubeconfig with the credentials it obtains during the bootstrapping process and write it out to the

--- a/docs/howto/krustlet-on-kind.md
+++ b/docs/howto/krustlet-on-kind.md
@@ -15,7 +15,7 @@ Kubernetes control plane, including KinD itself.
 ## Step 1: Get a bootstrap config
 
 Krustlet requires a bootstrap token and config the first time it runs. Follow the guide
-[here](bootstrapping.md) to generate a bootstrap config and then return to this document. This will
+[here](bootstrapping.md) to generate a bootstrap config and then return to this document.
 If you already have a kubeconfig available that you generated through another process, you can
 proceed to the next step. However, the credentials Krustlet uses must be part of the `system:nodes`
 group in order for things to function properly.


### PR DESCRIPTION
I'm still concerned that it isn't very clear. The bootstrapping procedure appears to be duplicated in several places (each Kubernetes flavor). Might be better to point them all at the one Bootstrapping README. 