### PR TITLE
switch default target to `build`

### DIFF
--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@ export RUST_LOG := "wascc_host=debug,wascc_provider=debug,wasi_provider=debug,ma
 export PFX_PASSWORD := "testing"
 export CONFIG_DIR := env_var_or_default('CONFIG_DIR', '$HOME/.krustlet/config')
 
-run: run-wascc
+run: build
 
 build +FLAGS='':
     cargo build {{FLAGS}}


### PR DESCRIPTION
This is sort of an opinion piece, but I feel like every time I run `just`, I expect it to run similar to `make`: it should only compile the project instead of running something.

This way, the instructions could be simplified to `just && just install` to install the wascc and wasi providers - assuming we had an `install` target.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>