### PR TITLE
Fill in container status image field

### DIFF
--- a/crates/kubelet/src/container/mod.rs
+++ b/crates/kubelet/src/container/mod.rs
@@ -8,7 +8,7 @@ use std::fmt::Display;
 mod handle;
 mod status;
 
-pub use handle::{Handle, HandleMap};
+pub use handle::{RuntimeContainer, HandleMap};
 pub use status::Status;
 
 /// Specifies how the store should check for module updates

--- a/crates/kubelet/src/container/mod.rs
+++ b/crates/kubelet/src/container/mod.rs
@@ -8,8 +8,8 @@ use std::fmt::Display;
 mod handle;
 mod status;
 
-pub use handle::{RuntimeContainer, HandleMap};
-pub use status::Status;
+pub use handle::{HandleMap, RuntimeContainer};
+pub use status::{KubeStatusInfo, Status};
 
 /// Specifies how the store should check for module updates
 #[derive(PartialEq, Debug, Clone, Copy)]
@@ -247,5 +247,15 @@ impl Container {
     /// Get working directory of container.
     pub fn working_dir(&self) -> Option<&String> {
         self.0.working_dir.as_ref()
+    }
+
+    /// Augments a `Status` with the information required to set the Kubernetes
+    /// container status.
+    pub fn augment_status(&self, status: Status) -> KubeStatusInfo {
+        KubeStatusInfo {
+            name: self.name().to_owned(),
+            image: self.image().unwrap_or_default(),
+            status,
+        }
     }
 }

--- a/crates/kubelet/src/container/status.rs
+++ b/crates/kubelet/src/container/status.rs
@@ -35,14 +35,14 @@ pub enum Status {
     },
 }
 
-/// TODO: DOCS
+/// Contains the data required to update a Kubernetes container status.
 #[derive(Clone, Debug)]
 pub struct KubeStatusInfo {
-    /// TODO: DOCS
+    /// The name of the container.
     pub name: String,
-    /// TODO: DOCS
+    /// The image referenced by the container.
     pub image: Option<oci_distribution::Reference>,
-    /// TODO: DOCS
+    /// The current state of the container.
     pub status: Status,
 }
 

--- a/crates/kubelet/src/pod/handle.rs
+++ b/crates/kubelet/src/pod/handle.rs
@@ -39,8 +39,11 @@ impl<H: StopHandler, F> Handle<H, F> {
         volumes: Option<HashMap<String, Ref>>,
         initial_message: Option<String>,
     ) -> anyhow::Result<Self> {
-        let container_keys: Vec<_> = container_handles.keys().cloned().collect();
-        pod.initialise_status(&client, &container_keys, initial_message)
+        let container_keys_images: Vec<_> = container_handles
+            .iter()
+            .map(|(k, v)| (k.clone(), v.spec().image().unwrap_or_default()))
+            .collect();
+        pod.initialise_status(&client, &container_keys_images, initial_message)
             .await;
 
         let mut channel_map = StreamMap::with_capacity(container_handles.len());

--- a/crates/kubelet/src/pod/status.rs
+++ b/crates/kubelet/src/pod/status.rs
@@ -3,7 +3,7 @@
 use k8s_openapi::api::core::v1::Pod;
 use kube::{api::PatchParams, Api};
 
-use crate::container::{ContainerMap, Status as ContainerStatus};
+use crate::container::{ContainerMap, KubeStatusInfo};
 
 /// Describe the status of a workload.
 #[derive(Clone, Debug, Default)]
@@ -12,7 +12,7 @@ pub struct Status {
     /// a message from the container statuses
     pub message: StatusMessage,
     /// The statuses of containers keyed off their names
-    pub container_statuses: ContainerMap<ContainerStatus>,
+    pub container_statuses: ContainerMap<KubeStatusInfo>,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/wasi-provider/src/wasi_runtime.rs
+++ b/crates/wasi-provider/src/wasi_runtime.rs
@@ -131,14 +131,11 @@ impl WasiRuntime {
         })
         .await??;
 
-        let (status_sender, status_recv) = watch::channel(KubeStatusInfo {
-            name: self.data.spec.name().to_owned(),
-            image: self.data.spec.image().unwrap_or_default(),
-            status: Status::Waiting {
+        let (status_sender, status_recv) =
+            watch::channel(self.data.spec.augment_status(Status::Waiting {
                 timestamp: chrono::Utc::now(),
                 message: "No status has been received from the process".into(),
-            },
-        });
+            }));
         let (interrupt_handle, handle) = self.spawn_wasmtime(status_sender, output_write).await?;
 
         let log_handle_factory = HandleFactory {

--- a/crates/wasi-provider/src/wasi_runtime.rs
+++ b/crates/wasi-provider/src/wasi_runtime.rs
@@ -53,6 +53,7 @@ pub struct WasiModuleRuntime<H, F> {
 }
 
 struct Data {
+    /// The Kubernetes container specification; used for status updates.
     spec: Container, // TODO: this feels like level leakage
     /// binary module data to be run as a wasm module
     module_data: Vec<u8>,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -7,7 +7,7 @@ mod expectations;
 mod pod_builder;
 mod pod_setup;
 mod test_resource_manager;
-use expectations::{assert_container_statuses, ContainerStatusExpectation};
+use expectations::{assert_container_statuses, Expect, Id};
 use pod_builder::{wasmerciser_pod, WasmerciserContainerSpec, WasmerciserVolumeSpec};
 use pod_setup::{wait_for_pod_complete, wait_for_pod_ready, OnFailure};
 use test_resource_manager::{TestResource, TestResourceManager, TestResourceSpec};
@@ -605,12 +605,12 @@ async fn test_init_containers() -> anyhow::Result<()> {
         &pods,
         INITY_WASI_POD,
         vec![
-            ContainerStatusExpectation::InitTerminated("init-1", "Module run completed"),
-            ContainerStatusExpectation::InitTerminated("init-2", "Module run completed"),
-            ContainerStatusExpectation::InitNotPresent(INITY_WASI_POD),
-            ContainerStatusExpectation::AppNotPresent("init-1"),
-            ContainerStatusExpectation::AppNotPresent("init-2"),
-            ContainerStatusExpectation::AppTerminated(INITY_WASI_POD, "Module run completed"),
+            (Id::Init("init-1"), Expect::IsTerminatedWith("Module run completed")),
+            (Id::Init("init-2"), Expect::IsTerminatedWith("Module run completed")),
+            (Id::Init(INITY_WASI_POD), Expect::IsNotPresent),
+            (Id::App("init-1"), Expect::IsNotPresent),
+            (Id::App("init-2"), Expect::IsNotPresent),
+            (Id::App(INITY_WASI_POD), Expect::IsTerminatedWith("Module run completed")),
         ],
     )
     .await?;


### PR DESCRIPTION
There are a number of fields in the Kubernetes container status that we don't fill in - e.g. containerID, image, imageID.  This PR is to explore how we might go about addressing this, starting with the image field.

I'm not particularly happy with the solution I've ended up with, but perhaps someone can use it to inspire a cleaner solution.  I think we may need to rethink some of the implicit container and pod representation, though, to come up with anything nice...