### PR TITLE
Implement an API similar to Pod for KubeContainer

### DIFF
--- a/crates/kubelet/src/container/mod.rs
+++ b/crates/kubelet/src/container/mod.rs
@@ -28,7 +28,7 @@ pub enum PullPolicy {
 impl PullPolicy {
     /// Get image pull policy of container applying defaults if None from:
     /// https://kubernetes.io/docs/concepts/configuration/overview/#container-images
-    pub fn parse_with_ref(policy: Option<&str>, image: Option<Reference>) -> anyhow::Result<Self> {
+    pub fn parse_effective(policy: Option<&str>, image: Option<Reference>) -> anyhow::Result<Self> {
         match PullPolicy::parse(policy)? {
             Some(policy) => Ok(policy),
             None => match image {
@@ -100,9 +100,9 @@ impl Container {
         }
     }
 
-    /// Get image pull policy of container.
-    pub fn image_pull_policy(&self) -> anyhow::Result<PullPolicy> {
-        PullPolicy::parse_with_ref(self.0.image_pull_policy.as_deref(), self.image()?)
+    /// Get effective pull policy of container.
+    pub fn effective_pull_policy(&self) -> anyhow::Result<PullPolicy> {
+        PullPolicy::parse_effective(self.0.image_pull_policy.as_deref(), self.image()?)
     }
 
     /// Get lifecycle of container.

--- a/crates/kubelet/src/container/mod.rs
+++ b/crates/kubelet/src/container/mod.rs
@@ -1,6 +1,102 @@
 //! `container` is a collection of utilities surrounding the Kubernetes container API.
+
+use k8s_openapi::api::core::v1::Container as KubeContainer;
+use oci_distribution::Reference;
+use std::convert::TryInto;
+
 mod handle;
 mod status;
 
 pub use handle::Handle;
 pub use status::Status;
+
+/// Specifies how the store should check for module updates
+#[derive(PartialEq, Debug)]
+pub enum PullPolicy {
+    /// Always return the module as it currently appears in the
+    /// upstream registry
+    Always,
+    /// Return the module as it is currently cached in the local store if
+    /// present; fetch it from the upstream registry only if it it not
+    /// present in the local store
+    IfNotPresent,
+    /// Never fetch the module from the upstream registry; if it is not
+    /// available locally then return an error
+    Never,
+}
+
+impl PullPolicy {
+    /// Parses a module pull policy from a Kubernetes ImagePullPolicy string
+    pub fn parse(name: Option<&String>) -> anyhow::Result<Option<Self>> {
+        match name {
+            None => Ok(None),
+            Some(s) => Self::parse_str(s),
+        }
+    }
+
+    fn parse_str(name: &str) -> anyhow::Result<Option<Self>> {
+        match name {
+            "Always" => Ok(Some(Self::Always)),
+            "IfNotPresent" => Ok(Some(Self::IfNotPresent)),
+            "Never" => Ok(Some(Self::Never)),
+            other => Err(anyhow::anyhow!("unrecognized pull policy {}", other)),
+        }
+    }
+}
+
+/// A Kubernetes Container
+///
+/// This is a new type around the k8s_openapi Container definition
+/// providing convenient accessor methods
+#[derive(Default, Debug, Clone)]
+pub struct Container(KubeContainer);
+
+impl Container {
+    /// Create new Container from KubeContainer
+    pub fn new(container: &KubeContainer) -> Self {
+        Container(container.clone())
+    }
+
+    /// Get image of container as `oci_distribution::Reference`.
+    pub fn image(&self) -> anyhow::Result<Option<Reference>> {
+        match self.0.image.as_ref() {
+            Some(s) => Some(s.clone().try_into()).transpose(),
+            None => Ok(None),
+        }
+    }
+
+    /// Get name of container.
+    pub fn name(&self) -> &str {
+        &self.0.name
+    }
+
+    /// Get image pull policy of container applying defaults if None from:
+    /// https://kubernetes.io/docs/concepts/configuration/overview/#container-images
+    pub fn image_pull_policy(&self) -> anyhow::Result<PullPolicy> {
+        match PullPolicy::parse(self.0.image_pull_policy.as_ref())? {
+            Some(policy) => Ok(policy),
+            None => match self.image()? {
+                Some(image) => match image.tag() {
+                    Some("latest") | None => Ok(PullPolicy::Always),
+                    _ => Ok(PullPolicy::IfNotPresent),
+                },
+                None => Ok(PullPolicy::IfNotPresent),
+            },
+        }
+    }
+
+    /// Get volume mounts of container.
+    pub fn volume_mounts(&self) -> &Option<Vec<k8s_openapi::api::core::v1::VolumeMount>> {
+        &self.0.volume_mounts
+    }
+
+    /// Get arguments of container.
+    pub fn args(&self) -> &Option<Vec<String>> {
+        &self.0.args
+    }
+
+    /// Get environment of container.
+    pub fn env(&self) -> &Option<Vec<k8s_openapi::api::core::v1::EnvVar>> {
+        &self.0.env
+    }
+}

--- a/crates/kubelet/src/container/mod.rs
+++ b/crates/kubelet/src/container/mod.rs
@@ -11,7 +11,7 @@ pub use handle::Handle;
 pub use status::Status;
 
 /// Specifies how the store should check for module updates
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone, Copy)]
 pub enum PullPolicy {
     /// Always return the module as it currently appears in the
     /// upstream registry
@@ -26,8 +26,23 @@ pub enum PullPolicy {
 }
 
 impl PullPolicy {
+    /// Get image pull policy of container applying defaults if None from:
+    /// https://kubernetes.io/docs/concepts/configuration/overview/#container-images
+    pub fn parse_with_ref(policy: Option<&str>, image: Option<Reference>) -> anyhow::Result<Self> {
+        match PullPolicy::parse(policy)? {
+            Some(policy) => Ok(policy),
+            None => match image {
+                Some(image) => match image.tag() {
+                    Some("latest") | None => Ok(PullPolicy::Always),
+                    _ => Ok(PullPolicy::IfNotPresent),
+                },
+                None => Ok(PullPolicy::IfNotPresent),
+            },
+        }
+    }
+
     /// Parses a module pull policy from a Kubernetes ImagePullPolicy string
-    pub fn parse(name: Option<&String>) -> anyhow::Result<Option<Self>> {
+    pub fn parse(name: Option<&str>) -> anyhow::Result<Option<Self>> {
         match name {
             None => Ok(None),
             Some(s) => Self::parse_str(s),
@@ -57,6 +72,26 @@ impl Container {
         Container(container.clone())
     }
 
+    /// Get arguments of container.
+    pub fn args(&self) -> &Option<Vec<String>> {
+        &self.0.args
+    }
+
+    /// Get command of container.
+    pub fn command(&self) -> &Option<Vec<String>> {
+        &self.0.command
+    }
+
+    /// Get environment of container.
+    pub fn env(&self) -> &Option<Vec<k8s_openapi::api::core::v1::EnvVar>> {
+        &self.0.env
+    }
+
+    /// Get environment of container.
+    pub fn env_from(&self) -> &Option<Vec<k8s_openapi::api::core::v1::EnvFromSource>> {
+        &self.0.env_from
+    }
+
     /// Get image of container as `oci_distribution::Reference`.
     pub fn image(&self) -> anyhow::Result<Option<Reference>> {
         match self.0.image.as_ref() {
@@ -65,24 +100,79 @@ impl Container {
         }
     }
 
+    /// Get image pull policy of container.
+    pub fn image_pull_policy(&self) -> anyhow::Result<PullPolicy> {
+        PullPolicy::parse_with_ref(self.0.image_pull_policy.as_deref(), self.image()?)
+    }
+
+    /// Get lifecycle of container.
+    pub fn lifecycle(&self) -> Option<&k8s_openapi::api::core::v1::Lifecycle> {
+        self.0.lifecycle.as_ref()
+    }
+
+    /// Get liveness probe of container.
+    pub fn liveness_probe(&self) -> Option<&k8s_openapi::api::core::v1::Probe> {
+        self.0.liveness_probe.as_ref()
+    }
+
     /// Get name of container.
     pub fn name(&self) -> &str {
         &self.0.name
     }
 
-    /// Get image pull policy of container applying defaults if None from:
-    /// https://kubernetes.io/docs/concepts/configuration/overview/#container-images
-    pub fn image_pull_policy(&self) -> anyhow::Result<PullPolicy> {
-        match PullPolicy::parse(self.0.image_pull_policy.as_ref())? {
-            Some(policy) => Ok(policy),
-            None => match self.image()? {
-                Some(image) => match image.tag() {
-                    Some("latest") | None => Ok(PullPolicy::Always),
-                    _ => Ok(PullPolicy::IfNotPresent),
-                },
-                None => Ok(PullPolicy::IfNotPresent),
-            },
-        }
+    /// Get ports of container.
+    pub fn ports(&self) -> &Option<Vec<k8s_openapi::api::core::v1::ContainerPort>> {
+        &self.0.ports
+    }
+
+    /// Get readiness probe of container.
+    pub fn readiness_probe(&self) -> Option<&k8s_openapi::api::core::v1::Probe> {
+        self.0.readiness_probe.as_ref()
+    }
+
+    /// Get resources of container.
+    pub fn resources(&self) -> Option<&k8s_openapi::api::core::v1::ResourceRequirements> {
+        self.0.resources.as_ref()
+    }
+
+    /// Get security context of container.
+    pub fn security_context(&self) -> Option<&k8s_openapi::api::core::v1::SecurityContext> {
+        self.0.security_context.as_ref()
+    }
+
+    /// Get startup probe of container.
+    pub fn startup_probe(&self) -> Option<&k8s_openapi::api::core::v1::Probe> {
+        self.0.startup_probe.as_ref()
+    }
+
+    /// Get stdin flag of container.
+    pub fn stdin(&self) -> Option<bool> {
+        self.0.stdin
+    }
+
+    /// Get stdin_once flag of container.
+    pub fn stdin_once(&self) -> Option<bool> {
+        self.0.stdin_once
+    }
+
+    /// Get termination message path of container.
+    pub fn termination_message_path(&self) -> Option<&String> {
+        self.0.termination_message_path.as_ref()
+    }
+
+    /// Get termination message policy of container.
+    pub fn termination_message_policy(&self) -> Option<&String> {
+        self.0.termination_message_policy.as_ref()
+    }
+
+    /// Get tty flag of container.
+    pub fn tty(&self) -> Option<bool> {
+        self.0.tty
+    }
+
+    /// Get volume devices of container.
+    pub fn volume_devices(&self) -> &Option<Vec<k8s_openapi::api::core::v1::VolumeDevice>> {
+        &self.0.volume_devices
     }
 
     /// Get volume mounts of container.
@@ -90,13 +180,8 @@ impl Container {
         &self.0.volume_mounts
     }
 
-    /// Get arguments of container.
-    pub fn args(&self) -> &Option<Vec<String>> {
-        &self.0.args
-    }
-
-    /// Get environment of container.
-    pub fn env(&self) -> &Option<Vec<k8s_openapi::api::core::v1::EnvVar>> {
-        &self.0.env
+    /// Get working directory of container.
+    pub fn working_dir(&self) -> Option<&String> {
+        self.0.working_dir.as_ref()
     }
 }

--- a/crates/kubelet/src/kubelet.rs
+++ b/crates/kubelet/src/kubelet.rs
@@ -279,9 +279,10 @@ async fn start_error_handler(
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::container::Container;
     use crate::pod::Pod;
     use k8s_openapi::api::core::v1::{
-        Container, EnvVar, EnvVarSource, ObjectFieldSelector, PodSpec, PodStatus,
+        Container as KubeContainer, EnvVar, EnvVarSource, ObjectFieldSelector, PodSpec, PodStatus,
     };
     use kube::api::ObjectMeta;
     use std::collections::BTreeMap;
@@ -319,7 +320,7 @@ mod test {
 
     #[tokio::test]
     async fn test_env_vars() {
-        let container = Container {
+        let container = Container::new(&KubeContainer {
             env: Some(vec![
                 EnvVar {
                     name: "first".into(),
@@ -394,7 +395,7 @@ mod test {
                 },
             ]),
             ..Default::default()
-        };
+        });
         let name = "my-name".to_string();
         let namespace = Some("my-namespace".to_string());
         let mut labels = BTreeMap::new();

--- a/crates/kubelet/src/node/mod.rs
+++ b/crates/kubelet/src/node/mod.rs
@@ -209,7 +209,7 @@ pub async fn evict_pods(client: &kube::Client, node_name: &str) -> anyhow::Resul
             let mut container_statuses = HashMap::new();
             for container in pod.containers() {
                 container_statuses.insert(
-                    container.name.clone(),
+                    container.name().to_string(),
                     ContainerStatus::Terminated {
                         timestamp: Utc::now(),
                         message: "Evicted on node shutdown.".to_string(),

--- a/crates/kubelet/src/pod/mod.rs
+++ b/crates/kubelet/src/pod/mod.rs
@@ -9,6 +9,7 @@ pub use status::{update_status, Phase, Status};
 
 use std::collections::HashMap;
 
+use crate::container::Container;
 use chrono::{DateTime, Utc};
 use k8s_openapi::api::core::v1::{
     Container as KubeContainer, ContainerStatus as KubeContainerStatus, Pod as KubePod,
@@ -203,12 +204,15 @@ impl Pod {
     }
 
     /// Get a pod's containers
-    pub fn containers(&self) -> &Vec<KubeContainer> {
+    pub fn containers(&self) -> Vec<Container> {
         self.0
             .spec
             .as_ref()
             .map(|s| &s.containers)
             .unwrap_or_else(|| &EMPTY_VEC)
+            .iter()
+            .map(|c| Container::new(c))
+            .collect()
     }
 
     /// Turn the Pod into the Kubernetes API version of a Pod

--- a/crates/kubelet/src/provider/mod.rs
+++ b/crates/kubelet/src/provider/mod.rs
@@ -2,11 +2,12 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
-use k8s_openapi::api::core::v1::{ConfigMap, Container, EnvVarSource, Pod as KubePod, Secret};
+use k8s_openapi::api::core::v1::{ConfigMap, EnvVarSource, Pod as KubePod, Secret};
 use kube::api::{Api, WatchEvent};
 use log::{error, info};
 use thiserror::Error;
 
+use crate::container::Container;
 use crate::log::Sender;
 use crate::node::Builder;
 use crate::pod::Pod;
@@ -127,7 +128,7 @@ pub trait Provider {
         client: &kube::Client,
     ) -> HashMap<String, String> {
         let mut env = HashMap::new();
-        let vars = match container.env.as_ref() {
+        let vars = match container.env().as_ref() {
             Some(e) => e,
             None => return env,
         };

--- a/crates/kubelet/src/store/mod.rs
+++ b/crates/kubelet/src/store/mod.rs
@@ -23,7 +23,7 @@ use crate::store::oci::Client;
 ///  ```rust
 /// use async_trait::async_trait;
 /// use oci_distribution::Reference;
-/// use kubelet::store::PullPolicy;
+/// use kubelet::container::PullPolicy;
 /// use kubelet::store::Store;
 /// use std::collections::HashMap;
 ///
@@ -33,9 +33,9 @@ use crate::store::oci::Client;
 ///
 /// #[async_trait]
 /// impl Store for InMemoryStore {
-///     async fn get(&self, image_ref: &Reference, pull_policy: Option<PullPolicy>) -> anyhow::Result<Vec<u8>> {
+///     async fn get(&self, image_ref: &Reference, pull_policy: PullPolicy) -> anyhow::Result<Vec<u8>> {
 ///         match pull_policy {
-///             Some(PullPolicy::Never) => (),
+///             PullPolicy::Never => (),
 ///             _ => todo!("Implement support for pull policies"),
 ///         }
 ///         match self.modules.get(image_ref) {

--- a/crates/kubelet/src/store/mod.rs
+++ b/crates/kubelet/src/store/mod.rs
@@ -71,7 +71,7 @@ pub trait Store {
                 .expect("Could not parse image.")
                 .expect("FATAL ERROR: container must have an image");
             let pull_policy = container
-                .image_pull_policy()
+                .effective_pull_policy()
                 .expect("Could not identify pull policy.");
             async move {
                 Ok((

--- a/crates/kubelet/src/store/oci/file.rs
+++ b/crates/kubelet/src/store/oci/file.rs
@@ -125,7 +125,7 @@ async fn file_content_is(path: PathBuf, text: String) -> bool {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::store::PullPolicy;
+    use crate::container::PullPolicy;
     use crate::store::Store;
     use oci_distribution::client::ImageData;
     use std::collections::HashMap;
@@ -137,24 +137,18 @@ mod test {
         assert_eq!(None, PullPolicy::parse(None).unwrap());
         assert_eq!(
             PullPolicy::Always,
-            PullPolicy::parse(Some("Always".to_owned()))
-                .unwrap()
-                .unwrap()
+            PullPolicy::parse(Some("Always")).unwrap().unwrap()
         );
         assert_eq!(
             PullPolicy::IfNotPresent,
-            PullPolicy::parse(Some("IfNotPresent".to_owned()))
-                .unwrap()
-                .unwrap()
+            PullPolicy::parse(Some("IfNotPresent")).unwrap().unwrap()
         );
         assert_eq!(
             PullPolicy::Never,
-            PullPolicy::parse(Some("Never".to_owned()))
-                .unwrap()
-                .unwrap()
+            PullPolicy::parse(Some("Never")).unwrap().unwrap()
         );
         assert!(
-            PullPolicy::parse(Some("IfMoonMadeOfGreenCheese".to_owned())).is_err(),
+            PullPolicy::parse(Some("IfMoonMadeOfGreenCheese")).is_err(),
             "Expected parse failure but didn't get one"
         );
     }
@@ -237,7 +231,7 @@ mod test {
         let fake_ref = Reference::try_from("foo/bar:1.0")?;
         let scratch_dir = create_temp_dir();
         let store = FileStore::new(fake_client, &scratch_dir.path);
-        let module_bytes = store.get(&fake_ref, Some(PullPolicy::IfNotPresent)).await?;
+        let module_bytes = store.get(&fake_ref, PullPolicy::IfNotPresent).await?;
         assert_eq!(3, module_bytes.len());
         assert_eq!(2, module_bytes[1]);
         Ok(())
@@ -249,7 +243,7 @@ mod test {
         let fake_ref = Reference::try_from("foo/bar:1.0")?;
         let scratch_dir = create_temp_dir();
         let store = FileStore::new(fake_client, &scratch_dir.path);
-        let module_bytes = store.get(&fake_ref, Some(PullPolicy::Always)).await?;
+        let module_bytes = store.get(&fake_ref, PullPolicy::Always).await?;
         assert_eq!(3, module_bytes.len());
         assert_eq!(2, module_bytes[1]);
         Ok(())
@@ -261,7 +255,7 @@ mod test {
         let fake_ref = Reference::try_from("foo/bar:1.0")?;
         let scratch_dir = create_temp_dir();
         let store = FileStore::new(fake_client, &scratch_dir.path);
-        let module_bytes = store.get(&fake_ref, Some(PullPolicy::Never)).await;
+        let module_bytes = store.get(&fake_ref, PullPolicy::Never).await;
         assert!(
             module_bytes.is_err(),
             "expected get with pull policy Never to fail but it worked"
@@ -275,9 +269,9 @@ mod test {
         let fake_ref = Reference::try_from("foo/bar:1.0")?;
         let scratch_dir = create_temp_dir();
         let store = FileStore::new(fake_client, &scratch_dir.path);
-        let prime_cache = store.get(&fake_ref, Some(PullPolicy::Always)).await;
+        let prime_cache = store.get(&fake_ref, PullPolicy::Always).await;
         assert!(prime_cache.is_ok());
-        let module_bytes = store.get(&fake_ref, Some(PullPolicy::Never)).await?;
+        let module_bytes = store.get(&fake_ref, PullPolicy::Never).await?;
         assert_eq!(3, module_bytes.len());
         assert_eq!(2, module_bytes[1]);
         Ok(())
@@ -290,11 +284,11 @@ mod test {
         let fake_ref = Reference::try_from("foo/bar:1.0")?;
         let scratch_dir = create_temp_dir();
         let store = FileStore::new(fake_client.clone(), &scratch_dir.path);
-        let module_bytes_orig = store.get(&fake_ref, Some(PullPolicy::IfNotPresent)).await?;
+        let module_bytes_orig = store.get(&fake_ref, PullPolicy::IfNotPresent).await?;
         assert_eq!(3, module_bytes_orig.len());
         assert_eq!(2, module_bytes_orig[1]);
         fake_client.update("foo/bar:1.0", vec![4, 5, 6, 7], "sha256:4567");
-        let module_bytes_after = store.get(&fake_ref, Some(PullPolicy::IfNotPresent)).await?;
+        let module_bytes_after = store.get(&fake_ref, PullPolicy::IfNotPresent).await?;
         assert_eq!(3, module_bytes_after.len());
         assert_eq!(2, module_bytes_after[1]);
         Ok(())
@@ -307,11 +301,11 @@ mod test {
         let fake_ref = Reference::try_from("foo/bar:1.0")?;
         let scratch_dir = create_temp_dir();
         let store = FileStore::new(fake_client.clone(), &scratch_dir.path);
-        let module_bytes_orig = store.get(&fake_ref, Some(PullPolicy::IfNotPresent)).await?;
+        let module_bytes_orig = store.get(&fake_ref, PullPolicy::IfNotPresent).await?;
         assert_eq!(3, module_bytes_orig.len());
         assert_eq!(2, module_bytes_orig[1]);
         fake_client.update("foo/bar:1.0", vec![4, 5, 6, 7], "sha256:4567");
-        let module_bytes_after = store.get(&fake_ref, Some(PullPolicy::Always)).await?;
+        let module_bytes_after = store.get(&fake_ref, PullPolicy::Always).await?;
         assert_eq!(4, module_bytes_after.len());
         assert_eq!(5, module_bytes_after[1]);
         Ok(())
@@ -323,7 +317,7 @@ mod test {
         let fake_ref = Reference::try_from("foo/bar")?;
         let scratch_dir = create_temp_dir();
         let store = FileStore::new(fake_client, &scratch_dir.path);
-        let module_bytes = store.get(&fake_ref, Some(PullPolicy::Always)).await?;
+        let module_bytes = store.get(&fake_ref, PullPolicy::Always).await?;
         assert_eq!(2, module_bytes.len());
         assert_eq!(3, module_bytes[1]);
         Ok(())
@@ -336,12 +330,13 @@ mod test {
         let fake_ref = Reference::try_from("foo/bar:2.0")?;
         let scratch_dir = create_temp_dir();
         let store = FileStore::new(fake_client.clone(), &scratch_dir.path);
-        let module_bytes_orig = store.get(&fake_ref, None).await?;
+        let policy = PullPolicy::parse_with_ref(None, Some(fake_ref.clone()))?;
+        let module_bytes_orig = store.get(&fake_ref, policy).await?;
         assert_eq!(3, module_bytes_orig.len());
         assert_eq!(7, module_bytes_orig[1]);
         fake_client.update("foo/bar:2.0", vec![8, 9], "sha256:89");
         // But with no policy it should *not* re-fetch a tag that's in cache
-        let module_bytes_after = store.get(&fake_ref, None).await?;
+        let module_bytes_after = store.get(&fake_ref, policy).await?;
         assert_eq!(3, module_bytes_after.len());
         assert_eq!(7, module_bytes_after[1]);
         Ok(())
@@ -355,11 +350,12 @@ mod test {
         let fake_ref = Reference::try_from("foo/bar:latest")?;
         let scratch_dir = create_temp_dir();
         let store = FileStore::new(fake_client.clone(), &scratch_dir.path);
-        let module_bytes_orig = store.get(&fake_ref, None).await?;
+        let policy = PullPolicy::parse_with_ref(None, Some(fake_ref.clone()))?;
+        let module_bytes_orig = store.get(&fake_ref, policy).await?;
         assert_eq!(2, module_bytes_orig.len());
         assert_eq!(4, module_bytes_orig[1]);
         fake_client.update("foo/bar:latest", vec![5, 6, 7], "sha256:567");
-        let module_bytes_after = store.get(&fake_ref, None).await?;
+        let module_bytes_after = store.get(&fake_ref, policy).await?;
         assert_eq!(3, module_bytes_after.len());
         assert_eq!(6, module_bytes_after[1]);
         Ok(())
@@ -371,11 +367,12 @@ mod test {
         let fake_ref = Reference::try_from("foo/bar")?;
         let scratch_dir = create_temp_dir();
         let store = FileStore::new(fake_client.clone(), &scratch_dir.path);
-        let module_bytes_orig = store.get(&fake_ref, None).await?;
+        let policy = PullPolicy::parse_with_ref(None, Some(fake_ref.clone()))?;
+        let module_bytes_orig = store.get(&fake_ref, policy).await?;
         assert_eq!(2, module_bytes_orig.len());
         assert_eq!(4, module_bytes_orig[1]);
         fake_client.update("foo/bar", vec![5, 6, 7], "sha256:567");
-        let module_bytes_after = store.get(&fake_ref, None).await?;
+        let module_bytes_after = store.get(&fake_ref, policy).await?;
         assert_eq!(3, module_bytes_after.len());
         assert_eq!(6, module_bytes_after[1]);
         Ok(())

--- a/crates/kubelet/src/store/oci/file.rs
+++ b/crates/kubelet/src/store/oci/file.rs
@@ -330,7 +330,7 @@ mod test {
         let fake_ref = Reference::try_from("foo/bar:2.0")?;
         let scratch_dir = create_temp_dir();
         let store = FileStore::new(fake_client.clone(), &scratch_dir.path);
-        let policy = PullPolicy::parse_with_ref(None, Some(fake_ref.clone()))?;
+        let policy = PullPolicy::parse_effective(None, Some(fake_ref.clone()))?;
         let module_bytes_orig = store.get(&fake_ref, policy).await?;
         assert_eq!(3, module_bytes_orig.len());
         assert_eq!(7, module_bytes_orig[1]);
@@ -350,7 +350,7 @@ mod test {
         let fake_ref = Reference::try_from("foo/bar:latest")?;
         let scratch_dir = create_temp_dir();
         let store = FileStore::new(fake_client.clone(), &scratch_dir.path);
-        let policy = PullPolicy::parse_with_ref(None, Some(fake_ref.clone()))?;
+        let policy = PullPolicy::parse_effective(None, Some(fake_ref.clone()))?;
         let module_bytes_orig = store.get(&fake_ref, policy).await?;
         assert_eq!(2, module_bytes_orig.len());
         assert_eq!(4, module_bytes_orig[1]);
@@ -367,7 +367,7 @@ mod test {
         let fake_ref = Reference::try_from("foo/bar")?;
         let scratch_dir = create_temp_dir();
         let store = FileStore::new(fake_client.clone(), &scratch_dir.path);
-        let policy = PullPolicy::parse_with_ref(None, Some(fake_ref.clone()))?;
+        let policy = PullPolicy::parse_effective(None, Some(fake_ref.clone()))?;
         let module_bytes_orig = store.get(&fake_ref, policy).await?;
         assert_eq!(2, module_bytes_orig.len());
         assert_eq!(4, module_bytes_orig[1]);

--- a/crates/wascc-provider/src/lib.rs
+++ b/crates/wascc-provider/src/lib.rs
@@ -220,7 +220,7 @@ impl<S: Store + Send + Sync> Provider for WasccProvider<S> {
         for container in pod.containers() {
             let env = Self::env_vars(&container, &pod, &client).await;
             let volume_bindings: Vec<VolumeBinding> =
-                if let Some(volume_mounts) = container.volume_mounts.as_ref() {
+                if let Some(volume_mounts) = container.volume_mounts().as_ref() {
                     volume_mounts
                         .iter()
                         .map(|vm| -> anyhow::Result<VolumeBinding> {
@@ -229,7 +229,7 @@ impl<S: Store + Send + Sync> Provider for WasccProvider<S> {
                                 anyhow::anyhow!(
                                     "no volume with the name of {} found for container {}",
                                     vm.name,
-                                    container.name
+                                    container.name()
                                 )
                             })?;
                             // We can safely assume that this should be valid UTF-8 because it would have
@@ -244,10 +244,10 @@ impl<S: Store + Send + Sync> Provider for WasccProvider<S> {
                     vec![]
                 };
 
-            debug!("Starting container {} on thread", container.name);
+            debug!("Starting container {} on thread", container.name());
 
             let module_data = modules
-                .remove(&container.name)
+                .remove(container.name())
                 .expect("FATAL ERROR: module map not properly populated");
             let lp = self.log_path.clone();
             let (status_sender, status_recv) = watch::channel(ContainerStatus::Waiting {
@@ -261,7 +261,7 @@ impl<S: Store + Send + Sync> Provider for WasccProvider<S> {
             .await?;
             match http_result {
                 Ok(handle) => {
-                    container_handles.insert(container.name.clone(), handle);
+                    container_handles.insert(container.name().to_string(), handle);
                     status_sender
                         .broadcast(ContainerStatus::Running {
                             timestamp: chrono::Utc::now(),
@@ -273,7 +273,7 @@ impl<S: Store + Send + Sync> Provider for WasccProvider<S> {
                     // (it was never used in creating a runtime handle)
                     let mut container_statuses = HashMap::new();
                     container_statuses.insert(
-                        container.name.clone(),
+                        container.name().to_string(),
                         ContainerStatus::Terminated {
                             timestamp: chrono::Utc::now(),
                             failed: true,


### PR DESCRIPTION
Basically, mirror Pod API behavior for Container, wrapping KubeContainer and providing nice accessor methods. 

As a start, I moved Image and PullPolicy parsing into the container module.