### PR TITLE
Use IP constants instead of parsing at runtime

### DIFF
--- a/crates/kubelet/src/config.rs
+++ b/crates/kubelet/src/config.rs
@@ -309,7 +309,7 @@ impl ConfigBuilder {
     }
 
     fn build(self, fallbacks: ConfigBuilderFallbacks) -> anyhow::Result<Config> {
-        let empty_ip_addr = IpAddr::V4(std::net::Ipv4Addr::new(0, 0, 0, 0));
+        let empty_ip_addr = IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED);
 
         let hostname = self.hostname.unwrap_or_else(fallbacks.hostname);
         let data_dir = self.data_dir.unwrap_or_else(fallbacks.data_dir);

--- a/crates/kubelet/src/config_interpreter.rs
+++ b/crates/kubelet/src/config_interpreter.rs
@@ -18,6 +18,8 @@ impl ClientConfigSource for Config {
 mod test {
     use super::*;
 
+    use std::net::{IpAddr, Ipv4Addr};
+
     fn empty_config() -> Config {
         // We can't use Config::default() because it can panic when trying
         // to derive a node IP address
@@ -28,11 +30,11 @@ mod test {
             hostname: "nope".to_owned(),
             insecure_registries: None,
             max_pods: 0,
-            node_ip: "127.0.0.1".parse().unwrap(),
+            node_ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
             node_labels: std::collections::HashMap::new(),
             node_name: "nope".to_owned(),
             server_config: crate::config::ServerConfig {
-                addr: "127.0.0.1".parse().unwrap(),
+                addr: IpAddr::V4(Ipv4Addr::LOCALHOST),
                 port: 0,
                 cert_file: std::path::PathBuf::from("/nope"),
                 private_key_file: std::path::PathBuf::from("/nope"),
@@ -49,8 +51,11 @@ mod test {
 
     #[test]
     fn oci_config_respects_config_insecure_registries() {
-        let mut config = empty_config();
-        config.insecure_registries = Some(vec!["local".to_owned(), "dev".to_owned()]);
+        let config = Config {
+            insecure_registries: Some(vec!["local".to_owned(), "dev".to_owned()]),
+            ..empty_config()
+        };
+
         let client_config = config.client_config();
 
         let expected_protocol =

--- a/crates/kubelet/src/node/mod.rs
+++ b/crates/kubelet/src/node/mod.rs
@@ -742,11 +742,11 @@ mod test {
         node_labels.insert("beta.kubernetes.io/os".to_owned(), "managed".to_owned());
 
         let config = Config {
-            node_ip: IpAddr::from(Ipv4Addr::new(127, 0, 0, 1)),
+            node_ip: IpAddr::from(Ipv4Addr::LOCALHOST),
             hostname: String::from("foo"),
             node_name: String::from("bar"),
             server_config: ServerConfig {
-                addr: IpAddr::from(Ipv4Addr::new(127, 0, 0, 1)),
+                addr: IpAddr::from(Ipv4Addr::LOCALHOST),
                 port: 8080,
                 cert_file: PathBuf::new(),
                 private_key_file: PathBuf::new(),


### PR DESCRIPTION
Replace some artisanal values with constants from the standard library.

➕ Drop two `Self` annotations that clippy bugged me about.