### PR TITLE
Option to load modules from local filesystem

### DIFF
--- a/crates/kubelet/src/config.rs
+++ b/crates/kubelet/src/config.rs
@@ -477,9 +477,9 @@ pub struct Opts {
     bootstrap_file: PathBuf,
 
     #[structopt(
-        long = "allow-local-modules",
+        long = "x-allow-local-modules",
         env = "KRUSTLET_ALLOW_LOCAL_MODULES",
-        help = "Whether to allow loading modules directly from the filesystem"
+        help = "(Experimental) Whether to allow loading modules directly from the filesystem"
     )]
     allow_local_modules: Option<bool>,
 }

--- a/crates/kubelet/src/config.rs
+++ b/crates/kubelet/src/config.rs
@@ -53,7 +53,8 @@ pub struct Config {
     pub max_pods: u16,
     /// The location of the tls bootstrapping file
     pub bootstrap_file: PathBuf,
-    /// Whether to allow modules to be loaded directly from the filesystem
+    /// Whether to allow modules to be loaded directly from local
+    /// filesystem paths, as well as from registries
     pub allow_local_modules: bool,
 }
 /// The configuration for the Kubelet server.

--- a/crates/kubelet/src/node/mod.rs
+++ b/crates/kubelet/src/node/mod.rs
@@ -744,6 +744,7 @@ mod test {
                 private_key_file: PathBuf::new(),
             },
             bootstrap_file: "doesnt/matter".into(),
+            allow_local_modules: false,
             data_dir: PathBuf::new(),
             node_labels,
             max_pods: 110,

