### PR TITLE
Self-contained integration tester

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1635,6 +1635,7 @@ dependencies = [
  "kube",
  "kubelet",
  "oci-distribution",
+ "regex",
  "reqwest",
  "serde",
  "serde_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1630,6 +1630,7 @@ dependencies = [
  "dirs",
  "env_logger",
  "futures",
+ "hostname",
  "k8s-openapi",
  "kube",
  "kubelet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ wasi-provider = { path = "./crates/wasi-provider", version = "0.4", default-feat
 oci-distribution = { path = "./crates/oci-distribution", version = "0.3", default-features = false }
 dirs = "2.0"
 hostname = "0.3"
+regex = "1.3"
 
 [dev-dependencies]
 futures = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,3 +70,7 @@ path = "src/krustlet-wascc.rs"
 [[bin]]
 name = "krustlet-wasi"
 path = "src/krustlet-wasi.rs"
+
+[[bin]]
+name = "oneclick"
+path = "tests/oneclick/src/main.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,8 @@ kubelet = { path = "./crates/kubelet", version = "0.4", default-features = false
 wascc-provider = { path = "./crates/wascc-provider", version = "0.4", default-features = false }
 wasi-provider = { path = "./crates/wasi-provider", version = "0.4", default-features = false }
 oci-distribution = { path = "./crates/oci-distribution", version = "0.3", default-features = false }
+dirs = "2.0"
+hostname = "0.3"
 
 [dev-dependencies]
 futures = "0.3"
@@ -55,7 +57,6 @@ serde_json = "1.0"
 serde = "1.0"
 k8s-openapi = { version = "0.8", default-features = false, features = ["v1_17"] }
 reqwest = { version = "0.10", default-features = false }
-dirs = "2.0"
 tempfile = "3.1"
 
 [workspace]

--- a/docs/community/developers.md
+++ b/docs/community/developers.md
@@ -148,6 +148,27 @@ And in terminal 3:
 $ just test-e2e
 ```
 
+You can run the integration tests without creating additional terminals or
+manually running the kubelets by running:
+
+```
+$ just test-e2e-standalone
+```
+
+This:
+
+* Bootstraps and approves certificates if necessary
+* Runs the WASI and WASCC kubelets in the background
+* Runs the integration tests
+* Terminates the kubelets when the integration tests complete
+* Reports test failures, and saves the kubelet logs if any tests failed
+
+You **will** still need to set `KRUSTLET_NODE_IP` because the tester doesn't know what
+kind of Kubernetes cluster you're using and so doesn't know how to infer a node IP.
+
+_WARNING:_ The standalone integration tester has not been, er, tested on Windows.
+Hashtag irony.
+
 ## Creating your own Kubelets with Krustlet
 
 If you want to create your own Kubelet based on Krustlet, all you need to do is implement a

--- a/justfile
+++ b/justfile
@@ -16,6 +16,9 @@ test:
 test-e2e:
     cargo test --test integration_tests
 
+test-e2e-standalone:
+    cargo run --bin oneclick
+
 run-wascc +FLAGS='': bootstrap
     KUBECONFIG=$(eval echo $CONFIG_DIR)/kubeconfig-wascc cargo run --bin krustlet-wascc {{FLAGS}} -- --node-name krustlet-wascc --port 3000 --bootstrap-file $(eval echo $CONFIG_DIR)/bootstrap.conf --cert-file $(eval echo $CONFIG_DIR)/krustlet-wascc.crt --private-key-file $(eval echo $CONFIG_DIR)/krustlet-wascc.key
 

--- a/tests/oneclick/src/main.rs
+++ b/tests/oneclick/src/main.rs
@@ -51,7 +51,7 @@ fn main() {
 
 fn config_dir() -> std::path::PathBuf {
     let home_dir = dirs::home_dir().expect("Can't get home dir"); // TODO: allow override of config dir
-    home_dir.join(".krustlet/cnfig")
+    home_dir.join(".krustlet/config")
 }
 
 fn prepare_for_bootstrap() -> BootstrapReadiness {

--- a/tests/oneclick/src/main.rs
+++ b/tests/oneclick/src/main.rs
@@ -291,7 +291,7 @@ fn launch_kubelet(
         ])
         .env("KUBECONFIG", kubeconfig)
         .env(
-            "RUSTLOG",
+            "RUST_LOG",
             "wascc_host=debug,wascc_provider=debug,wasi_provider=debug,main=debug",
         )
         .stdout(std::process::Stdio::piped())

--- a/tests/oneclick/src/main.rs
+++ b/tests/oneclick/src/main.rs
@@ -512,9 +512,8 @@ fn write_kubelet_log_to_file(
     file_path: std::path::PathBuf,
 ) {
     let mut file_result = std::fs::File::create(file_path);
-    let file_result_mut = file_result.as_mut();
-    match file_result_mut {
-        Ok(file) => {
+    match file_result {
+        Ok(ref mut file) => {
             let write_result = std::io::copy(log, file);
             match write_result {
                 Ok(_) => (),

--- a/tests/oneclick/src/main.rs
+++ b/tests/oneclick/src/main.rs
@@ -388,10 +388,11 @@ impl OwnedChildProcess {
             Ok(_) => {
                 self.terminated = true;
                 Ok(())
-            },
-            Err(e) => {
-                Err(anyhow::anyhow!("Failed to terminate spawned kubelet process: {}", e))
             }
+            Err(e) => Err(anyhow::anyhow!(
+                "Failed to terminate spawned kubelet process: {}",
+                e
+            )),
         }
     }
 }
@@ -438,15 +439,24 @@ fn run_tests(readiness: BootstrapReadiness) -> anyhow::Result<()> {
 
     if matches!(test_result, Err(_)) {
         // TODO: ideally we shouldn't have to wait for termination before getting logs
-        let terminate_result = wasi_process.terminate()
+        let terminate_result = wasi_process
+            .terminate()
             .and_then(|_| wascc_process.terminate());
         match terminate_result {
             Ok(_) => {
                 let wasi_log_destination = std::path::PathBuf::from("./krustlet-wasi-e2e");
-                capture_kubelet_logs("krustlet-wasi", &mut wasi_process.child, wasi_log_destination);
+                capture_kubelet_logs(
+                    "krustlet-wasi",
+                    &mut wasi_process.child,
+                    wasi_log_destination,
+                );
                 let wascc_log_destination = std::path::PathBuf::from("./krustlet-wascc-e2e");
-                capture_kubelet_logs("krustlet-wascc", &mut wascc_process.child, wascc_log_destination);
-            },
+                capture_kubelet_logs(
+                    "krustlet-wascc",
+                    &mut wascc_process.child,
+                    wascc_log_destination,
+                );
+            }
             Err(e) => {
                 eprintln!("{}", e);
                 eprintln!("Can't capture kubelet logs as they didn't terminate");

--- a/tests/oneclick/src/main.rs
+++ b/tests/oneclick/src/main.rs
@@ -86,7 +86,11 @@ fn all_or_none(files: Vec<std::path::PathBuf>) -> AllOrNone {
 }
 
 fn delete_csr(csr_name: impl AsRef<str>) -> std::io::Result<std::process::Child> {
-    std::process::Command::new("kubectl").args(&["delete", "csr", csr_name.as_ref()]).spawn()
+    std::process::Command::new("kubectl")
+        .args(&["delete", "csr", csr_name.as_ref()])
+        .stderr(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
 }
 
 trait ResultSequence {

--- a/tests/oneclick/src/main.rs
+++ b/tests/oneclick/src/main.rs
@@ -1,0 +1,43 @@
+const EXIT_CODE_BOOTSTRAPPED: i32 = 0;
+const EXIT_CODE_NEED_APPROVE: i32 = 1;
+const EXIT_CODE_NEED_MANUAL_CLEANUP: i32 = 2;
+
+fn main() {
+    let cert_paths: Vec<_> = vec! [
+        "/home/ivan/.krustlet/config/krustlet-wasi.crt",
+        "/home/ivan/.krustlet/config/krustlet-wasi.key",
+        "/home/ivan/.krustlet/config/krustlet-wascc.crt",
+        "/home/ivan/.krustlet/config/krustlet-wascc.key",
+    ].iter().map(std::path::PathBuf::from).collect();
+
+    let status = all_or_none(cert_paths);
+
+    match status {
+        AllOrNone::AllExist => std::process::exit(EXIT_CODE_BOOTSTRAPPED),
+        AllOrNone::NoneExist => (),
+        AllOrNone::Error => std::process::exit(EXIT_CODE_NEED_MANUAL_CLEANUP),
+    };
+
+}
+
+enum AllOrNone {
+    AllExist,
+    NoneExist,
+    Error,
+}
+
+fn all_or_none(files: Vec<std::path::PathBuf>) -> AllOrNone {
+    let (exist, missing): (Vec<_>, Vec<_>) = files.iter().partition(|f| f.exists());
+
+    if missing.is_empty() {
+        return AllOrNone::AllExist;
+    }
+
+    for f in exist {
+        if matches!(std::fs::remove_file(f), Err(_)) {
+            return AllOrNone::Error;
+        }
+    }
+
+    AllOrNone::NoneExist
+}

--- a/tests/oneclick/src/main.rs
+++ b/tests/oneclick/src/main.rs
@@ -49,10 +49,12 @@ fn main() {
     std::process::exit(exit_code);
 }
 
-fn prepare_for_bootstrap() -> BootstrapReadiness {
+fn config_dir() -> std::path::PathBuf {
     let home_dir = dirs::home_dir().expect("Can't get home dir"); // TODO: allow override of config dir
-    let config_dir = home_dir.join(".krustlet/cnfig");
+    home_dir.join(".krustlet/cnfig")
+}
 
+fn prepare_for_bootstrap() -> BootstrapReadiness {
     let host_name = hostname::get()
         .expect("Can't get host name")
         .into_string()
@@ -65,7 +67,7 @@ fn prepare_for_bootstrap() -> BootstrapReadiness {
         "krustlet-wascc.key",
     ]
     .iter()
-    .map(|f| config_dir.join(f))
+    .map(|f| config_dir().join(f))
     .collect();
 
     let status = all_or_none(cert_paths);
@@ -198,6 +200,7 @@ fn run_bootstrap() -> anyhow::Result<()> {
     let bootstrap_script = format!("{}/docs/howto/assets/bootstrap.{}", repo_root, ext);
     let bootstrap_output = std::process::Command::new(shell)
         .arg(bootstrap_script)
+        .env("CONFIG_DIR", config_dir())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .output()?;

--- a/tests/oneclick/src/main.rs
+++ b/tests/oneclick/src/main.rs
@@ -3,12 +3,17 @@ const EXIT_CODE_NEED_APPROVE: i32 = 1;
 const EXIT_CODE_NEED_MANUAL_CLEANUP: i32 = 2;
 
 fn main() {
+    let home_dir = dirs::home_dir().expect("Can't get home dir"); // TODO: allow override of config dir
+    let config_dir = home_dir.join(".krustlet/cnfig");
+
+    let host_name = hostname::get().expect("Can't get host name").into_string().expect("Can't get host name");
+
     let cert_paths: Vec<_> = vec! [
-        "/home/ivan/.krustlet/config/krustlet-wasi.crt",
-        "/home/ivan/.krustlet/config/krustlet-wasi.key",
-        "/home/ivan/.krustlet/config/krustlet-wascc.crt",
-        "/home/ivan/.krustlet/config/krustlet-wascc.key",
-    ].iter().map(std::path::PathBuf::from).collect();
+        "krustlet-wasi.crt",
+        "krustlet-wasi.key",
+        "krustlet-wascc.crt",
+        "krustlet-wascc.key",
+    ].iter().map(|f| config_dir.join(f)).collect();
 
     let status = all_or_none(cert_paths);
 
@@ -19,8 +24,11 @@ fn main() {
     };
 
     // We are not bootstrapped, but there may be existing CSRs around
-    let wasi_host_name = "hecate";
-    let wascc_host_name = "hecate";
+
+    // TODO: allow override of host names
+    let wasi_host_name = &host_name;
+    let wascc_host_name = &host_name;
+
     let wasi_cert_name = format!("{}-tls", wasi_host_name);
     let wascc_cert_name = format!("{}-tls", wascc_host_name);
 

--- a/tests/oneclick/src/main.rs
+++ b/tests/oneclick/src/main.rs
@@ -75,6 +75,10 @@ fn config_dir() -> std::path::PathBuf {
     home_dir.join(".krustlet/config")
 }
 
+fn config_file_path_str(file_name: impl AsRef<std::path::Path>) -> String {
+    config_dir().join(file_name).to_str().unwrap().to_owned()
+}
+
 fn build_workspace() -> anyhow::Result<()> {
     let build_result = std::process::Command::new("cargo")
         .args(&["build"])
@@ -263,28 +267,10 @@ fn launch_kubelet(
     // run the kubelet as a background process using the
     // same cmd line as in the justfile:
     // KUBECONFIG=$(eval echo $CONFIG_DIR)/kubeconfig-wasi cargo run --bin krustlet-wasi {{FLAGS}} -- --node-name krustlet-wasi --port 3001 --bootstrap-file $(eval echo $CONFIG_DIR)/bootstrap.conf --cert-file $(eval echo $CONFIG_DIR)/krustlet-wasi.crt --private-key-file $(eval echo $CONFIG_DIR)/krustlet-wasi.key
-    // TODO: all this to_str().unwrap().to_owned() is farcical - what is the right way to do this?
-    let config_dir = config_dir();
-    let bootstrap_conf = config_dir
-        .join("bootstrap.conf")
-        .to_str()
-        .unwrap()
-        .to_owned();
-    let cert = config_dir
-        .join(format!("{}.crt", name))
-        .to_str()
-        .unwrap()
-        .to_owned();
-    let private_key = config_dir
-        .join(format!("{}.key", name))
-        .to_str()
-        .unwrap()
-        .to_owned();
-    let kubeconfig = config_dir
-        .join(format!("kubeconfig-{}", kubeconfig_suffix))
-        .to_str()
-        .unwrap()
-        .to_owned();
+    let bootstrap_conf = config_file_path_str("bootstrap.conf");
+    let cert = config_file_path_str(format!("{}.crt", name));
+    let private_key = config_file_path_str(format!("{}.key", name));
+    let kubeconfig = config_file_path_str(format!("kubeconfig-{}", kubeconfig_suffix));
     let port_arg = format!("{}", kubelet_port);
 
     let repo_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));


### PR DESCRIPTION
Addresses #318.

This PR adds a new binary which, when run, does the following:

* Builds the WASI and WASCC kubelets
* Checks if bootstrapped certificates exist; if not, cleans up what does exist and runs the bootstrap script
* Launches both kubelets
* If bootstrapping, monitors both kubelets for the certificate approval message, and approves the certificate
* Runs the integration tests and waits for them to complete
* If the tests fail, captures the kubectl stdout and stderr to files, and prints the test failure details
* Terminates the running kubelets

There is still a lot that could be improved about this, e.g. stream test results as they arrive, send the logs to a better place than the current directory, etc.  But I think it's a useful first step.

## Why write it in Rust, not bash?

Because we can now build and test on Windows, and I don't want to have to maintain parallel bash and Powershell scripts.  Rust is fiddlier than is ideal for this sort of glue code, but using Rust instead of, say, Python means we don't incur another dependency.

Which reminds me...

* ~TODO: invoke `bootstrap.ps1` instead of `bootstrap.sh` when running on Windows~ Wait, I already did that ~and forgot about it~ - excellent work, Ivan, high five

## How do I use it?

Run `just test-e2e-standalone`, or `cargo run --bin oneclick`.

## Can we change the names, reorganise the code, etc.?

Yes.

## Any other to-dos?

I'm glad you asked.

* TODO: incorporate it in the CI
* ~TODO: add it to the documentation~