### PR TITLE
[oci-distribution] Use table-based tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2108,6 +2108,8 @@ dependencies = [
  "hyperx",
  "log 0.4.11",
  "reqwest",
+ "rstest",
+ "rstest_reuse",
  "serde",
  "serde_json",
  "tokio",
@@ -2733,6 +2735,29 @@ dependencies = [
  "byteorder",
  "rmp",
  "serde",
+]
+
+[[package]]
+name = "rstest"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec448bc157977efdc0a71369cf923915b0c4806b1b2449c3fb011071d6f7c38"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "rstest_reuse"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea58a205448b6b691df0025d0871882c60ce66b46ee8b26217d68f794eb0f965"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/oci-distribution/Cargo.toml
+++ b/crates/oci-distribution/Cargo.toml
@@ -38,3 +38,7 @@ www-authenticate = "0.3"
 hyperx = "0.13"
 futures-util = "0.3"
 log = "0.4"
+
+[dev-dependencies]
+rstest = "0.6"
+rstest_reuse = "0.1"

--- a/crates/oci-distribution/src/lib.rs
+++ b/crates/oci-distribution/src/lib.rs
@@ -1,5 +1,8 @@
 //! An OCI Distribution client for fetching oci images from an OCI compliant remote store
-#![deny(missing_docs)]
+#![cfg_attr(not(test), deny(missing_docs))]
+
+#[cfg(test)]
+use rstest_reuse;
 
 pub mod client;
 pub mod errors;


### PR DESCRIPTION
This PR refactors the `client` and `reference` modules to use "table-based" tests via a procedural macro, and is related to https://github.com/deislabs/krustlet/pull/349#discussion_r469433569.

This is meant to:
- prevent early failures from masking issues in later test cases
- provide test output that makes it easier to trace failures back to a
   specific test case
- reduce the cost of adding new test cases

`cargo test | sort` before:

```
running 15 tests
test client::test::test_auth ... ok
test client::test::test_fetch_digest ... ok
test client::test::test_pull_image ... ok
test client::test::test_pull_layer ... ok
test client::test::test_pull_manifest ... ok
test client::test::test_to_v2_blob_url ... ok
test client::test::test_to_v2_manifest ... ok
test errors::test::test_deserialize ... ok
test manifest::test::test_manifest ... ok
test reference::test::parse::digest_only ... ok
test reference::test::parse::missing_slash_char ... ok
test reference::test::parse::no_tag_or_digest ... ok
test reference::test::parse::owned_string ... ok
test reference::test::parse::tag_and_digest ... ok
test reference::test::parse::tag_only ... ok
```

`cargo test | sort` after:

```
running 39 tests
test client::test::auth::case_1_no_tag ... ok
test client::test::auth::case_2_tag ... ok
test client::test::auth::case_3_digest ... ok
test client::test::auth::case_4_tag_and_digest ... ok
test client::test::auth::case_5_empty ... ok
test client::test::fetch_digest::case_1_no_tag ... ok
test client::test::fetch_digest::case_2_tag ... ok
test client::test::fetch_digest::case_3_digest ... ok
test client::test::fetch_digest::case_4_tag_and_digest ... ok
test client::test::fetch_digest::case_5_empty ... ok
test client::test::pull_image::case_1_no_tag ... ok
test client::test::pull_image::case_2_tag ... ok
test client::test::pull_image::case_3_digest ... ok
test client::test::pull_image::case_4_tag_and_digest ... ok
test client::test::pull_image::case_5_empty ... ok
test client::test::pull_layer::case_1_no_tag ... ok
test client::test::pull_layer::case_2_tag ... ok
test client::test::pull_layer::case_3_digest ... ok
test client::test::pull_layer::case_4_tag_and_digest ... ok
test client::test::pull_layer::case_5_empty ... ok
test client::test::pull_manifest::case_1_no_tag ... ok
test client::test::pull_manifest::case_2_tag ... ok
test client::test::pull_manifest::case_3_digest ... ok
test client::test::pull_manifest::case_4_tag_and_digest ... ok
test client::test::pull_manifest::case_5_empty ... ok
test client::test::to_v2_blob_url ... ok
test client::test::to_v2_manifest::case_1_no_tag ... ok
test client::test::to_v2_manifest::case_2_tag ... ok
test client::test::to_v2_manifest::case_3_digest ... ok
test client::test::to_v2_manifest::case_4_tag_and_digest ... ok
test errors::test::test_deserialize ... ok
test manifest::test::test_manifest ... ok
test reference::test::parse::case_1_owned_string ... ok
test reference::test::parse::case_2_tag ... ok
test reference::test::parse::case_3_digest ... ok
test reference::test::parse::case_4_tag_and_digest ... ok
test reference::test::parse::case_5_no_tag_or_digest ... ok
test reference::test::parse::case_6_missing_slash ... ok
test reference::test::parse::case_7_empty ... ok
```