--- a/crates/kubelet/src/pod/handle.rs
+++ b/crates/kubelet/src/pod/handle.rs
@@ -39,7 +39,7 @@ impl<H: StopHandler, F> Handle<H, F> {
         volumes: Option<HashMap<String, Ref>>,
         initial_message: Option<String>,
     ) -> anyhow::Result<Self> {
-        let container_names = container_handles.keys().collect();
+        let container_names: Vec<_> = container_handles.keys().collect();
         pod.initialise_status(&client, &container_names, initial_message)
             .await;
 

--- a/crates/kubelet/src/pod/mod.rs
+++ b/crates/kubelet/src/pod/mod.rs
@@ -228,7 +228,7 @@ impl Pod {
     pub async fn initialise_status(
         &self,
         client: &kube::Client,
-        container_names: &Vec<&String>,
+        container_names: &[&String],
         initial_message: Option<String>,
     ) {
         let mut all_waiting_map = HashMap::new();

--- a/crates/kubelet/src/store/composite/mod.rs
+++ b/crates/kubelet/src/store/composite/mod.rs
@@ -60,11 +60,7 @@ struct CompositeStore {
 
 #[async_trait]
 impl Store for CompositeStore {
-    async fn get(
-        &self,
-        image_ref: &Reference,
-        pull_policy: PullPolicy,
-    ) -> anyhow::Result<Vec<u8>> {
+    async fn get(&self, image_ref: &Reference, pull_policy: PullPolicy) -> anyhow::Result<Vec<u8>> {
         if self.interceptor.intercepts(image_ref) {
             self.interceptor.get(image_ref, pull_policy).await
         } else {
@@ -113,10 +109,7 @@ mod test {
     async fn if_interceptor_matches_then_composite_store_returns_intercepting_value() {
         let store = Arc::new(FakeBase {}).with_override(Arc::new(FakeInterceptor {}));
         let result = store
-            .get(
-                &Reference::try_from("int/foo").unwrap(),
-                PullPolicy::Never,
-            )
+            .get(&Reference::try_from("int/foo").unwrap(), PullPolicy::Never)
             .await
             .unwrap();
         assert_eq!(3, result.len());
@@ -127,10 +120,7 @@ mod test {
     async fn if_interceptor_does_not_match_then_composite_store_returns_base_value() {
         let store = Arc::new(FakeBase {}).with_override(Arc::new(FakeInterceptor {}));
         let result = store
-            .get(
-                &Reference::try_from("mint/foo").unwrap(),
-                PullPolicy::Never,
-            )
+            .get(&Reference::try_from("mint/foo").unwrap(), PullPolicy::Never)
             .await
             .unwrap();
         assert_eq!(4, result.len());

--- a/crates/kubelet/src/store/composite/mod.rs
+++ b/crates/kubelet/src/store/composite/mod.rs
@@ -6,15 +6,20 @@ use async_trait::async_trait;
 use oci_distribution::Reference;
 use std::sync::Arc;
 
-/// TODO
+/// A `Store` that has additional logic to determine if it can satisfy
+/// a particular reference. An `InterceptingStore` can be composed with
+/// another Store to satisfy specific requests in a custom way.
 pub trait InterceptingStore: Store {
-    /// TODO
+    /// Whether this `InterceptingStore` can satisfy the given reference.
     fn intercepts(&self, image_ref: &Reference) -> bool;
 }
 
-/// TODO
+/// Provides a way to overlay an `InterceptingStore` so that the
+/// interceptor handles the references it can, and the base store
+/// handles all other references.
 pub trait ComposableStore {
-    /// TODO
+    /// Creates a `Store` identical to the implementer except that
+    /// 'get' requests are offered to the interceptor first.
     fn with_override(
         self,
         interceptor: Arc<dyn InterceptingStore + Send + Sync>,
@@ -48,8 +53,7 @@ where
     }
 }
 
-/// TODO
-pub struct CompositeStore {
+struct CompositeStore {
     base: Arc<dyn Store + Send + Sync>,
     interceptor: Arc<dyn InterceptingStore + Send + Sync>,
 }

--- a/crates/kubelet/src/store/composite/mod.rs
+++ b/crates/kubelet/src/store/composite/mod.rs
@@ -63,7 +63,7 @@ impl Store for CompositeStore {
     async fn get(
         &self,
         image_ref: &Reference,
-        pull_policy: Option<PullPolicy>,
+        pull_policy: PullPolicy,
     ) -> anyhow::Result<Vec<u8>> {
         if self.interceptor.intercepts(image_ref) {
             self.interceptor.get(image_ref, pull_policy).await
@@ -86,7 +86,7 @@ mod test {
         async fn get(
             &self,
             _image_ref: &Reference,
-            _pull_policy: Option<PullPolicy>,
+            _pull_policy: PullPolicy,
         ) -> anyhow::Result<Vec<u8>> {
             Ok(vec![11, 10, 5, 14])
         }
@@ -97,7 +97,7 @@ mod test {
         async fn get(
             &self,
             _image_ref: &Reference,
-            _pull_policy: Option<PullPolicy>,
+            _pull_policy: PullPolicy,
         ) -> anyhow::Result<Vec<u8>> {
             Ok(vec![1, 2, 3])
         }
@@ -115,7 +115,7 @@ mod test {
         let result = store
             .get(
                 &Reference::try_from("int/foo").unwrap(),
-                Some(PullPolicy::Never),
+                PullPolicy::Never,
             )
             .await
             .unwrap();
@@ -129,7 +129,7 @@ mod test {
         let result = store
             .get(
                 &Reference::try_from("mint/foo").unwrap(),
-                Some(PullPolicy::Never),
+                PullPolicy::Never,
             )
             .await
             .unwrap();

--- a/crates/kubelet/src/store/composite/mod.rs
+++ b/crates/kubelet/src/store/composite/mod.rs
@@ -1,0 +1,70 @@
+//! `composite` implements building complex stores from simpler ones.
+
+use crate::store::PullPolicy;
+use crate::store::Store;
+use async_trait::async_trait;
+use oci_distribution::Reference;
+use std::sync::Arc;
+
+/// TODO
+pub trait InterceptingStore: Store {
+    /// TODO
+    fn intercepts(&self, image_ref: &Reference) -> bool;
+}
+
+/// TODO
+pub trait ComposableStore {
+    /// TODO
+    fn with_override(
+        self,
+        interceptor: Arc<dyn InterceptingStore + Send + Sync>,
+    ) -> Arc<dyn Store + Send + Sync>;
+}
+
+impl ComposableStore for Arc<dyn Store + Send + Sync> {
+    fn with_override(
+        self,
+        interceptor: Arc<dyn InterceptingStore + Send + Sync>,
+    ) -> Arc<dyn Store + Send + Sync> {
+        Arc::new(CompositeStore {
+            base: self,
+            interceptor,
+        })
+    }
+}
+
+impl<S> ComposableStore for Arc<S>
+where
+    S: Store + Send + Sync + 'static,
+{
+    fn with_override(
+        self,
+        interceptor: Arc<dyn InterceptingStore + Send + Sync>,
+    ) -> Arc<dyn Store + Send + Sync> {
+        Arc::new(CompositeStore {
+            base: self,
+            interceptor,
+        })
+    }
+}
+
+/// TODO
+pub struct CompositeStore {
+    base: Arc<dyn Store + Send + Sync>,
+    interceptor: Arc<dyn InterceptingStore + Send + Sync>,
+}
+
+#[async_trait]
+impl Store for CompositeStore {
+    async fn get(
+        &self,
+        image_ref: &Reference,
+        pull_policy: Option<PullPolicy>,
+    ) -> anyhow::Result<Vec<u8>> {
+        if self.interceptor.intercepts(image_ref) {
+            self.interceptor.get(image_ref, pull_policy).await
+        } else {
+            self.base.get(image_ref, pull_policy).await
+        }
+    }
+}

--- a/crates/kubelet/src/store/fs/mod.rs
+++ b/crates/kubelet/src/store/fs/mod.rs
@@ -1,0 +1,28 @@
+//! `fs` implements fetching modules from the local file system.
+
+use crate::store::composite::InterceptingStore;
+use crate::store::{PullPolicy, Store};
+use async_trait::async_trait;
+use oci_distribution::Reference;
+use std::path::PathBuf;
+
+/// TODO
+pub struct FileSystemStore {}
+
+#[async_trait]
+impl Store for FileSystemStore {
+    async fn get(
+        &self,
+        image_ref: &Reference,
+        _pull_policy: Option<PullPolicy>,
+    ) -> anyhow::Result<Vec<u8>> {
+        let path = PathBuf::from(image_ref.repository());
+        Ok(tokio::fs::read(&path).await?)
+    }
+}
+
+impl InterceptingStore for FileSystemStore {
+    fn intercepts(&self, image_ref: &Reference) -> bool {
+        image_ref.registry() == "fs"
+    }
+}

--- a/crates/kubelet/src/store/fs/mod.rs
+++ b/crates/kubelet/src/store/fs/mod.rs
@@ -6,7 +6,15 @@ use async_trait::async_trait;
 use oci_distribution::Reference;
 use std::path::PathBuf;
 
-/// TODO
+/// A `Store` which fetches modules only from the local filesystem,
+/// not a remote registry. References must be of the form
+/// fs/<path>, e.g. fs//wasm/mymodule.wasm or fs/./out/mymodule.wasm.
+/// Version tags are ignored.
+///
+/// FileSystemStore can be composed with another Store to support hybrid retrieval -
+/// typically a developer scenario where you want the application under
+/// test to be your local build, but all other modules to be retrieved from
+/// their production registries.
 pub struct FileSystemStore {}
 
 #[async_trait]

--- a/crates/kubelet/src/store/fs/mod.rs
+++ b/crates/kubelet/src/store/fs/mod.rs
@@ -22,7 +22,7 @@ impl Store for FileSystemStore {
     async fn get(
         &self,
         image_ref: &Reference,
-        _pull_policy: Option<PullPolicy>,
+        _pull_policy: PullPolicy,
     ) -> anyhow::Result<Vec<u8>> {
         let path = PathBuf::from(image_ref.repository());
         Ok(tokio::fs::read(&path).await?)

--- a/crates/kubelet/src/store/mod.rs
+++ b/crates/kubelet/src/store/mod.rs
@@ -1,4 +1,6 @@
 //! `store` contains logic around fetching and storing modules.
+pub mod composite;
+pub mod fs;
 pub mod oci;
 
 use oci_distribution::client::ImageData;

--- a/crates/kubelet/src/store/mod.rs
+++ b/crates/kubelet/src/store/mod.rs
@@ -46,7 +46,7 @@ use crate::store::oci::Client;
 /// }
 /// ```
 #[async_trait]
-pub trait Store {
+pub trait Store: Sync {
     /// Get a module's data given its image `Reference`.
     async fn get(&self, image_ref: &Reference, pull_policy: PullPolicy) -> anyhow::Result<Vec<u8>>;
 

--- a/crates/wascc-provider/src/lib.rs
+++ b/crates/wascc-provider/src/lib.rs
@@ -7,13 +7,14 @@
 //! ```rust,no_run
 //! use kubelet::{Kubelet, config::Config};
 //! use kubelet::store::oci::FileStore;
+//! use std::sync::Arc;
 //! use wascc_provider::WasccProvider;
 //!
 //! async fn start() {
 //!     // Get a configuration for the Kubelet
 //!     let kubelet_config = Config::default();
 //!     let client = oci_distribution::Client::default();
-//!     let store = FileStore::new(client, &std::path::PathBuf::from(""));
+//!     let store = Arc::new(FileStore::new(client, &std::path::PathBuf::from("")));
 //!
 //!     // Load a kubernetes configuration
 //!     let kubeconfig = kube::Config::infer().await.unwrap();
@@ -128,9 +129,9 @@ impl StopHandler for ActorHandle {
 /// TODO: In the future, we will look at loading capabilities using the "sidecar" metaphor
 /// from Kubernetes.
 #[derive(Clone)]
-pub struct WasccProvider<S> {
+pub struct WasccProvider {
     handles: Arc<RwLock<HashMap<String, Handle<ActorHandle, LogHandleFactory>>>>,
-    store: S,
+    store: Arc<dyn Store + Sync + Send>,
     volume_path: PathBuf,
     log_path: PathBuf,
     kubeconfig: kube::Config,
@@ -138,11 +139,11 @@ pub struct WasccProvider<S> {
     port_map: Arc<TokioMutex<HashMap<i32, String>>>,
 }
 
-impl<S: Store + Send + Sync> WasccProvider<S> {
+impl WasccProvider {
     /// Returns a new wasCC provider configured to use the proper data directory
     /// (including creating it if necessary)
     pub async fn new(
-        store: S,
+        store: Arc<dyn Store + Sync + Send>,
         config: &kubelet::config::Config,
         kubeconfig: kube::Config,
     ) -> anyhow::Result<Self> {
@@ -297,7 +298,7 @@ impl<S: Store + Send + Sync> WasccProvider<S> {
 }
 
 #[async_trait]
-impl<S: Store + Send + Sync> Provider for WasccProvider<S> {
+impl Provider for WasccProvider {
     const ARCH: &'static str = TARGET_WASM32_WASCC;
 
     async fn node(&self, builder: &mut Builder) -> anyhow::Result<()> {

--- a/docs/topics/configuration.md
+++ b/docs/topics/configuration.md
@@ -84,7 +84,7 @@ not implemented automatically by the kubelet core. These flags are as follows:
 * `--bootstrap-file` - should be passed to `kubelet::bootstrap` if you use the
   bootstrapping feature
 * `--data-dir` - this should be used to construct the `FileStore` if you use one
-* `--allow-local-modules` - if specified you should compose a `FileSystemStore`
+* `--x-allow-local-modules` - if specified you should compose a `FileSystemStore`
   onto your normal store
 
 See the `krustlet-wasi.rs` file for examples of how to honour these flags.

--- a/docs/topics/configuration.md
+++ b/docs/topics/configuration.md
@@ -26,7 +26,7 @@ kubelet implementers" section below.
 | -p, --port         | KRUSTLET_PORT             | listenerPort       | The port on which the kubelet should listen. The default is 3000                                                                                                                                       |
 | --cert-file        | KRUSTLET_CERT_FILE        | tlsCertificateFile | The path to the TLS certificate for the kubelet. The default is `(data directory)/config/krustlet.crt`                                                                                                 |
 | --private-key-file | KRUSTLET_PRIVATE_KEY_FILE | tlsPrivateKeyFile  | The path to the private key for the TLS certificate. The default is `(data directory)/config/krustlet.key`                                                                                             |
-| --allow-local-modules | KRUSTLET_ALLOW_LOCAL_MODULES | allowLocalModules | If true, the kubelet should recognise references prefixed with 'fs' as indicating a filesystem path rather than a registry location |
+| --x-allow-local-modules | KRUSTLET_ALLOW_LOCAL_MODULES | allowLocalModules | If true, the kubelet should recognise references prefixed with 'fs' as indicating a filesystem path rather than a registry location. This is an experimental flag for use in development scenarios where you don't want to repeatedly push your local builds to a registry; it is likely to be removed in a future version when we have a more comprehensive toolchain for local development. |
 
 ## Node labels format
 

--- a/src/krustlet-wascc.rs
+++ b/src/krustlet-wascc.rs
@@ -1,4 +1,5 @@
 use kubelet::config::Config;
+use kubelet::store::composite::ComposableStore;
 use kubelet::store::oci::FileStore;
 use kubelet::Kubelet;
 use std::sync::Arc;
@@ -15,12 +16,22 @@ async fn main() -> anyhow::Result<()> {
 
     let kubeconfig = kubelet::bootstrap(&config, &config.bootstrap_file).await?;
 
-    let client = oci_distribution::Client::default();
-    let mut store_path = config.data_dir.join(".oci");
-    store_path.push("modules");
-    let store = Arc::new(FileStore::new(client, &store_path));
+    let store = make_store(&config);
 
     let provider = WasccProvider::new(store, &config, kubeconfig.clone()).await?;
     let kubelet = Kubelet::new(provider, kubeconfig, config).await?;
     kubelet.start().await
+}
+
+fn make_store(config: &Config) -> Arc<dyn kubelet::store::Store + Send + Sync> {
+    let client = oci_distribution::Client::default();
+    let mut store_path = config.data_dir.join(".oci");
+    store_path.push("modules");
+    let file_store = Arc::new(FileStore::new(client, &store_path));
+
+    if config.allow_local_modules {
+        file_store.with_override(Arc::new(kubelet::store::fs::FileSystemStore {}))
+    } else {
+        file_store
+    }
 }

--- a/src/krustlet-wascc.rs
+++ b/src/krustlet-wascc.rs
@@ -1,6 +1,7 @@
 use kubelet::config::Config;
 use kubelet::store::oci::FileStore;
 use kubelet::Kubelet;
+use std::sync::Arc;
 use wascc_provider::WasccProvider;
 
 #[tokio::main]
@@ -17,7 +18,7 @@ async fn main() -> anyhow::Result<()> {
     let client = oci_distribution::Client::default();
     let mut store_path = config.data_dir.join(".oci");
     store_path.push("modules");
-    let store = FileStore::new(client, &store_path);
+    let store = Arc::new(FileStore::new(client, &store_path));
 
     let provider = WasccProvider::new(store, &config, kubeconfig.clone()).await?;
     let kubelet = Kubelet::new(provider, kubeconfig, config).await?;

--- a/src/krustlet-wasi.rs
+++ b/src/krustlet-wasi.rs
@@ -1,6 +1,7 @@
 use kubelet::config::Config;
 use kubelet::store::oci::FileStore;
 use kubelet::Kubelet;
+use std::sync::Arc;
 use wasi_provider::WasiProvider;
 
 #[tokio::main]
@@ -17,7 +18,7 @@ async fn main() -> anyhow::Result<()> {
     let client = oci_distribution::Client::default();
     let mut store_path = config.data_dir.join(".oci");
     store_path.push("modules");
-    let store = FileStore::new(client, &store_path);
+    let store = Arc::new(FileStore::new(client, &store_path));
 
     let provider = WasiProvider::new(store, &config, kubeconfig.clone()).await?;
     let kubelet = Kubelet::new(provider, kubeconfig, config).await?;

--- a/src/krustlet-wasi.rs
+++ b/src/krustlet-wasi.rs
@@ -1,4 +1,5 @@
 use kubelet::config::Config;
+use kubelet::store::composite::ComposableStore;
 use kubelet::store::oci::FileStore;
 use kubelet::Kubelet;
 use std::sync::Arc;
@@ -15,12 +16,22 @@ async fn main() -> anyhow::Result<()> {
 
     let kubeconfig = kubelet::bootstrap(&config, &config.bootstrap_file).await?;
 
-    let client = oci_distribution::Client::default();
-    let mut store_path = config.data_dir.join(".oci");
-    store_path.push("modules");
-    let store = Arc::new(FileStore::new(client, &store_path));
+    let store = make_store(&config);
 
     let provider = WasiProvider::new(store, &config, kubeconfig.clone()).await?;
     let kubelet = Kubelet::new(provider, kubeconfig, config).await?;
     kubelet.start().await
+}
+
+fn make_store(config: &Config) -> Arc<dyn kubelet::store::Store + Send + Sync> {
+    let client = oci_distribution::Client::default();
+    let mut store_path = config.data_dir.join(".oci");
+    store_path.push("modules");
+    let file_store = Arc::new(FileStore::new(client, &store_path));
+
+    if config.allow_local_modules {
+        file_store.with_override(Arc::new(kubelet::store::fs::FileSystemStore {}))
+    } else {
+        file_store
+    }
 }


### PR DESCRIPTION
During the dev-test cycle it can be useful to load modules that have been built locally but not pushed to a registry.  This PR supports this via a new `--allow-local-modules=true` command line flag (also available via environment variable or config file).  If `--allow-local-modules` is `true`, references of the form `fs/<path>` are loaded directly from the file system instead of from a registry.  For example:

* `fs//wasm/mymodule.wasm` - loads from absolute path `/wasm/mymodule.wasm`
* `fs/./out/mymodule.wasm` or `fs/out/mymodule.wasm` - loads from path `out/mymodule.wasm`, relative to the working directory of the kubelet process

As it is the custom kubelet (e.g. `krustlet-wasi`) which constructs the module store, it is up to that code to honour the `--allow-local-modules` flag.  Awareness of the flag is _not_ baked into the FileStore or the  module loader.