### PR TITLE
fix(release): sleep for 60 seconds before publishing kubelet

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,8 @@ jobs:
         working-directory: ./crates/oci-distribution
         run: cargo publish --token ${{ secrets.CargoToken }}
         continue-on-error: true
+      - name: wait for oci-distribution to be published
+        run: sleep 60
       - name: publish kubelet to crates.io
         working-directory: ./crates/kubelet
         run: cargo publish --token ${{ secrets.CargoToken }}


### PR DESCRIPTION
often, a new publish of the kubelet crate may need to wait until the new version of oci-distribution is available.

closes #341