### PR TITLE
continue on error when `cargo publish` fails

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,8 @@ jobs:
       - name: publish oci-distribution to crates.io
         working-directory: ./crates/oci-distribution
         run: cargo publish --token ${{ secrets.CargoToken }}
+        continue-on-error: true
       - name: publish kubelet to crates.io
         working-directory: ./crates/kubelet
         run: cargo publish --token ${{ secrets.CargoToken }}
+        continue-on-error: true


### PR DESCRIPTION
closes #263 by allowing the job to succeed when `cargo publish` fails to release a package.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>