### PR TITLE
ref(*): Renames node taint to `kubernetes.io/arch`

### DIFF
--- a/crates/wascc-provider/src/lib.rs
+++ b/crates/wascc-provider/src/lib.rs
@@ -336,7 +336,7 @@ impl Provider for WasccProvider {
 
     async fn node(&self, builder: &mut Builder) -> anyhow::Result<()> {
         builder.set_architecture("wasm-wasi");
-        builder.add_taint("NoExecute", "krustlet/arch", Self::ARCH);
+        builder.add_taint("NoExecute", "kubernetes.io/arch", Self::ARCH);
         Ok(())
     }
 

--- a/crates/wasi-provider/src/lib.rs
+++ b/crates/wasi-provider/src/lib.rs
@@ -268,7 +268,7 @@ impl Provider for WasiProvider {
 
     async fn node(&self, builder: &mut Builder) -> anyhow::Result<()> {
         builder.set_architecture("wasm-wasi");
-        builder.add_taint("NoExecute", "krustlet/arch", Self::ARCH);
+        builder.add_taint("NoExecute", "kubernetes.io/arch", Self::ARCH);
         Ok(())
     }
 

--- a/demos/wascc/fileserver/k8s.yaml
+++ b/demos/wascc/fileserver/k8s.yaml
@@ -28,7 +28,7 @@ spec:
     - key: "node.kubernetes.io/network-unavailable"
       operator: "Exists"
       effect: "NoSchedule"
-    - key: "krustlet/arch"
+    - key: "kubernetes.io/arch"
       operator: "Equal"
       value: "wasm32-wascc"
       effect: "NoExecute"

--- a/demos/wascc/greet/greet-wascc.yaml
+++ b/demos/wascc/greet/greet-wascc.yaml
@@ -20,7 +20,7 @@ spec:
     - key: "node.kubernetes.io/network-unavailable"
       operator: "Exists"
       effect: "NoSchedule"
-    - key: "krustlet/arch"
+    - key: "kubernetes.io/arch"
       operator: "Equal"
       value: "wasm32-wascc"
       effect: "NoExecute"

--- a/demos/wascc/hello-world-assemblyscript/k8s.yaml
+++ b/demos/wascc/hello-world-assemblyscript/k8s.yaml
@@ -15,7 +15,7 @@ spec:
     - key: "node.kubernetes.io/network-unavailable"
       operator: "Exists"
       effect: "NoSchedule"
-    - key: "krustlet/arch"
+    - key: "kubernetes.io/arch"
       operator: "Equal"
       value: "wasm32-wascc"
       effect: "NoExecute"

--- a/demos/wascc/uppercase/uppercase-wascc.yaml
+++ b/demos/wascc/uppercase/uppercase-wascc.yaml
@@ -20,7 +20,7 @@ spec:
     - key: "node.kubernetes.io/network-unavailable"
       operator: "Exists"
       effect: "NoSchedule"
-    - key: "krustlet/arch"
+    - key: "kubernetes.io/arch"
       operator: "Equal"
       value: "wasm32-wascc"
       effect: "NoExecute"

--- a/demos/wasi/greet/greet-wasi.yaml
+++ b/demos/wasi/greet/greet-wasi.yaml
@@ -15,7 +15,7 @@ spec:
     - key: "node.kubernetes.io/network-unavailable"
       operator: "Exists"
       effect: "NoSchedule"
-    - key: "krustlet/arch"
+    - key: "kubernetes.io/arch"
       operator: "Equal"
       value: "wasm32-wasi"
       effect: "NoExecute"

--- a/demos/wasi/hello-world-assemblyscript/k8s.yaml
+++ b/demos/wasi/hello-world-assemblyscript/k8s.yaml
@@ -28,7 +28,7 @@ spec:
   nodeSelector:
     kubernetes.io/arch: "wasm32-wasi"
   tolerations:
-    - key: "krustlet/arch"
+    - key: "kubernetes.io/arch"
       operator: "Equal"
       value: "wasm32-wasi"
       effect: "NoExecute"

--- a/demos/wasi/hello-world-c/k8s.yaml
+++ b/demos/wasi/hello-world-c/k8s.yaml
@@ -28,7 +28,7 @@ spec:
   nodeSelector:
     kubernetes.io/arch: "wasm32-wasi"
   tolerations:
-    - key: "krustlet/arch"
+    - key: "kubernetes.io/arch"
       operator: "Equal"
       value: "wasm32-wasi"
       effect: "NoExecute"

--- a/demos/wasi/hello-world-rust/k8s.yaml
+++ b/demos/wasi/hello-world-rust/k8s.yaml
@@ -43,7 +43,7 @@ spec:
   nodeSelector:
     kubernetes.io/arch: "wasm32-wasi"
   tolerations:
-    - key: "krustlet/arch"
+    - key: "kubernetes.io/arch"
       operator: "Equal"
       value: "wasm32-wasi"
       effect: "NoExecute"

--- a/demos/wasi/simpleserver/simpleserver.yaml
+++ b/demos/wasi/simpleserver/simpleserver.yaml
@@ -13,7 +13,7 @@ spec:
     - key: "node.kubernetes.io/network-unavailable"
       operator: "Exists"
       effect: "NoSchedule"
-    - key: "krustlet/arch"
+    - key: "kubernetes.io/arch"
       operator: "Equal"
       value: "wasm32-wasi"
       effect: "NoExecute"

--- a/docs/howto/krustlet-on-gke.md
+++ b/docs/howto/krustlet-on-gke.md
@@ -200,7 +200,7 @@ spec:
   nodeSelector:
     kubernetes.io/arch: "wasm32-wasi"
   tolerations:
-    - key: "krustlet/arch"
+    - key: "kubernetes.io/arch"
       operator: "Equal"
       value: "wasm32-wasi"
       effect: "NoExecute"

--- a/docs/howto/wasm.md
+++ b/docs/howto/wasm.md
@@ -15,7 +15,7 @@ nodes, you should use the Kubernetes tolerations system; in some cases you
 will also need to use node affinity.
 
 The `krustlet-wasi` and `krustlet-wascc` 'virtual nodes' both have
-`NoExecute` taints with the key `krustlet/arch` and a provider-defined
+`NoExecute` taints with the key `kubernetes.io/arch` and a provider-defined
 value (`wasm32-wasi` or `wasm32-wascc` respectively).  WASM pods must
 therefore specify a toleration for this taint.  For example:
 
@@ -30,7 +30,7 @@ spec:
     image: webassembly.azurecr.io/hello-wasm:v1
   tolerations:
   - effect: NoExecute
-    key: krustlet/arch
+    key: kubernetes.io/arch
     operator: Equal
     value: wasm32-wasi   # or wasm32-wascc according to module target arch
 ```

--- a/docs/intro/tutorial03.md
+++ b/docs/intro/tutorial03.md
@@ -25,7 +25,7 @@ spec:
     - name: krustlet-tutorial
       image: mycontainerregistry007.azurecr.io/krustlet-tutorial:v1.0.0
   tolerations:
-    - key: "krustlet/arch"
+    - key: "kubernetes.io/arch"
       operator: "Equal"
       value: "wasm32-wasi"
       effect: "NoExecute"

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -75,15 +75,15 @@ async fn verify_wascc_node(node: Node) -> () {
         .expect("node had no taints");
     let taint = taints
         .iter()
-        .find(|t| t.key == "krustlet/arch")
-        .expect("did not find krustlet/arch taint");
+        .find(|t| t.key == "kubernetes.io/arch")
+        .expect("did not find kubernetes.io/arch taint");
     // There is no "operator" field in the type for the crate for some reason,
     // so we can't compare it here
     assert_eq!(
         taint,
         &Taint {
             effect: "NoExecute".to_owned(),
-            key: "krustlet/arch".to_owned(),
+            key: "kubernetes.io/arch".to_owned(),
             value: Some("wasm32-wascc".to_owned()),
             ..Default::default()
         }
@@ -113,7 +113,7 @@ async fn create_wascc_pod(client: kube::Client, pods: &Api<Pod>) -> anyhow::Resu
             "tolerations": [
                 {
                     "effect": "NoExecute",
-                    "key": "krustlet/arch",
+                    "key": "kubernetes.io/arch",
                     "operator": "Equal",
                     "value": "wasm32-wascc"
                 },
@@ -183,15 +183,15 @@ async fn verify_wasi_node(node: Node) -> () {
         .expect("node had no taints");
     let taint = taints
         .iter()
-        .find(|t| t.key == "krustlet/arch")
-        .expect("did not find krustlet/arch taint");
+        .find(|t| t.key == "kubernetes.io/arch")
+        .expect("did not find kubernetes.io/arch taint");
     // There is no "operator" field in the type for the crate for some reason,
     // so we can't compare it here
     assert_eq!(
         taint,
         &Taint {
             effect: "NoExecute".to_owned(),
-            key: "krustlet/arch".to_owned(),
+            key: "kubernetes.io/arch".to_owned(),
             value: Some("wasm32-wasi".to_owned()),
             ..Default::default()
         }
@@ -243,7 +243,7 @@ async fn create_wasi_pod(
             "tolerations": [
                 {
                     "effect": "NoExecute",
-                    "key": "krustlet/arch",
+                    "key": "kubernetes.io/arch",
                     "operator": "Equal",
                     "value": "wasm32-wasi"
                 },
@@ -311,7 +311,7 @@ async fn create_fancy_schmancy_wasi_pod(
             "tolerations": [
                 {
                     "effect": "NoExecute",
-                    "key": "krustlet/arch",
+                    "key": "kubernetes.io/arch",
                     "operator": "Equal",
                     "value": "wasm32-wasi"
                 },

--- a/tests/pod_builder.rs
+++ b/tests/pod_builder.rs
@@ -91,7 +91,7 @@ pub fn wasmerciser_pod(
             "tolerations": [
                 {
                     "effect": "NoExecute",
-                    "key": "krustlet/arch",
+                    "key": "kubernetes.io/arch",
                     "operator": "Equal",
                     "value": architecture,
                 },


### PR DESCRIPTION
Please note that this is a breaking change that should be called out
in the release notes. This updates all documentation and examples
to use the new taint name.

Closes #334