### PR TITLE
Support init containers

### DIFF
--- a/crates/kubelet/src/container/handle.rs
+++ b/crates/kubelet/src/container/handle.rs
@@ -53,7 +53,7 @@ impl<H: StopHandler, F> Handle<H, F> {
 
     /// Returns a clone of the status_channel for use in reporting the status to
     /// another process
-    pub(crate) fn status(&self) -> Receiver<Status> {
+    pub fn status(&self) -> Receiver<Status> {
         self.status_channel.clone()
     }
 

--- a/crates/kubelet/src/node/mod.rs
+++ b/crates/kubelet/src/node/mod.rs
@@ -3,7 +3,7 @@
 use crate::config::Config;
 use crate::container::Status as ContainerStatus;
 use crate::pod::Pod;
-use crate::pod::Status as PodStatus;
+use crate::pod::{Status as PodStatus, StatusMessage as PodStatusMessage};
 use crate::provider::Provider;
 use chrono::prelude::*;
 use futures::{StreamExt, TryStreamExt};
@@ -218,7 +218,7 @@ pub async fn evict_pods(client: &kube::Client, node_name: &str) -> anyhow::Resul
                 );
             }
             let status = PodStatus {
-                message: Some("Evicted on node shutdown.".to_string()),
+                message: PodStatusMessage::Message("Evicted on node shutdown.".to_string()),
                 container_statuses,
             };
             pod.patch_status(client.clone(), status).await;

--- a/crates/kubelet/src/pod/handle.rs
+++ b/crates/kubelet/src/pod/handle.rs
@@ -10,7 +10,7 @@ use crate::container::Handle as ContainerHandle;
 use crate::handle::StopHandler;
 use crate::log::{HandleFactory, Sender};
 use crate::pod::Pod;
-use crate::pod::Status;
+use crate::pod::{Status, StatusMessage};
 use crate::provider::ProviderError;
 use crate::volume::Ref;
 
