### PR TITLE
[oci-distribution] Update Reference docs and implement FromStr

### DIFF
--- a/crates/oci-distribution/src/reference.rs
+++ b/crates/oci-distribution/src/reference.rs
@@ -3,9 +3,25 @@ use std::str::FromStr;
 
 /// An OCI image reference
 ///
-/// currently, the library only accepts modules tagged in the following structure:
-/// <registry>/<repository>, <registry>/<repository>:<tag>, or <registry>/<repository>@<digest>
-/// for example: webassembly.azurecr.io/hello:v1 or webassembly.azurecr.io/hello
+/// Parsing references in the following formats is supported:
+/// - `<registry>/<repository>`
+/// - `<registry>/<repository>:<tag>`
+/// - `<registry>/<repository>@<digest>`
+/// - `<registry>/<repository>:<tag>@<digest>`
+///
+/// # Examples
+///
+/// Parsing a tagged image reference:
+/// ```
+/// use oci_distribution::Reference;
+///
+/// let reference: Reference = "docker.io/library/hello-world:latest".parse().unwrap();
+///
+/// assert_eq!("docker.io", reference.registry());
+/// assert_eq!("library/hello-world", reference.repository());
+/// assert_eq!(Some("latest"), reference.tag());
+/// assert_eq!(None, reference.digest());
+/// ```
 #[derive(Clone, Hash, PartialEq, Eq)]
 pub struct Reference {
     whole: String,


### PR DESCRIPTION
Follow up to address https://github.com/deislabs/krustlet/pull/349#discussion_r470282660

- Implements [FromStr](https://doc.rust-lang.org/std/str/trait.FromStr.html) to make it possible to parse `Reference` from `&str` without explicitly importing [TryFrom](https://doc.rust-lang.org/std/convert/trait.TryFrom.html)
- Updates the rustdoc for the `Reference` type to render supported image reference formats correctly and include an example

Here's what the updated docs look like:

<img width="982" alt="Screen Shot 2020-08-21 at 12 12 56 PM" src="https://user-images.githubusercontent.com/6752382/90911912-ad9ccf00-e3a7-11ea-8dea-58269f3162fb.png">

The example included in the docs is also evaluated during `cargo test`.