### PR TITLE
Notify user if they need to approve a bootstrap CSR

### DIFF
--- a/src/krustlet-wascc.rs
+++ b/src/krustlet-wascc.rs
@@ -14,7 +14,7 @@ async fn main() -> anyhow::Result<()> {
     // Initialize the logger
     env_logger::init();
 
-    let kubeconfig = kubelet::bootstrap(&config, &config.bootstrap_file).await?;
+    let kubeconfig = kubelet::bootstrap(&config, &config.bootstrap_file, notify_bootstrap).await?;
 
     let store = make_store(&config);
 
@@ -34,4 +34,8 @@ fn make_store(config: &Config) -> Arc<dyn kubelet::store::Store + Send + Sync> {
     } else {
         file_store
     }
+}
+
+fn notify_bootstrap(message: String) {
+    println!("BOOTSTRAP: {}", message);
 }

--- a/src/krustlet-wasi.rs
+++ b/src/krustlet-wasi.rs
@@ -14,7 +14,7 @@ async fn main() -> anyhow::Result<()> {
     // Initialize the logger
     env_logger::init();
 
-    let kubeconfig = kubelet::bootstrap(&config, &config.bootstrap_file).await?;
+    let kubeconfig = kubelet::bootstrap(&config, &config.bootstrap_file, notify_bootstrap).await?;
 
     let store = make_store(&config);
 
@@ -34,4 +34,8 @@ fn make_store(config: &Config) -> Arc<dyn kubelet::store::Store + Send + Sync> {
     } else {
         file_store
     }
+}
+
+fn notify_bootstrap(message: String) {
+    println!("BOOTSTRAP: {}", message);
 }


### PR DESCRIPTION
This adds a notification to the bootstrap process to inform the user when they need to approve a CSR.  It serves two purposes:

1. Currently if you do `bootstrap.sh` and then, say, `just run-wasi`, the kubelet just sits there but all your tests fail because it's waiting on TLS cert approval.  Now the user will have a visual prompt of what they need to do.

2. In preparation for #318, it provides a point in the output where a test harness can know that the CSR is ready, and can extract the CSR name in order to approve it.

Note that the actual interaction is NOT provided by the `kubelet` crate, either by logging macros or by `println!`.  This is because we cannot control the log level on the `kubelet` crate, and we do not want to use `println!` in the crate because it could in principle be hosted in a non-console environment.  Therefore instead the kubelet _application_ passes in a callback representing how it would like to notify its users - in our cases via `println!` again because the justfile logging settings didn't show info messages.