### PR TITLE
Add automatic port mapping for waSCC demos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4007,6 +4007,7 @@ dependencies = [
  "kubelet",
  "log 0.4.8",
  "oci-distribution",
+ "rand 0.7.3",
  "serde",
  "serde_derive",
  "serde_json",

--- a/crates/wascc-provider/Cargo.toml
+++ b/crates/wascc-provider/Cargo.toml
@@ -36,6 +36,7 @@ wascc-fs = { version = "0.0.5", features = ["static_plugin"] }
 wascc-logging = { path = "../wascc-logging", version = "0.1", features = ["static_plugin"] }
 wascc-httpsrv = { version = "0.6", features = ["static_plugin"] }
 k8s-openapi = { version = "0.8", default-features = false, features = ["v1_17"] }
+rand = "0.7.3"
 
 [dev-dependencies]
 oci-distribution = { path = "../oci-distribution", version = "0.2" }

--- a/crates/wascc-provider/src/lib.rs
+++ b/crates/wascc-provider/src/lib.rs
@@ -562,7 +562,6 @@ async fn find_available_port(
         let generated_port: i32 = rand::thread_rng().gen_range(30000, 32768);
         port.replace(generated_port);
         empty_port.insert(port.unwrap());
-
         if !lock.contains_key(&port.unwrap()) {
             lock.insert(port.unwrap(), pod_name);
             break;

--- a/crates/wascc-provider/src/lib.rs
+++ b/crates/wascc-provider/src/lib.rs
@@ -226,7 +226,7 @@ impl<S: Store + Send + Sync> Provider for WasccProvider<S> {
         let volumes = Ref::volumes_from_pod(&self.volume_path, &pod, &client).await?;
         for container in pod.containers() {
             let mut port_assigned: i32 = 0;
-            if let Some(container_vec) = container.ports.as_ref() {
+            if let Some(container_vec) = container.ports().as_ref() {
                 for c_port in container_vec.iter() {
                     let container_port = c_port.container_port;
                     if let Some(host_port) = c_port.host_port {

--- a/crates/wascc-provider/src/lib.rs
+++ b/crates/wascc-provider/src/lib.rs
@@ -44,6 +44,8 @@ use kubelet::provider::ProviderError;
 use kubelet::store::Store;
 use kubelet::volume::Ref;
 use log::{debug, error, info, trace};
+use std::error::Error;
+use std::fmt;
 use tempfile::NamedTempFile;
 use tokio::sync::watch::{self, Receiver};
 use tokio::sync::RwLock;
@@ -222,35 +224,24 @@ impl<S: Store + Send + Sync> Provider for WasccProvider<S> {
         let client = kube::Client::new(self.kubeconfig.clone());
         let volumes = Ref::volumes_from_pod(&self.volume_path, &pod, &client).await?;
         for container in pod.containers() {
-            //switch code to here, before env var gets set
             let mut port_assigned: i32 = 0;
+            info!(
+                "The following ports are already taken: {:?}",
+                self.port_set.lock().unwrap()
+            );
             if let Some(container_vec) = container.ports.as_ref() {
                 for c_port in container_vec.iter() {
                     let container_port = c_port.container_port;
                     let host_port = c_port.host_port;
-                    //self.port_set.lock().unwrap().insert(30000);
                     if c_port.host_port.is_none() {
-                        println!("host port is not specified");
                         if container_port >= 0 && container_port <= 65536 {
-                            //find a port that's not taken and assign it
-                            port_assigned = find_available_port(&self.port_set);
-                            if port_assigned == -1 {
-                                error!("Failed to assign port {}, all ports between 30000 and 32767 are taken", &host_port.unwrap());
-                                return Err(anyhow::anyhow!(
-                                    "All ports between 30000 and 32767 are taken"
-                                ));
-                            }
+                            port_assigned = find_available_port(&self.port_set)?;
                         }
                     } else {
-                        println!("host port is specified");
-
                         if !self.port_set.lock().unwrap().contains(&host_port.unwrap()) {
-                            //not taken, assign that port
                             port_assigned = host_port.unwrap();
-                            println!("host port is available, so assign it");
                             self.port_set.lock().unwrap().insert(port_assigned);
                         } else {
-                            //port is taken, error
                             error!(
                                 "Failed to assign hostport {}, because it's taken",
                                 &host_port.unwrap()
@@ -263,12 +254,7 @@ impl<S: Store + Send + Sync> Provider for WasccProvider<S> {
                     }
                 }
             }
-            println!(
-                "ports that are already taken: {:?}",
-                self.port_set.lock().unwrap()
-            );
-            println!("new port assigned is: {}", port_assigned);
-            //container.env
+            debug!("New port assigned is: {}", port_assigned);
             let env = Self::env_vars(&container, &pod, &client).await;
             let volume_bindings: Vec<VolumeBinding> =
                 if let Some(volume_mounts) = container.volume_mounts().as_ref() {
@@ -307,7 +293,6 @@ impl<S: Store + Send + Sync> Provider for WasccProvider<S> {
             });
             let host = self.host.clone();
             let http_result = tokio::task::spawn_blocking(move || {
-                println!("wascc run http");
                 wascc_run_http(
                     host,
                     module_data,
@@ -544,7 +529,26 @@ fn wascc_run_http(
     wascc_run(host, data, &mut caps, volumes, log_path, status_recv)
 }
 
-fn find_available_port(port_set: &Arc<Mutex<HashSet<i32>>>) -> i32 {
+#[derive(Debug)]
+struct PortAllocationError {}
+
+impl PortAllocationError {
+    fn new() -> PortAllocationError {
+        PortAllocationError {}
+    }
+}
+impl fmt::Display for PortAllocationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "all ports are currently in use")
+    }
+}
+impl Error for PortAllocationError {
+    fn description(&self) -> &str {
+        "all ports are currently in use"
+    }
+}
+
+fn find_available_port(port_set: &Arc<Mutex<HashSet<i32>>>) -> Result<i32, PortAllocationError> {
     let mut range = rand::thread_rng();
     let mut port: i32 = -1;
 
@@ -557,7 +561,11 @@ fn find_available_port(port_set: &Arc<Mutex<HashSet<i32>>>) -> i32 {
             break;
         }
     }
-    port
+
+    if port == -1 {
+        return Err(PortAllocationError::new());
+    }
+    Ok(port)
 }
 
 /// Capability describes a waSCC capability.

--- a/demos/wascc/fileserver/README.md
+++ b/demos/wascc/fileserver/README.md
@@ -21,6 +21,9 @@ Create the pod and configmap with `kubectl`:
 $ kubectl create -f k8s.yaml
 ```
 
+If the container port is specified in the yaml file, but host port is not. A random port will be assigned. Look for **New port assigned is: xxxxx"** in the logs. Then, run **curl localhost:xxxxx** with the assigned port number.
+To assign a specific host port, add **hostPort: xxxxx** in the yaml files in a new line under containerPort: 8080
+
 ## Building the example
 
 To set up your development environment, you'll need the following tools:

--- a/demos/wascc/fileserver/k8s.yaml
+++ b/demos/wascc/fileserver/k8s.yaml
@@ -11,7 +11,6 @@ spec:
       name: fileserver-wascc
       env:
         - name: PORT
-          value: "8080"
       ports:
         - containerPort: 8080
       volumeMounts:

--- a/demos/wascc/fileserver/k8s.yaml
+++ b/demos/wascc/fileserver/k8s.yaml
@@ -9,8 +9,6 @@ spec:
     - image: webassembly.azurecr.io/fileserver-wascc:v0.2.0
       imagePullPolicy: Always
       name: fileserver-wascc
-      env:
-        - name: PORT
       ports:
         - containerPort: 8080
       volumeMounts:

--- a/demos/wascc/greet/README.md
+++ b/demos/wascc/greet/README.md
@@ -14,3 +14,6 @@ Create the pod and configmap with `kubectl`:
 ```shell
 $ kubectl apply -f greet-wascc.yaml
 ```
+
+If the container port is specified in the yaml file, but host port is not. A random port will be assigned. Look for **New port assigned is: xxxxx"** in the logs. Then, run **curl localhost:xxxxx** with the assigned port number.
+To assign a specific host port, add **hostPort: xxxxx** in the yaml files in a new line under containerPort: 8080

--- a/demos/wascc/greet/greet-wascc.yaml
+++ b/demos/wascc/greet/greet-wascc.yaml
@@ -10,8 +10,8 @@ spec:
       imagePullPolicy: Always
       name: greet
       env:
-      - name: PORT
-        value: "8080"
+        - name: PORT
+          value: "8080"
       ports:
         - containerPort: 8080
   nodeSelector:

--- a/demos/wascc/greet/greet-wascc.yaml
+++ b/demos/wascc/greet/greet-wascc.yaml
@@ -11,7 +11,6 @@ spec:
       name: greet
       env:
         - name: PORT
-          value: "8080"
       ports:
         - containerPort: 8080
   nodeSelector:

--- a/demos/wascc/greet/greet-wascc.yaml
+++ b/demos/wascc/greet/greet-wascc.yaml
@@ -9,8 +9,6 @@ spec:
     - image: webassembly.azurecr.io/greet-wascc:v0.5
       imagePullPolicy: Always
       name: greet
-      env:
-        - name: PORT
       ports:
         - containerPort: 8080
   nodeSelector:

--- a/demos/wascc/hello-world-assemblyscript/README.md
+++ b/demos/wascc/hello-world-assemblyscript/README.md
@@ -16,6 +16,9 @@ Create the pod and configmap with `kubectl`:
 $ kubectl apply -f k8s.yaml
 ```
 
+If the container port is specified in the yaml file, but host port is not. A random port will be assigned. Look for **New port assigned is: xxxxx"** in the logs. Then, run **curl localhost:xxxxx** with the assigned port number.
+To assign a specific host port, add **hostPort: xxxxx** in the yaml files in a new line under containerPort: 8080
+
 ## Building from Source
 
 If you want to compile the demo and inspect it, you'll need to do the following.

--- a/demos/wascc/hello-world-assemblyscript/k8s.yaml
+++ b/demos/wascc/hello-world-assemblyscript/k8s.yaml
@@ -8,7 +8,6 @@ spec:
       image: webassembly.azurecr.io/hello-world-wascc-assemblyscript:v0.1.0
       env:
         - name: PORT
-          value: "8080"
       ports:
         - containerPort: 8080
   nodeSelector:

--- a/demos/wascc/hello-world-assemblyscript/k8s.yaml
+++ b/demos/wascc/hello-world-assemblyscript/k8s.yaml
@@ -6,8 +6,6 @@ spec:
   containers:
     - name: hello-world-wascc-assemblyscript
       image: webassembly.azurecr.io/hello-world-wascc-assemblyscript:v0.1.0
-      env:
-        - name: PORT
       ports:
         - containerPort: 8080
   nodeSelector:

--- a/demos/wascc/uppercase/README.md
+++ b/demos/wascc/uppercase/README.md
@@ -18,3 +18,6 @@ Create the pod and configmap with `kubectl`:
 ```shell
 $ kubectl apply -f uppercase-wascc.yaml
 ```
+
+If the container port is specified in the yaml file, but host port is not. A random port will be assigned. Look for **New port assigned is: xxxxx"** in the logs. Then, run **curl localhost:xxxxx** with the assigned port number.
+To assign a specific host port, add **hostPort: xxxxx** in the yaml files in a new line under containerPort: 8080

--- a/demos/wascc/uppercase/uppercase-wascc.yaml
+++ b/demos/wascc/uppercase/uppercase-wascc.yaml
@@ -10,8 +10,8 @@ spec:
       imagePullPolicy: Always
       name: uppercase
       env:
-      - name: PORT
-        value: "8080"
+        - name: PORT
+          value: "8080"
       ports:
         - containerPort: 8080
   nodeSelector:

--- a/demos/wascc/uppercase/uppercase-wascc.yaml
+++ b/demos/wascc/uppercase/uppercase-wascc.yaml
@@ -9,8 +9,6 @@ spec:
     - image: webassembly.azurecr.io/uppercase-wascc:v0.3
       imagePullPolicy: Always
       name: uppercase
-      env:
-        - name: PORT
       ports:
         - containerPort: 8080
   nodeSelector:

--- a/demos/wascc/uppercase/uppercase-wascc.yaml
+++ b/demos/wascc/uppercase/uppercase-wascc.yaml
@@ -11,7 +11,6 @@ spec:
       name: uppercase
       env:
         - name: PORT
-          value: "8080"
       ports:
         - containerPort: 8080
   nodeSelector:

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -67,6 +67,12 @@ async fn test_wascc_provider() -> Result<(), Box<dyn std::error::Error>> {
                 {
                     "name": "greet-wascc",
                     "image": "webassembly.azurecr.io/greet-wascc:v0.4",
+                    "ports": [
+                        {
+                            "containerPort": 8080,
+                            "hostPort": 30000
+                        }
+                    ],
                 },
             ],
             "tolerations": [
@@ -83,7 +89,6 @@ async fn test_wascc_provider() -> Result<(), Box<dyn std::error::Error>> {
     let pod = pods.create(&PostParams::default(), &p).await?;
 
     assert_eq!(pod.status.unwrap().phase.unwrap(), "Pending");
-
     let api = Api::namespaced(client, "default");
     let inf: Informer<Pod> = Informer::new(api).params(
         ListParams::default()
@@ -112,7 +117,7 @@ async fn test_wascc_provider() -> Result<(), Box<dyn std::error::Error>> {
     assert!(went_ready, "pod never went ready");
 
     // Send a request to the pod to trigger some logging
-    reqwest::get("http://127.0.0.1:8080")
+    reqwest::get("http://127.0.0.1:30000")
         .await
         .expect("unable to perform request to test pod");
 


### PR DESCRIPTION
Fixes #288 
When multiple waSCC demos are running on the same port (containerPort or hostPort), to avoid thread panics, automatically maps the ports following these behaviors: 
1. If containerPort is specified and hostPort is not, then automatically assign a port number
2. If hostPort is specified (whether or not containerPort is specified), then try to assign that port number. If it is taken, the pod will error (the pod fails)