### PR TITLE
downgrade to azure-cli 2.9.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,11 +86,12 @@ jobs:
           cd krustlet
           sha256sum * > checksums-${{ env.RELEASE_VERSION }}.txt
       - name: upload to azure
-        uses: bacongobbler/azure-blob-storage-upload@v1.0.0
+        uses: bacongobbler/azure-blob-storage-upload@main
         with:
           source_dir: krustlet
           container_name: releases
           connection_string: ${{ secrets.AzureStorageConnectionString }}
+          sync: false
   crates:
     name: publish to crates.io
     runs-on: ubuntu-latest


### PR DESCRIPTION
A recent bug was introduced to the azure CLI preventing `az storage blob upload-batch` from working. In the meantime, a hotfix has been provided to the HEAD of azure-blob-storage-upload reverting back to azure-cli v2.9.1

The `sync` flag was also introduced since v1.0.0, which is enabled by default. sync must be disabled to preserve files currently present in the storage account.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>