@@ -32,12 +32,31 @@ impl<H: StopHandler, F> Handle<H, F> {
     /// kubernetes object and to be able to update the status of that object. The optional volumes
     /// parameter allows a caller to pass a map of volumes to keep reference to (so that they will
     /// be dropped along with the pod)
-    pub fn new(
+    pub async fn new(
         container_handles: HashMap<String, ContainerHandle<H, F>>,
         pod: Pod,
         client: kube::Client,
         volumes: Option<HashMap<String, Ref>>,
+        initial_message: Option<String>,
     ) -> anyhow::Result<Self> {
+        let mut all_waiting_map = HashMap::new();
+        for name in container_handles.keys() {
+            let waiting = crate::container::Status::Waiting {
+                timestamp: chrono::Utc::now(),
+                message: "PodInitializing".to_owned(),
+            };
+            all_waiting_map.insert(name.clone(), waiting);
+        }
+        let initial_status_message = match initial_message {
+            Some(m) => StatusMessage::Message(m),
+            None => StatusMessage::Clear,
+        };
+        let all_waiting = Status {
+            message: initial_status_message,
+            container_statuses: all_waiting_map,
+        };
+        pod.clone().patch_status(client.clone(), all_waiting).await;
+
         let mut channel_map = StreamMap::with_capacity(container_handles.len());
         for (name, handle) in container_handles.iter() {
             channel_map.insert(name.clone(), handle.status());
@@ -52,16 +71,20 @@ impl<H: StopHandler, F> Handle<H, F> {
                 let (name, status) = match channel_map.next().await {
                     Some(s) => s,
                     // None means everything is closed, so go ahead and exit
-                    None => return,
+                    None => {
+                        return;
+                    }
                 };
-                debug!("Got status update from container {}: {:#?}", name, status);
+
                 let mut container_statuses = HashMap::new();
                 container_statuses.insert(name, status);
-                let status = Status {
-                    message: None,
+
+                let pod_status = Status {
+                    message: StatusMessage::LeaveUnchanged, // TODO: sure?
                     container_statuses,
                 };
-                cloned_pod.patch_status(client.clone(), status).await;
+
+                cloned_pod.patch_status(client.clone(), pod_status).await;
             }
         });
         Ok(Self {
@@ -113,8 +136,7 @@ impl<H: StopHandler, F> Handle<H, F> {
     /// Wait for all containers in the pod to complete
     pub async fn wait(&mut self) -> anyhow::Result<()> {
         let mut handles = self.container_handles.write().await;
-        for (name, handle) in handles.iter_mut() {
-            debug!("Waiting for container {} to terminate", name);
+        for (_, handle) in handles.iter_mut() {
             handle.wait().await?;
         }
         (&mut self.status_handle).await?;

--- a/crates/kubelet/src/pod/handle.rs
+++ b/crates/kubelet/src/pod/handle.rs
@@ -40,7 +40,8 @@ impl<H: StopHandler, F> Handle<H, F> {
         initial_message: Option<String>,
     ) -> anyhow::Result<Self> {
         let container_names = container_handles.keys().collect();
-        pod.initialise_status(&client, &container_names, initial_message).await;
+        pod.initialise_status(&client, &container_names, initial_message)
+            .await;
 
         let mut channel_map = StreamMap::with_capacity(container_handles.len());
         for (name, handle) in container_handles.iter() {

--- a/crates/kubelet/src/pod/mod.rs
+++ b/crates/kubelet/src/pod/mod.rs
@@ -215,6 +215,17 @@ impl Pod {
             .collect()
     }
 
+    /// Get a pod's init containers
+    pub fn init_containers(&self) -> Vec<Container> {
+        // We can't use and_then because that requires the lambda to return an Option,
+        // but we have to return an &Option to avoid a move.
+        let inits = match self.0.spec.as_ref() {
+            None => &None,
+            Some(spec) => &spec.init_containers
+        };
+        inits.as_ref().unwrap_or_else(|| &EMPTY_VEC).iter().map(|c| Container::new(c)).collect()
+    }
+
     /// Turn the Pod into the Kubernetes API version of a Pod
     pub fn into_kube_pod(self) -> KubePod {
         self.0

--- a/crates/kubelet/src/pod/mod.rs
+++ b/crates/kubelet/src/pod/mod.rs
@@ -217,13 +217,14 @@ impl Pod {
 
     /// Get a pod's init containers
     pub fn init_containers(&self) -> Vec<Container> {
-        // We can't use and_then because that requires the lambda to return an Option,
-        // but we have to return an &Option to avoid a move.
-        let inits = match self.0.spec.as_ref() {
-            None => &None,
-            Some(spec) => &spec.init_containers,
-        };
-        inits.as_ref().unwrap_or_else(|| &EMPTY_VEC).iter().map(|c| Container::new(c)).collect()
+        self.0
+            .spec
+            .as_ref()
+            .and_then(|s| s.init_containers.as_ref())
+            .unwrap_or(&EMPTY_VEC)
+            .iter()
+            .map(|c| Container::new(c))
+            .collect()
     }
 
     /// Turn the Pod into the Kubernetes API version of a Pod

--- a/crates/kubelet/src/pod/mod.rs
+++ b/crates/kubelet/src/pod/mod.rs
@@ -221,7 +221,7 @@ impl Pod {
         // but we have to return an &Option to avoid a move.
         let inits = match self.0.spec.as_ref() {
             None => &None,
-            Some(spec) => &spec.init_containers
+            Some(spec) => &spec.init_containers,
         };
         inits.as_ref().unwrap_or_else(|| &EMPTY_VEC).iter().map(|c| Container::new(c)).collect()
     }

--- a/crates/kubelet/src/pod/status.rs
+++ b/crates/kubelet/src/pod/status.rs
@@ -12,9 +12,26 @@ use crate::container::Status as ContainerStatus;
 pub struct Status {
     /// Allows a provider to set a custom message, otherwise, kubelet will infer
     /// a message from the container statuses
-    pub message: Option<String>,
+    pub message: StatusMessage,
     /// The statuses of containers keyed off their names
     pub container_statuses: HashMap<String, ContainerStatus>,
+}
+
+#[derive(Clone, Debug)]
+/// The message to be set in a pod status update.
+pub enum StatusMessage {
+    /// Do not change the existing status message.
+    LeaveUnchanged,
+    /// Remove any existing status message.
+    Clear,
+    /// Set the status message to the given value.
+    Message(String),
+}
+
+impl Default for StatusMessage {
+    fn default() -> Self {
+        Self::LeaveUnchanged
+    }
 }
 
 /// Describe the lifecycle phase of a workload.

--- a/crates/kubelet/src/store/mod.rs
+++ b/crates/kubelet/src/store/mod.rs
@@ -64,8 +64,15 @@ pub trait Store {
             pod.name()
         );
         // Fetch all of the container modules in parallel
+        // let containers = pod.containers();
+        // let container_module_futures = containers.iter().map(move |container| {
+        //     let reference = container
+        //         .image()
+        //         .expect("Could not parse image.")
+        let init_containers = pod.init_containers();
         let containers = pod.containers();
-        let container_module_futures = containers.iter().map(move |container| {
+        let all_containers = init_containers.iter().chain(containers.iter());
+        let container_module_futures = all_containers.map(move |container| {
             let reference = container
                 .image()
                 .expect("Could not parse image.")

--- a/crates/wascc-provider/src/lib.rs
+++ b/crates/wascc-provider/src/lib.rs
@@ -269,7 +269,7 @@ impl<S: Store + Send + Sync> WasccProvider<S> {
                         timestamp: chrono::Utc::now(),
                     })
                     .expect("status should be able to send");
-                return Ok(());
+                Ok(())
             }
             Err(e) => {
                 // We can't broadcast here because the receiver has been dropped at this point
@@ -288,7 +288,7 @@ impl<S: Store + Send + Sync> WasccProvider<S> {
                     container_statuses,
                 };
                 pod.patch_status(client.clone(), status).await;
-                return Err(anyhow::anyhow!("Failed to run pod: {}", e));
+                Err(anyhow::anyhow!("Failed to run pod: {}", e))
             }
         }
     }

--- a/crates/wascc-provider/src/lib.rs
+++ b/crates/wascc-provider/src/lib.rs
@@ -199,7 +199,7 @@ impl<S: Store + Send + Sync> WasccProvider<S> {
         })
     }
 
-    async fn start_one_container(
+    async fn start_container(
         &self,
         container: &Container,
         pod: &Pod,
@@ -345,7 +345,7 @@ impl<S: Store + Send + Sync> Provider for WasccProvider<S> {
             }
             debug!("New port assigned is: {}", port_assigned);
 
-            self.start_one_container(
+            self.start_container(
                 &container,
                 &pod,
                 &client,

--- a/crates/wascc-provider/src/lib.rs
+++ b/crates/wascc-provider/src/lib.rs
@@ -506,6 +506,12 @@ impl<S: Store + Send + Sync> Provider for WasccProvider<S> {
 }
 
 fn validate_pod_runnable(pod: &Pod) -> anyhow::Result<()> {
+    if !pod.init_containers().is_empty() {
+        return Err(anyhow::anyhow!(
+            "Cannot run {}: spec specifies init containers which are not supported on wasCC",
+            pod.name()
+        ));
+    }
     for container in pod.containers() {
         validate_container_runnable(&container)?;
     }

--- a/crates/wasi-provider/src/lib.rs
+++ b/crates/wasi-provider/src/lib.rs
@@ -203,6 +203,7 @@ impl<S: Store + Send + Sync> WasiProvider<S> {
                 failed,
             }) = status.next().await
             {
+                container_handles.remove(&container.name);
                 return Ok(ContainerTerminationResult {
                     succeeded: !failed,
                     message,
@@ -238,6 +239,7 @@ impl<S: Store + Send + Sync> Provider for WasiProvider<S> {
         for container in pod.init_containers() {
             self.run_one_container_to_completion(&container, &pod, &client, &mut modules, &volumes, &mut container_handles).await?;
         }
+        info!("Finished running init containers for pod {:?}", pod_name);
         info!("Starting containers for pod {:?}", pod_name);
         for container in pod.containers() {
             self.run_one_container(

--- a/crates/wasi-provider/src/lib.rs
+++ b/crates/wasi-provider/src/lib.rs
@@ -39,6 +39,7 @@ use std::sync::Arc;
 
 use k8s_openapi::api::core::v1::Pod as KubePod;
 use kube::{api::DeleteParams, Api};
+use kubelet::container::Container;
 use kubelet::node::Builder;
 use kubelet::pod::{key_from_pod, pod_key, Handle, Pod};
 use kubelet::provider::Provider;
@@ -83,6 +84,71 @@ impl<S: Store + Send + Sync> WasiProvider<S> {
             kubeconfig,
         })
     }
+
+    fn volume_path_map(
+        container: &Container,
+        volumes: &HashMap<String, Ref>,
+    ) -> anyhow::Result<HashMap<PathBuf, Option<PathBuf>>> {
+        if let Some(volume_mounts) = container.volume_mounts().as_ref() {
+            volume_mounts
+                .iter()
+                .map(|vm| -> anyhow::Result<(PathBuf, Option<PathBuf>)> {
+                    // Check the volume exists first
+                    let vol = volumes.get(&vm.name).ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "no volume with the name of {} found for container {}",
+                            vm.name,
+                            container.name()
+                        )
+                    })?;
+                    let mut guest_path = PathBuf::from(&vm.mount_path);
+                    if let Some(sub_path) = &vm.sub_path {
+                        guest_path.push(sub_path);
+                    }
+                    // We can safely assume that this should be valid UTF-8 because it would have
+                    // been validated by the k8s API
+                    Ok((vol.deref().clone(), Some(guest_path)))
+                })
+                .collect::<anyhow::Result<HashMap<PathBuf, Option<PathBuf>>>>()
+        } else {
+            Ok(HashMap::default())
+        }
+    }
+
+    async fn run_one_container(
+        &self,
+        container: &Container,
+        pod: &Pod,
+        client: &kube::client::Client,
+        modules: &mut HashMap<String, Vec<u8>>,
+        volumes: &HashMap<String, Ref>,
+        container_handles: &mut HashMap<
+            String,
+            kubelet::container::Handle<wasi_runtime::Runtime, wasi_runtime::HandleFactory>,
+        >,
+    ) -> anyhow::Result<()> {
+        let env = Self::env_vars(&container, &pod, &client).await;
+        let args = container.args().clone().unwrap_or_default();
+        let module_data = modules
+            .remove(container.name())
+            .expect("FATAL ERROR: module map not properly populated");
+        let container_volumes = Self::volume_path_map(container, volumes)?;
+
+        let runtime = WasiRuntime::new(
+            module_data,
+            env,
+            args,
+            container_volumes,
+            self.log_path.clone(),
+        )
+        .await?;
+
+        debug!("Starting container {} on thread", container.name());
+        let handle = runtime.start().await?;
+        container_handles.insert(container.name().to_string(), handle);
+
+        Ok(())
+    }
 }
 
 #[async_trait::async_trait]
@@ -109,49 +175,15 @@ impl<S: Store + Send + Sync> Provider for WasiProvider<S> {
         let volumes = Ref::volumes_from_pod(&self.volume_path, &pod, &client).await?;
         info!("Starting containers for pod {:?}", pod_name);
         for container in pod.containers() {
-            let env = Self::env_vars(&container, &pod, &client).await;
-            let args = container.args().clone().unwrap_or_default();
-            let module_data = modules
-                .remove(container.name())
-                .expect("FATAL ERROR: module map not properly populated");
-            let container_volumes: HashMap<PathBuf, Option<PathBuf>> =
-                if let Some(volume_mounts) = container.volume_mounts().as_ref() {
-                    volume_mounts
-                        .iter()
-                        .map(|vm| -> anyhow::Result<(PathBuf, Option<PathBuf>)> {
-                            // Check the volume exists first
-                            let vol = volumes.get(&vm.name).ok_or_else(|| {
-                                anyhow::anyhow!(
-                                    "no volume with the name of {} found for container {}",
-                                    vm.name,
-                                    container.name()
-                                )
-                            })?;
-                            let mut guest_path = PathBuf::from(&vm.mount_path);
-                            if let Some(sub_path) = &vm.sub_path {
-                                guest_path.push(sub_path);
-                            }
-                            // We can safely assume that this should be valid UTF-8 because it would have
-                            // been validated by the k8s API
-                            Ok((vol.deref().clone(), Some(guest_path)))
-                        })
-                        .collect::<anyhow::Result<_>>()?
-                } else {
-                    HashMap::default()
-                };
-
-            let runtime = WasiRuntime::new(
-                module_data,
-                env,
-                args,
-                container_volumes,
-                self.log_path.clone(),
+            self.run_one_container(
+                &container,
+                &pod,
+                &client,
+                &mut modules,
+                &volumes,
+                &mut container_handles,
             )
-            .await?;
-
-            debug!("Starting container {} on thread", container.name());
-            let handle = runtime.start().await?;
-            container_handles.insert(container.name().to_string(), handle);
+            .await?
         }
         info!(
             "All containers started for pod {:?}. Updating status",

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -352,13 +352,24 @@ async fn create_pod_with_init_containers(
                             "name": "hostpath-test"
                         }
                     ]
+                },
+                {
+                    "name": "init-2",
+                    "image": "webassembly.azurecr.io/wasmerciser:v0.1.0",
+                    "args": [ "write(lit:kiki)to(file:/hp/neatcat.txt)" ],
+                    "volumeMounts": [
+                        {
+                            "mountPath": "/hp",
+                            "name": "hostpath-test"
+                        }
+                    ]
                 }
             ],
             "containers": [
                 {
                     "name": pod_name,
                     "image": "webassembly.azurecr.io/wasmerciser:v0.1.0",
-                    "args": [ "assert_exists(file:/hp/floofycat.txt)", "read(file:/hp/floofycat.txt)to(var:fcat)", "assert_value(var:fcat)is(lit:slats)", "write(var:fcat)to(stm:stdout)" ],
+                    "args": [ "assert_exists(file:/hp/floofycat.txt)", "assert_exists(file:/hp/neatcat.txt)", "read(file:/hp/floofycat.txt)to(var:fcat)", "assert_value(var:fcat)is(lit:slats)", "write(var:fcat)to(stm:stdout)" ],
                     "volumeMounts": [
                         {
                             "mountPath": "/hp",

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -342,7 +342,6 @@ async fn create_fancy_schmancy_wasi_pod(
 
 async fn create_faily_pod(client: kube::Client, pods: &Api<Pod>) -> anyhow::Result<()> {
     let pod_name = FAILY_POD;
-    let pod_name = INITY_WASI_POD;
     let p = serde_json::from_value(json!({
         "apiVersion": "v1",
         "kind": "Pod",

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -164,7 +164,7 @@ impl Drop for WasccTestResourceCleaner {
     fn drop(&mut self) {
         let t = std::thread::spawn(move || {
             let mut rt =
-                tokio::runtime::Runtime::new().expect("Failed to reate Tokio runtime for cleanup");
+                tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime for cleanup");
             rt.block_on(clean_up_wascc_test_resources());
         });
 
@@ -642,7 +642,7 @@ impl Drop for WasiTestResourceCleaner {
     fn drop(&mut self) {
         let t = std::thread::spawn(move || {
             let mut rt =
-                tokio::runtime::Runtime::new().expect("Failed to reate Tokio runtime for cleanup");
+                tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime for cleanup");
             rt.block_on(clean_up_wasi_test_resources())
         });
 

--- a/tests/pod_builder.rs
+++ b/tests/pod_builder.rs
@@ -1,0 +1,107 @@
+use std::sync::Arc;
+use k8s_openapi::api::core::v1::{Container, Pod, Volume, VolumeMount};
+use serde_json::json;
+
+pub struct PodLifetimeOwner {
+    pub pod: Pod,
+    _tempdirs: Vec<Arc<tempfile::TempDir>>,  // only to keep the directories alive
+}
+
+pub struct WasmerciserContainerSpec {
+    pub name: &'static str,
+    pub args: &'static [&'static str],
+}
+
+pub struct WasmerciserVolumeSpec {
+    pub volume_name: &'static str,
+    pub mount_path: &'static str,
+}
+
+fn wasmerciser_container(
+    spec: &WasmerciserContainerSpec,
+    volumes: &Vec<WasmerciserVolumeSpec>,
+) -> anyhow::Result<Container> {
+    let volume_mounts: Vec<_> = volumes
+        .iter()
+        .map(|v| wasmerciser_volume_mount(v).unwrap())
+        .collect();
+    let container: Container = serde_json::from_value(json!({
+        "name": spec.name,
+        "image": "webassembly.azurecr.io/wasmerciser:v0.1.0",
+        "args": spec.args,
+        "volumeMounts": volume_mounts,
+    }))?;
+    Ok(container)
+}
+
+fn wasmerciser_volume_mount(spec: &WasmerciserVolumeSpec) -> anyhow::Result<VolumeMount> {
+    let mount: VolumeMount = serde_json::from_value(json!({
+        "mountPath": spec.mount_path,
+        "name": spec.volume_name
+    }))?;
+    Ok(mount)
+}
+
+fn wasmerciser_volume(spec: &WasmerciserVolumeSpec) -> anyhow::Result<(Volume, Arc<tempfile::TempDir>)> {
+    let tempdir = Arc::new(tempfile::tempdir()?);
+
+    let volume: Volume = serde_json::from_value(json!({
+        "name": spec.volume_name,
+        "hostPath": {
+            "path": tempdir.path()
+        }
+    }))?;
+
+    Ok((volume, tempdir))
+}
+
+pub fn wasmerciser_pod(
+    pod_name: &str,
+    inits: Vec<WasmerciserContainerSpec>,
+    containers: Vec<WasmerciserContainerSpec>,
+    test_volumes: Vec<WasmerciserVolumeSpec>,
+) -> anyhow::Result<PodLifetimeOwner> {
+    let init_container_specs: Vec<_> = inits
+        .iter()
+        .map(|spec| wasmerciser_container(spec, &test_volumes).unwrap())
+        .collect();
+    let app_container_specs: Vec<_> = containers
+        .iter()
+        .map(|spec| wasmerciser_container(spec, &test_volumes).unwrap())
+        .collect();
+
+    let volume_maps: Vec<_> = test_volumes
+        .iter()
+        .map(|spec| wasmerciser_volume(spec).unwrap())
+        .collect();
+    let (volumes, tempdirs) = unzip(&volume_maps);
+
+    let pod = serde_json::from_value(json!({
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+            "name": pod_name
+        },
+        "spec": {
+            "initContainers": init_container_specs,
+            "containers": app_container_specs,
+            "tolerations": [
+                {
+                    "effect": "NoExecute",
+                    "key": "krustlet/arch",
+                    "operator": "Equal",
+                    "value": "wasm32-wasi"
+                },
+            ],
+            "volumes": volumes,
+        }
+    }))?;
+
+    Ok(PodLifetimeOwner{ pod, _tempdirs: tempdirs })
+}
+
+fn unzip<T, U: Clone>(source: &Vec<(T, U)>) -> (Vec<&T>, Vec<U>) {
+    let ts: Vec<_> = source.iter().map(|v| &v.0).collect();
+    let us: Vec<_> = source.iter().map(|v| v.1.clone()).collect();
+    (ts, us)
+}


### PR DESCRIPTION
Fixes #25 

**NOTES:**

* This first drop _only supports init containers in the WASI provider._  #25 requires them for all runtimes.
* ~waSCC will be harder to test because it doesn't allow us to pass command line args.  We can address this by improving the wasmerciser to accept commands via an environment variable as well as the command line.~ _EV support is now implemented_
* ~This will not currently pass CI because the integrations tests use the wasmerciser (to write a file in the init container and then read it back in the main container).  I've checked the tests pass on my machine by using a hacked store that can load from local `.wasm` files, but they won't work yet with the real OCI store.~