### PR TITLE
[oci-distribution] Support digest references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "oci-distribution"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ env_logger = "0.7"
 kubelet = { path = "./crates/kubelet", version = "0.4", default-features = false, features = ["cli"] }
 wascc-provider = { path = "./crates/wascc-provider", version = "0.4", default-features = false }
 wasi-provider = { path = "./crates/wasi-provider", version = "0.4", default-features = false }
-oci-distribution = { path = "./crates/oci-distribution", version = "0.3", default-features = false }
+oci-distribution = { path = "./crates/oci-distribution", version = "0.4", default-features = false }
 
 [dev-dependencies]
 futures = "0.3"

--- a/crates/kubelet/Cargo.toml
+++ b/crates/kubelet/Cargo.toml
@@ -54,7 +54,7 @@ native-tls = "0.2"
 tokio-tls = "0.3"
 thiserror = "1.0"
 lazy_static = "1.4"
-oci-distribution = { path = "../oci-distribution", version = "0.3", default-features = false }
+oci-distribution = { path = "../oci-distribution", version = "0.4", default-features = false }
 url = "2.1"
 warp = { version = "0.2", features = ['tls'] }
 http = "0.2"

--- a/crates/oci-distribution/Cargo.toml
+++ b/crates/oci-distribution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oci-distribution"
-version = "0.3.0"
+version = "0.4.0"
 authors = [
     "Matt Butcher <matt.butcher@microsoft.com>",
     "Matthew Fisher <matt.fisher@microsoft.com>",

--- a/crates/wascc-provider/Cargo.toml
+++ b/crates/wascc-provider/Cargo.toml
@@ -39,4 +39,4 @@ k8s-openapi = { version = "0.8", default-features = false, features = ["v1_17"] 
 rand = "0.7.3"
 
 [dev-dependencies]
-oci-distribution = { path = "../oci-distribution", version = "0.3" }
+oci-distribution = { path = "../oci-distribution", version = "0.4" }

--- a/crates/wasi-provider/Cargo.toml
+++ b/crates/wasi-provider/Cargo.toml
@@ -36,4 +36,4 @@ futures = "0.3"
 k8s-openapi = { version = "0.8", default-features = false, features = ["v1_17"] }
 
 [dev-dependencies]
-oci-distribution = { path = "../oci-distribution", version = "0.3" }
+oci-distribution = { path = "../oci-distribution", version = "0.4" }


### PR DESCRIPTION
The OCI distribution spec supports [fetching manifests by tag or digest](https://github.com/opencontainers/distribution-spec/blob/master/spec.md#get-manifest). This PR adds support for parsing and downloading digested manifest references.

## ⚠️ Breaking Changes

The public `to_v2_blob_url` and `to_v2_manifest_url` methods of `Reference` have been removed and are now private methods on `Client`. These seemed like implementation details of the client, but if it would be preferable to hash this out in a separate PR I'm happy to do so.