### PR TITLE
bind capabilities if actor has it in its claims

### DIFF
--- a/crates/wascc-provider/src/lib.rs
+++ b/crates/wascc-provider/src/lib.rs
@@ -276,8 +276,8 @@ impl WasccProvider {
             message: "No status has been received from the process".into(),
         });
         let host = self.host.clone();
-        let http_result = tokio::task::spawn_blocking(move || {
-            wascc_run_http(
+        let wascc_result = tokio::task::spawn_blocking(move || {
+            wascc_run(
                 host,
                 module_data,
                 env,
@@ -288,7 +288,7 @@ impl WasccProvider {
             )
         })
         .await?;
-        match http_result {
+        match wascc_result {
             Ok(handle) => {
                 run_context
                     .container_handles
@@ -559,29 +559,6 @@ struct VolumeBinding {
     host_path: PathBuf,
 }
 
-/// Run a WasCC module inside of the host, configuring it to handle HTTP requests.
-///
-/// This bootstraps an HTTP host, using the value of the env's `PORT` key to expose a port.
-fn wascc_run_http(
-    host: Arc<Mutex<WasccHost>>,
-    data: Vec<u8>,
-    mut env: EnvVars,
-    volumes: Vec<VolumeBinding>,
-    log_path: &Path,
-    status_recv: Receiver<ContainerStatus>,
-    port_assigned: i32,
-) -> anyhow::Result<ContainerHandle<ActorHandle, LogHandleFactory>> {
-    let mut caps: Vec<Capability> = Vec::new();
-
-    env.insert("PORT".to_string(), port_assigned.to_string());
-    caps.push(Capability {
-        name: HTTP_CAPABILITY,
-        binding: None,
-        env,
-    });
-    wascc_run(host, data, &mut caps, volumes, log_path, status_recv)
-}
-
 #[derive(Debug)]
 struct PortAllocationError {}
 
@@ -650,11 +627,13 @@ impl kubelet::log::HandleFactory<tokio::fs::File> for LogHandleFactory {
 fn wascc_run(
     host: Arc<Mutex<WasccHost>>,
     data: Vec<u8>,
-    capabilities: &mut Vec<Capability>,
+    mut env: EnvVars,
     volumes: Vec<VolumeBinding>,
     log_path: &Path,
     status_recv: Receiver<ContainerStatus>,
+    port_assigned: i32,
 ) -> anyhow::Result<ContainerHandle<ActorHandle, LogHandleFactory>> {
+    let mut capabilities: Vec<Capability> = Vec::new();
     info!("sending actor to wascc host");
     let log_output = NamedTempFile::new_in(log_path)?;
     let mut logenv: HashMap<String, String> = HashMap::new();
@@ -662,16 +641,30 @@ fn wascc_run(
         LOG_PATH_KEY.to_string(),
         log_output.path().to_str().unwrap().to_owned(),
     );
-    capabilities.push(Capability {
-        name: LOG_CAPABILITY,
-        binding: None,
-        env: logenv,
-    });
 
     let load = Actor::from_bytes(data).map_err(|e| anyhow::anyhow!("Error loading WASM: {}", e))?;
     let pk = load.public_key();
 
-    if load.capabilities().contains(&FS_CAPABILITY.to_owned()) {
+    let actor_caps = load.capabilities();
+
+    if actor_caps.contains(&LOG_CAPABILITY.to_owned()) {
+        capabilities.push(Capability {
+            name: LOG_CAPABILITY,
+            binding: None,
+            env: logenv,
+        });
+    }
+
+    if actor_caps.contains(&HTTP_CAPABILITY.to_owned()) {
+        env.insert("PORT".to_string(), port_assigned.to_string());
+        capabilities.push(Capability {
+            name: HTTP_CAPABILITY,
+            binding: None,
+            env,
+        });
+    }
+
+    if actor_caps.contains(&FS_CAPABILITY.to_owned()) {
         for vol in &volumes {
             info!(
                 "Loading File System capability for volume name: '{}' host_path: '{}'",


### PR DESCRIPTION
This fixes an issue where capabilities that the actor did not add to its claim are being added, causing a runtime error. We should only be binding capabilities that the actor requested.

closes #239

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>