### PR TITLE
fix Windows build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
             }
           - {
               os: "windows-latest",
-              arch: "msvc",
+              arch: "amd64",
               args: "--release --no-default-features --features rustls-tls",
               extension: ".exe",
             }
@@ -35,6 +35,7 @@ jobs:
 
       - name: set the release version (tag)
         if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
         run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF/refs\/tags\//}
 
       - name: set the release version (master)
@@ -60,7 +61,7 @@ jobs:
           mkdir _dist
           cp README.md LICENSE target/release/krustlet-wasi${{ matrix.config.extension }} target/release/krustlet-wascc${{ matrix.config.extension }} _dist/
           cd _dist
-          tar czf krustlet-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz README.md LICENSE krustlet-wasi krustlet-wascc
+          tar czf krustlet-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz README.md LICENSE krustlet-wasi${{ matrix.config.extension }} krustlet-wascc${{ matrix.config.extension }}
 
       - uses: actions/upload-artifact@v1
         with:


### PR DESCRIPTION
I noticed a few things that went awry with the windows build:

- the .exe file extension was not present for the executables
- setting the release version ran under powershell instead of bash
- the architecture used was "msvc", but the download link expected the architecture "amd64".

closes #346.