### PR TITLE
Modularise WASI integration tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ rustls-tls = ["kube/rustls-tls", "kubelet/rustls-tls", "wasi-provider/rustls-tls
 
 [dependencies]
 anyhow = "1.0"
-tokio = { version = "0.2", features = ["macros", "rt-threaded"] }
+tokio = { version = "0.2", features = ["macros", "rt-threaded", "time"] }
 kube = { version= "0.35", default-features = false }
 env_logger = "0.7"
 kubelet = { path = "./crates/kubelet", version = "0.3", default-features = false, features = ["cli"] }

--- a/tests/assert.rs
+++ b/tests/assert.rs
@@ -45,22 +45,6 @@ pub async fn pod_container_log_contains(
     Ok(())
 }
 
-// pub async fn pod_log_does_not_contain(
-//     pods: &Api<Pod>,
-//     pod_name: &str,
-//     unexpected_log: &str,
-// ) -> anyhow::Result<()> {
-//     let logs = pods.logs(pod_name, &LogParams::default()).await?;
-//     assert!(
-//         !logs.contains(unexpected_log),
-//         format!(
-//             "Expected log NOT containing {} but got {}",
-//             unexpected_log, logs
-//         )
-//     );
-//     Ok(())
-// }
-
 pub async fn pod_exited_successfully(pods: &Api<Pod>, pod_name: &str) -> anyhow::Result<()> {
     let pod = pods.get(pod_name).await?;
 

--- a/tests/assert.rs
+++ b/tests/assert.rs
@@ -1,0 +1,145 @@
+use futures::{TryStreamExt};
+use k8s_openapi::api::core::v1::{Pod};
+use kube::{
+    api::{Api, LogParams},
+};
+
+pub async fn pod_log_equals(
+    pods: &Api<Pod>,
+    pod_name: &str,
+    expected_log: &str,
+) -> anyhow::Result<()> {
+    let mut logs = pods.log_stream(pod_name, &LogParams::default()).await?;
+
+    while let Some(chunk) = logs.try_next().await? {
+        assert_eq!(expected_log, String::from_utf8_lossy(&chunk));
+    }
+
+    Ok(())
+}
+
+pub async fn pod_log_contains(
+    pods: &Api<Pod>,
+    pod_name: &str,
+    expected_log: &str,
+) -> anyhow::Result<()> {
+    let logs = pods.logs(pod_name, &LogParams::default()).await?;
+    assert!(
+        logs.contains(expected_log),
+        format!("Expected log containing {} but got {}", expected_log, logs)
+    );
+    Ok(())
+}
+
+pub async fn pod_container_log_contains(
+    pods: &Api<Pod>,
+    pod_name: &str,
+    container_name: &str,
+    expected_log: &str,
+) -> anyhow::Result<()> {
+    let mut log_params = LogParams::default();
+    log_params.container = Some(container_name.to_owned());
+    let logs = pods.logs(pod_name, &log_params).await?;
+    assert!(
+        logs.contains(expected_log),
+        format!("Expected log containing {} but got {}", expected_log, logs)
+    );
+    Ok(())
+}
+
+// pub async fn pod_log_does_not_contain(
+//     pods: &Api<Pod>,
+//     pod_name: &str,
+//     unexpected_log: &str,
+// ) -> anyhow::Result<()> {
+//     let logs = pods.logs(pod_name, &LogParams::default()).await?;
+//     assert!(
+//         !logs.contains(unexpected_log),
+//         format!(
+//             "Expected log NOT containing {} but got {}",
+//             unexpected_log, logs
+//         )
+//     );
+//     Ok(())
+// }
+
+pub async fn pod_exited_successfully(pods: &Api<Pod>, pod_name: &str) -> anyhow::Result<()> {
+    let pod = pods.get(pod_name).await?;
+
+    let state = (|| {
+        pod.status?.container_statuses?[0]
+            .state
+            .as_ref()?
+            .terminated
+            .clone()
+    })()
+    .expect("Could not fetch terminated states");
+    assert_eq!(state.exit_code, 0);
+
+    Ok(())
+}
+
+pub async fn pod_exited_with_failure(pods: &Api<Pod>, pod_name: &str) -> anyhow::Result<()> {
+    let pod = pods.get(pod_name).await?;
+
+    let phase = (|| pod.status?.phase)().expect("Could not get pod phase");
+    assert_eq!(phase, "Failed");
+
+    Ok(())
+}
+
+pub async fn pod_message_contains(
+    pods: &Api<Pod>,
+    pod_name: &str,
+    expected_message: &str,
+) -> anyhow::Result<()> {
+    let pod = pods.get(pod_name).await?;
+
+    let message = (|| pod.status?.message)().expect("Could not get pod message");
+    assert!(
+        message.contains(expected_message),
+        format!(
+            "Expected pod message containing {} but got {}",
+            expected_message, message
+        )
+    );
+
+    Ok(())
+}
+
+pub async fn main_container_exited_with_failure(
+    pods: &Api<Pod>,
+    pod_name: &str,
+) -> anyhow::Result<()> {
+    let pod = pods.get(pod_name).await?;
+
+    let state = (|| {
+        pod.status?.container_statuses?[0]
+            .state
+            .as_ref()?
+            .terminated
+            .clone()
+    })()
+    .expect("Could not fetch terminated states");
+    assert_eq!(state.exit_code, 1);
+
+    Ok(())
+}
+
+pub async fn container_file_contains(
+    container_file_path: &str,
+    expected_content: &str,
+    file_error: &str,
+) -> anyhow::Result<()> {
+    let file_path_base = dirs::home_dir()
+        .expect("home dir does not exist")
+        .join(".krustlet/volumes/hello-wasi-default");  // TODO: volume name
+    let container_file_bytes = tokio::fs::read(file_path_base.join(container_file_path))
+        .await
+        .expect(file_error);
+    assert_eq!(
+        expected_content.to_owned().into_bytes(),
+        container_file_bytes
+    );
+    Ok(())
+}

--- a/tests/assert.rs
+++ b/tests/assert.rs
@@ -1,8 +1,6 @@
-use futures::{TryStreamExt};
-use k8s_openapi::api::core::v1::{Pod};
-use kube::{
-    api::{Api, LogParams},
-};
+use futures::TryStreamExt;
+use k8s_openapi::api::core::v1::Pod;
+use kube::api::{Api, LogParams};
 
 pub async fn pod_log_equals(
     pods: &Api<Pod>,
@@ -133,7 +131,7 @@ pub async fn container_file_contains(
 ) -> anyhow::Result<()> {
     let file_path_base = dirs::home_dir()
         .expect("home dir does not exist")
-        .join(".krustlet/volumes/hello-wasi-default");  // TODO: volume name
+        .join(".krustlet/volumes/hello-wasi-default"); // TODO: volume name
     let container_file_bytes = tokio::fs::read(file_path_base.join(container_file_path))
         .await
         .expect(file_error);

--- a/tests/assert.rs
+++ b/tests/assert.rs
@@ -125,13 +125,17 @@ pub async fn main_container_exited_with_failure(
 }
 
 pub async fn container_file_contains(
+    pod_name: &str,
+    pod_namespace: &str,
     container_file_path: &str,
     expected_content: &str,
     file_error: &str,
 ) -> anyhow::Result<()> {
+    let pod_dir_name = format!("{}-{}", pod_name, pod_namespace);
     let file_path_base = dirs::home_dir()
         .expect("home dir does not exist")
-        .join(".krustlet/volumes/hello-wasi-default"); // TODO: volume name
+        .join(".krustlet/volumes")
+        .join(pod_dir_name);
     let container_file_bytes = tokio::fs::read(file_path_base.join(container_file_path))
         .await
         .expect(file_error);

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -271,9 +271,6 @@ async fn create_wasi_pod(
         }
     }))?;
 
-    // TODO: Create a testing module to write to the path to actually check that writing and reading
-    // from a host path volume works
-
     let pod = pods.create(&PostParams::default(), &p).await?;
     resource_manager.push(TestResource::Pod(pod_name.to_owned()));
 
@@ -525,68 +522,6 @@ async fn set_up_wasi_test_environment(
 
     Ok(())
 }
-
-// async fn clean_up_wasi_test_resources() -> anyhow::Result<()> {
-//     let client = kube::Client::try_default()
-//         .await
-//         .expect("Failed to create client");
-
-//     let secrets: Api<Secret> = Api::namespaced(client.clone(), "default");
-//     let config_maps: Api<ConfigMap> = Api::namespaced(client.clone(), "default");
-//     let pods: Api<Pod> = Api::namespaced(client.clone(), "default");
-
-//     let cleanup_errors: Vec<_> = vec![
-//         secrets
-//             .delete("hello-wasi-secret", &DeleteParams::default())
-//             .await
-//             .err()
-//             .map(|e| format!("secret hello-wasi-secret ({})", e)),
-//         config_maps
-//             .delete("hello-wasi-configmap", &DeleteParams::default())
-//             .await
-//             .err()
-//             .map(|e| format!("configmap hello-wasi-configmap ({})", e)),
-//         pods.delete(SIMPLE_WASI_POD, &DeleteParams::default())
-//             .await
-//             .err()
-//             .map(|e| format!("pod {} ({})", SIMPLE_WASI_POD, e)),
-//         pods.delete(VERBOSE_WASI_POD, &DeleteParams::default())
-//             .await
-//             .err()
-//             .map(|e| format!("pod {} ({})", VERBOSE_WASI_POD, e)),
-//         pods.delete(FAILY_POD, &DeleteParams::default())
-//             .await
-//             .err()
-//             .map(|e| format!("pod {} ({})", FAILY_POD, e)),
-//         pods.delete(LOGGY_POD, &DeleteParams::default())
-//             .await
-//             .err()
-//             .map(|e| format!("pod {} ({})", LOGGY_POD, e)),
-//         pods.delete(INITY_WASI_POD, &DeleteParams::default())
-//             .await
-//             .err()
-//             .map(|e| format!("pod {} ({})", INITY_WASI_POD, e)),
-//         pods.delete(FAILY_INITS_POD, &DeleteParams::default())
-//             .await
-//             .err()
-//             .map(|e| format!("pod {} ({})", FAILY_INITS_POD, e)),
-//     ]
-//     .iter()
-//     .filter(|e| e.is_some())
-//     .map(|e| e.as_ref().unwrap().to_string())
-//     .filter(|s| !s.contains(r#"reason: "NotFound""#))
-//     .collect();
-
-//     if cleanup_errors.is_empty() {
-//         Ok(())
-//     } else {
-//         let cleanup_failure_text = format!(
-//             "Error(s) cleaning up resources: {}",
-//             cleanup_errors.join(", ")
-//         );
-//         Err(anyhow::anyhow!(cleanup_failure_text))
-//     }
-// }
 
 #[tokio::test]
 async fn test_pod_logs_and_mounts() -> anyhow::Result<()> {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -525,7 +525,7 @@ async fn set_up_wasi_test_environment(
 
 #[tokio::test]
 async fn test_pod_logs_and_mounts() -> anyhow::Result<()> {
-    let mut resource_manager = TestResourceManager::new();
+    let mut resource_manager = TestResourceManager::new("default");
 
     let client = kube::Client::try_default().await?;
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -502,13 +502,13 @@ async fn test_wasi_node_should_verify() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn test_pod_logs_and_mounts() -> anyhow::Result<()> {
-    let mut resource_manager = TestResourceManager::new("wasi-e2e-pod-logs-and-mounts");
-
+    let test_ns = "wasi-e2e-pod-logs-and-mounts";
     let client = kube::Client::try_default().await?;
-    let pods: Api<Pod> = Api::namespaced(client.clone(), resource_manager.namespace());
+    let pods: Api<Pod> = Api::namespaced(client.clone(), test_ns);
+    let mut resource_manager = TestResourceManager::initialise(test_ns, client.clone()).await?;
 
     resource_manager
-        .set_up_test_namespace(
+        .set_up_resources(
             client.clone(),
             vec![
                 TestResourceSpec::secret("hello-wasi-secret", "myval", "a cool secret"),
@@ -545,14 +545,10 @@ async fn test_pod_logs_and_mounts() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn test_all_the_other_wasis() -> anyhow::Result<()> {
-    let mut resource_manager = TestResourceManager::new("wasi-e2e");
-
+    let test_ns = "wasi-e2e";
     let client = kube::Client::try_default().await?;
-    let pods: Api<Pod> = Api::namespaced(client.clone(), resource_manager.namespace());
-
-    resource_manager
-        .set_up_test_namespace(client.clone(), vec![])
-        .await?;
+    let pods: Api<Pod> = Api::namespaced(client.clone(), test_ns);
+    let mut resource_manager = TestResourceManager::initialise(test_ns, client.clone()).await?;
 
     create_fancy_schmancy_wasi_pod(client.clone(), &pods, &mut resource_manager).await?;
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -505,6 +505,7 @@ async fn test_pod_logs_and_mounts() -> anyhow::Result<()> {
     let mut resource_manager = TestResourceManager::new("wasi-e2e-pod-logs-and-mounts");
 
     let client = kube::Client::try_default().await?;
+    let pods: Api<Pod> = Api::namespaced(client.clone(), resource_manager.namespace());
 
     resource_manager
         .set_up_test_namespace(
@@ -515,8 +516,6 @@ async fn test_pod_logs_and_mounts() -> anyhow::Result<()> {
             ],
         )
         .await?;
-
-    let pods: Api<Pod> = Api::namespaced(client.clone(), resource_manager.namespace());
 
     create_wasi_pod(client.clone(), &pods, &mut resource_manager).await?;
 
@@ -549,12 +548,11 @@ async fn test_all_the_other_wasis() -> anyhow::Result<()> {
     let mut resource_manager = TestResourceManager::new("wasi-e2e");
 
     let client = kube::Client::try_default().await?;
+    let pods: Api<Pod> = Api::namespaced(client.clone(), resource_manager.namespace());
 
     resource_manager
         .set_up_test_namespace(client.clone(), vec![])
         .await?;
-
-    let pods: Api<Pod> = Api::namespaced(client.clone(), resource_manager.namespace());
 
     create_fancy_schmancy_wasi_pod(client.clone(), &pods, &mut resource_manager).await?;
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -516,7 +516,6 @@ async fn test_pod_logs_and_mounts() -> anyhow::Result<()> {
 
     resource_manager
         .set_up_resources(
-            client.clone(),
             vec![
                 TestResourceSpec::secret("hello-wasi-secret", "myval", "a cool secret"),
                 TestResourceSpec::config_map("hello-wasi-configmap", "myval", "a cool configmap"),

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -521,12 +521,10 @@ async fn test_pod_logs_and_mounts() -> anyhow::Result<()> {
     let (client, pods, mut resource_manager) = set_up_test(test_ns).await?;
 
     resource_manager
-        .set_up_resources(
-            vec![
-                TestResourceSpec::secret("hello-wasi-secret", "myval", "a cool secret"),
-                TestResourceSpec::config_map("hello-wasi-configmap", "myval", "a cool configmap"),
-            ],
-        )
+        .set_up_resources(vec![
+            TestResourceSpec::secret("hello-wasi-secret", "myval", "a cool secret"),
+            TestResourceSpec::config_map("hello-wasi-configmap", "myval", "a cool configmap"),
+        ])
         .await?;
 
     create_wasi_pod(client.clone(), &pods, &mut resource_manager).await?;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -10,7 +10,7 @@ mod test_resource_manager;
 use expectations::{assert_container_statuses, ContainerStatusExpectation};
 use pod_builder::{wasmerciser_pod, WasmerciserContainerSpec, WasmerciserVolumeSpec};
 use pod_setup::{wait_for_pod_complete, wait_for_pod_ready, OnFailure};
-use test_resource_manager::{TestResource, TestResourceManager};
+use test_resource_manager::{TestResource, TestResourceManager, TestResourceSpec};
 
 #[tokio::test]
 async fn test_wascc_provider() -> Result<(), Box<dyn std::error::Error>> {
@@ -506,7 +506,15 @@ async fn test_pod_logs_and_mounts() -> anyhow::Result<()> {
 
     let client = kube::Client::try_default().await?;
 
-    resource_manager.set_up_test_namespace(client.clone()).await?;
+    resource_manager
+        .set_up_test_namespace(
+            client.clone(),
+            vec![
+                TestResourceSpec::secret("hello-wasi-secret", "myval", "a cool secret"),
+                TestResourceSpec::config_map("hello-wasi-configmap", "myval", "a cool configmap"),
+            ],
+        )
+        .await?;
 
     let pods: Api<Pod> = Api::namespaced(client.clone(), resource_manager.namespace());
 
@@ -542,7 +550,9 @@ async fn test_all_the_other_wasis() -> anyhow::Result<()> {
 
     let client = kube::Client::try_default().await?;
 
-    resource_manager.set_up_test_namespace(client.clone()).await?;
+    resource_manager
+        .set_up_test_namespace(client.clone(), vec![])
+        .await?;
 
     let pods: Api<Pod> = Api::namespaced(client.clone(), resource_manager.namespace());
 

--- a/tests/pod_builder.rs
+++ b/tests/pod_builder.rs
@@ -96,6 +96,9 @@ pub fn wasmerciser_pod(
                     "value": architecture,
                 },
             ],
+            "nodeSelector": {
+                "kubernetes.io/arch": architecture
+            },
             "volumes": volumes,
         }
     }))?;

--- a/tests/pod_setup.rs
+++ b/tests/pod_setup.rs
@@ -1,0 +1,88 @@
+use futures::{StreamExt, TryStreamExt};
+use k8s_openapi::api::core::v1::{Pod};
+use kube::{
+    api::{Api, ListParams, WatchEvent},
+    runtime::Informer,
+};
+
+pub async fn wait_for_pod_ready(client: kube::Client, pod_name: &str) -> anyhow::Result<()> {
+    let api = Api::namespaced(client, "default");
+    let inf: Informer<Pod> = Informer::new(api).params(
+        ListParams::default()
+            .fields(&format!("metadata.name={}", pod_name))
+            .timeout(30),
+    );
+
+    let mut watcher = inf.poll().await?.boxed();
+    let mut went_ready = false;
+    while let Some(event) = watcher.try_next().await? {
+        match event {
+            WatchEvent::Modified(o) => {
+                let phase = o.status.unwrap().phase.unwrap();
+                if phase == "Running" {
+                    went_ready = true;
+                    break;
+                }
+            }
+            WatchEvent::Error(e) => {
+                panic!("WatchEvent error: {:?}", e);
+            }
+            _ => {}
+        }
+    }
+
+    assert!(went_ready, "pod never went ready");
+
+    Ok(())
+}
+
+#[derive(PartialEq)]
+pub enum OnFailure {
+    Accept,
+    Panic,
+}
+
+pub async fn wait_for_pod_complete(
+    client: kube::Client,
+    pod_name: &str,
+    on_failure: OnFailure,
+) -> anyhow::Result<()> {
+    let api = Api::namespaced(client.clone(), "default");
+    let inf: Informer<Pod> = Informer::new(api).params(
+        ListParams::default()
+            .fields(&format!("metadata.name={}", pod_name))
+            .timeout(30),
+    );
+
+    let mut watcher = inf.poll().await?.boxed();
+    let mut went_ready = false;
+    while let Some(event) = watcher.try_next().await? {
+        match event {
+            WatchEvent::Modified(o) => {
+                let phase = o.status.unwrap().phase.unwrap();
+                if phase == "Failed" && on_failure == OnFailure::Accept {
+                    return Ok(());
+                }
+                if phase == "Running" {
+                    went_ready = true;
+                }
+                if phase == "Succeeded" && !went_ready {
+                    panic!(
+                        "Pod {} reached completed phase before receiving Running phase",
+                        pod_name
+                    );
+                } else if phase == "Succeeded" {
+                    break;
+                }
+            }
+            WatchEvent::Error(e) => {
+                panic!("WatchEvent error: {:?}", e);
+            }
+            _ => {}
+        }
+    }
+
+    assert!(went_ready, format!("pod {} never went ready", pod_name));
+
+    Ok(())
+}

--- a/tests/pod_setup.rs
+++ b/tests/pod_setup.rs
@@ -1,5 +1,5 @@
 use futures::{StreamExt, TryStreamExt};
-use k8s_openapi::api::core::v1::{Pod};
+use k8s_openapi::api::core::v1::Pod;
 use kube::{
     api::{Api, ListParams, WatchEvent},
     runtime::Informer,

--- a/tests/pod_setup.rs
+++ b/tests/pod_setup.rs
@@ -5,8 +5,12 @@ use kube::{
     runtime::Informer,
 };
 
-pub async fn wait_for_pod_ready(client: kube::Client, pod_name: &str) -> anyhow::Result<()> {
-    let api = Api::namespaced(client, "default");
+pub async fn wait_for_pod_ready(
+    client: kube::Client,
+    pod_name: &str,
+    namespace: &str,
+) -> anyhow::Result<()> {
+    let api = Api::namespaced(client, namespace);
     let inf: Informer<Pod> = Informer::new(api).params(
         ListParams::default()
             .fields(&format!("metadata.name={}", pod_name))
@@ -45,9 +49,10 @@ pub enum OnFailure {
 pub async fn wait_for_pod_complete(
     client: kube::Client,
     pod_name: &str,
+    namespace: &str,
     on_failure: OnFailure,
 ) -> anyhow::Result<()> {
-    let api = Api::namespaced(client.clone(), "default");
+    let api = Api::namespaced(client.clone(), namespace);
     let inf: Informer<Pod> = Informer::new(api).params(
         ListParams::default()
             .fields(&format!("metadata.name={}", pod_name))

--- a/tests/test_resource_manager.rs
+++ b/tests/test_resource_manager.rs
@@ -1,0 +1,92 @@
+use futures::StreamExt;
+use k8s_openapi::api::core::v1::{ConfigMap, Pod, Secret};
+use kube::api::{Api, DeleteParams};
+
+#[derive(Clone, Debug)]
+pub enum TestResource {
+    Secret(String),
+    ConfigMap(String),
+    Pod(String),
+}
+
+pub struct TestResourceManager {
+    resources: Vec<TestResource>,
+}
+
+impl Drop for TestResourceManager {
+    fn drop(&mut self) {
+        let resources = self.resources.clone();
+        let t = std::thread::spawn(move || {
+            let mut rt =
+                tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime for cleanup");
+            rt.block_on(clean_up_resources(resources))
+        });
+
+        let thread_result = t.join();
+        let cleanup_result = thread_result.expect("Failed to clean up WASI test resources");
+        cleanup_result.unwrap()
+    }
+}
+
+impl TestResourceManager {
+    pub fn new() -> Self {
+        TestResourceManager { resources: vec![] }
+    }
+
+    pub fn push(&mut self, resource: TestResource) {
+        self.resources.push(resource)
+    }
+}
+
+// This needs to be a free function to work nicely with the Drop
+// implementation
+async fn clean_up_resources(resources: Vec<TestResource>) -> anyhow::Result<()> {
+    let cleanup_error_opts: Vec<_> = futures::stream::iter(resources)
+        .then(clean_up_resource)
+        .collect()
+        .await;
+    let cleanup_errors: Vec<_> = cleanup_error_opts
+        .iter()
+        .filter(|e| e.is_some())
+        .map(|e| e.as_ref().unwrap().to_string())
+        .filter(|s| !s.contains(r#"reason: "NotFound""#))
+        .collect();
+
+    if cleanup_errors.is_empty() {
+        Ok(())
+    } else {
+        let cleanup_failure_text = format!(
+            "Error(s) cleaning up resources: {}",
+            cleanup_errors.join(", ")
+        );
+        Err(anyhow::anyhow!(cleanup_failure_text))
+    }
+}
+
+async fn clean_up_resource(resource: TestResource) -> Option<String> {
+    let client = kube::Client::try_default()
+        .await
+        .expect("Failed to create client");
+
+    let secrets: Api<Secret> = Api::namespaced(client.clone(), "default");
+    let config_maps: Api<ConfigMap> = Api::namespaced(client.clone(), "default");
+    let pods: Api<Pod> = Api::namespaced(client.clone(), "default");
+
+    match resource {
+        TestResource::Secret(name) => secrets
+            .delete(&name, &DeleteParams::default())
+            .await
+            .err()
+            .map(|e| format!("secret {} ({})", name, e)),
+        TestResource::ConfigMap(name) => config_maps
+            .delete(&name, &DeleteParams::default())
+            .await
+            .err()
+            .map(|e| format!("configmap {} ({})", name, e)),
+        TestResource::Pod(name) => pods
+            .delete(&name, &DeleteParams::default())
+            .await
+            .err()
+            .map(|e| format!("pod {} ({})", name, e)),
+    }
+}

--- a/tests/test_resource_manager.rs
+++ b/tests/test_resource_manager.rs
@@ -103,10 +103,7 @@ impl TestResourceManager {
         Ok(())
     }
 
-    async fn set_up_resource(
-        &mut self,
-        resource: &TestResourceSpec,
-    ) -> anyhow::Result<()> {
+    async fn set_up_resource(&mut self, resource: &TestResourceSpec) -> anyhow::Result<()> {
         let secrets: Api<Secret> = Api::namespaced(self.client.clone(), self.namespace());
         let config_maps: Api<ConfigMap> = Api::namespaced(self.client.clone(), self.namespace());
 


### PR DESCRIPTION
This PR breaks up the single WASI megatest into a bunch of more granular test functions, currently one per pod used in the testing.  The tests are now able to run in parallel and are kept separate through namespaces.  The pattern for creating new tests is intended to be clear and to require minimal programmer effort, so that we will hopefully be inclined to write new tests for new things and not bolt things onto existing tests out of laziness!

I also moved a bunch of stuff out of the main test file into helper files - some of this, such as the `TestResourceManager` is behavioural, but other parts are just moving things to make the main file a bit more navigable.