### PR TITLE
Image pull secrets

### DIFF
--- a/crates/kubelet/src/lib.rs
+++ b/crates/kubelet/src/lib.rs
@@ -62,6 +62,7 @@ pub mod log;
 pub mod node;
 pub mod pod;
 pub mod provider;
+pub mod secret;
 pub mod store;
 pub mod volume;
 

--- a/crates/kubelet/src/pod/mod.rs
+++ b/crates/kubelet/src/pod/mod.rs
@@ -90,6 +90,20 @@ impl Pod {
             .unwrap_or_else(|| &EMPTY_MAP)
     }
 
+    /// Get the names of the pod's image pull secrets
+    pub fn image_pull_secrets(&self) -> Vec<String> {
+        match self.0.spec.as_ref() {
+            None => vec![],
+            Some(spec) => match spec.image_pull_secrets.as_ref() {
+                None => vec![],
+                Some(objrefs) => objrefs
+                    .iter()
+                    .filter_map(|objref| objref.name.clone())
+                    .collect(),
+            },
+        }
+    }
+
     /// Indicate if this pod is a static pod.
     /// TODO: A missing owner_references field was an indication of static pod in my testing but I
     /// dont know how reliable this is.

--- a/crates/kubelet/src/secret/mod.rs
+++ b/crates/kubelet/src/secret/mod.rs
@@ -1,0 +1,23 @@
+//! Resolves image pull secrets
+
+use oci_distribution::secrets::RegistryAuth;
+
+/// Resolves registry authentication from image pull secrets
+pub struct RegistryAuthResolver {
+    kube_client: kube::Client,
+    pod_namespace: String,
+}
+
+impl RegistryAuthResolver {
+    /// Creates a resolver for the given pod
+    pub fn new(client: &kube::Client, pod: &crate::pod::Pod) -> Self {
+        RegistryAuthResolver {
+            kube_client: client.clone(),
+            pod_namespace: pod.namespace().to_owned(),
+        }
+    }
+    /// Get the registry authentication method appropriate to the given image reference
+    pub async fn resolve_registry_auth(&self, reference: &oci_distribution::Reference) -> anyhow::Result<RegistryAuth> {
+        Ok(RegistryAuth::Anonymous)
+    }
+}

--- a/crates/kubelet/src/secret/mod.rs
+++ b/crates/kubelet/src/secret/mod.rs
@@ -13,11 +13,11 @@ pub struct RegistryAuthResolver {
 
 impl RegistryAuthResolver {
     /// Creates a resolver for the given pod
-    pub fn new(client: &kube::Client, pod: &crate::pod::Pod) -> Self {
+    pub fn new(client: kube::Client, pod: &crate::pod::Pod) -> Self {
         // TODO: is it safe to capture this stuff or might we need to re-resolve e.g.
         // the list of secret names after a pod modify?
         RegistryAuthResolver {
-            kube_client: client.clone(),
+            kube_client: client,
             pod_namespace: pod.namespace().to_owned(),
             image_pull_secret_names: pod.image_pull_secrets(),
         }
@@ -40,7 +40,7 @@ impl RegistryAuthResolver {
 
         for secret_result in secret_results {
             match secret_result {
-                Err(e) => return Err(anyhow::Error::from(e)),
+                Err(e) => return Err(e.into()),
                 Ok(secret) => {
                     if let Some(auth) = parse_auth(&secret, reference.registry()) {
                         return Ok(auth);

--- a/crates/kubelet/src/secret/mod.rs
+++ b/crates/kubelet/src/secret/mod.rs
@@ -1,23 +1,112 @@
 //! Resolves image pull secrets
 
+use k8s_openapi::api::core::v1::Secret;
+use kube::api::Api;
 use oci_distribution::secrets::RegistryAuth;
 
 /// Resolves registry authentication from image pull secrets
 pub struct RegistryAuthResolver {
     kube_client: kube::Client,
     pod_namespace: String,
+    image_pull_secret_names: Vec<String>,
 }
 
 impl RegistryAuthResolver {
     /// Creates a resolver for the given pod
     pub fn new(client: &kube::Client, pod: &crate::pod::Pod) -> Self {
+        // TODO: is it safe to capture this stuff or might we need to re-resolve e.g.
+        // the list of secret names after a pod modify?
         RegistryAuthResolver {
             kube_client: client.clone(),
             pod_namespace: pod.namespace().to_owned(),
+            image_pull_secret_names: pod.image_pull_secrets(),
         }
     }
+
     /// Get the registry authentication method appropriate to the given image reference
-    pub async fn resolve_registry_auth(&self, reference: &oci_distribution::Reference) -> anyhow::Result<RegistryAuth> {
+    pub async fn resolve_registry_auth(
+        &self,
+        reference: &oci_distribution::Reference,
+    ) -> anyhow::Result<RegistryAuth> {
+        let secrets_api: Api<Secret> =
+            Api::namespaced(self.kube_client.clone(), &self.pod_namespace);
+
+        let secret_futures: Vec<_> = self
+            .image_pull_secret_names
+            .iter()
+            .map(|name| secrets_api.get(name))
+            .collect();
+        let secret_results = futures::future::join_all(secret_futures).await;
+
+        for secret_result in secret_results {
+            match secret_result {
+                Err(e) => return Err(anyhow::Error::from(e)),
+                Ok(secret) => {
+                    if let Some(auth) = parse_auth(&secret, reference.registry()) {
+                        return Ok(auth);
+                    }
+                }
+            }
+        }
+
         Ok(RegistryAuth::Anonymous)
+    }
+}
+
+fn parse_auth(secret: &Secret, registry_name: &str) -> Option<RegistryAuth> {
+    if let Some(data) = secret.data.as_ref() {
+        parse_auth_from_secret_data(data, registry_name)
+    } else {
+        None
+    }
+}
+
+fn parse_auth_from_secret_data(
+    secret_data: &std::collections::BTreeMap<String, k8s_openapi::ByteString>,
+    registry_name: &str,
+) -> Option<RegistryAuth> {
+    secret_data
+        .values()
+        .find_map(|v| parse_auth_from_secret_value(v, registry_name))
+}
+
+fn parse_auth_from_secret_value(
+    secret_value: &k8s_openapi::ByteString,
+    registry_name: &str,
+) -> Option<RegistryAuth> {
+    // We are intereted in secret_value if it is of the form
+    // {
+    //   "auths": {
+    //     "reg1": { ... },
+    //     "reg2": { ... }
+    //   }
+    // }
+    parse_byte_string_json(secret_value)
+        .and_then(|value| parse_auth_from_json_value(&value, registry_name))
+}
+
+fn parse_byte_string_json(byte_string: &k8s_openapi::ByteString) -> Option<serde_json::Value> {
+    serde_json::from_slice(&byte_string.0).ok()
+}
+
+fn parse_auth_from_json_value(
+    json_value: &serde_json::Value,
+    registry_name: &str,
+) -> Option<RegistryAuth> {
+    json_value
+        .get("auths")
+        .and_then(|auths| auths.get(registry_name))
+        .and_then(|creds| parse_auth_from_json_creds(creds))
+}
+
+fn parse_auth_from_json_creds(json_creds: &serde_json::Value) -> Option<RegistryAuth> {
+    let username = json_creds.get("username");
+    let password = json_creds.get("password");
+    // TODO: my test creds also included an entry "auth" - should we return this? (e.g. bearer auth?)
+    match (username, password) {
+        (Some(serde_json::Value::String(u)), Some(serde_json::Value::String(p))) => {
+            Some(RegistryAuth::Basic(u.to_owned(), p.to_owned()))
+        }
+        _ => None,
     }
 }

--- a/crates/kubelet/src/store/composite/mod.rs
+++ b/crates/kubelet/src/store/composite/mod.rs
@@ -3,7 +3,7 @@
 use crate::store::PullPolicy;
 use crate::store::Store;
 use async_trait::async_trait;
-use oci_distribution::secrets::RegistrySecrets;
+use oci_distribution::secrets::RegistryAuth;
 use oci_distribution::Reference;
 use std::sync::Arc;
 
@@ -65,12 +65,12 @@ impl Store for CompositeStore {
         &self,
         image_ref: &Reference,
         pull_policy: PullPolicy,
-        secrets: &RegistrySecrets,
+        auth: &RegistryAuth,
     ) -> anyhow::Result<Vec<u8>> {
         if self.interceptor.intercepts(image_ref) {
-            self.interceptor.get(image_ref, pull_policy, secrets).await
+            self.interceptor.get(image_ref, pull_policy, auth).await
         } else {
-            self.base.get(image_ref, pull_policy, secrets).await
+            self.base.get(image_ref, pull_policy, auth).await
         }
     }
 }
@@ -78,7 +78,7 @@ impl Store for CompositeStore {
 #[cfg(test)]
 mod test {
     use super::*;
-    use oci_distribution::secrets::RegistrySecrets;
+    use oci_distribution::secrets::RegistryAuth;
     use std::convert::TryFrom;
 
     struct FakeBase {}
@@ -90,7 +90,7 @@ mod test {
             &self,
             _image_ref: &Reference,
             _pull_policy: PullPolicy,
-            _secrets: &RegistrySecrets,
+            _auth: &RegistryAuth,
         ) -> anyhow::Result<Vec<u8>> {
             Ok(vec![11, 10, 5, 14])
         }
@@ -102,7 +102,7 @@ mod test {
             &self,
             _image_ref: &Reference,
             _pull_policy: PullPolicy,
-            _secrets: &RegistrySecrets,
+            _auth: &RegistryAuth,
         ) -> anyhow::Result<Vec<u8>> {
             Ok(vec![1, 2, 3])
         }
@@ -121,7 +121,7 @@ mod test {
             .get(
                 &Reference::try_from("int/foo").unwrap(),
                 PullPolicy::Never,
-                &RegistrySecrets::none(),
+                &RegistryAuth::Anonymous,
             )
             .await
             .unwrap();
@@ -136,7 +136,7 @@ mod test {
             .get(
                 &Reference::try_from("mint/foo").unwrap(),
                 PullPolicy::Never,
-                &RegistrySecrets::none(),
+                &RegistryAuth::Anonymous,
             )
             .await
             .unwrap();

--- a/crates/kubelet/src/store/fs/mod.rs
+++ b/crates/kubelet/src/store/fs/mod.rs
@@ -3,7 +3,7 @@
 use crate::store::composite::InterceptingStore;
 use crate::store::{PullPolicy, Store};
 use async_trait::async_trait;
-use oci_distribution::secrets::RegistrySecrets;
+use oci_distribution::secrets::RegistryAuth;
 use oci_distribution::Reference;
 use std::path::PathBuf;
 
@@ -24,7 +24,7 @@ impl Store for FileSystemStore {
         &self,
         image_ref: &Reference,
         _pull_policy: PullPolicy,
-        _secrets: &RegistrySecrets,
+        _auth: &RegistryAuth,
     ) -> anyhow::Result<Vec<u8>> {
         let path = PathBuf::from(image_ref.repository());
         Ok(tokio::fs::read(&path).await?)

--- a/crates/kubelet/src/store/fs/mod.rs
+++ b/crates/kubelet/src/store/fs/mod.rs
@@ -3,6 +3,7 @@
 use crate::store::composite::InterceptingStore;
 use crate::store::{PullPolicy, Store};
 use async_trait::async_trait;
+use oci_distribution::secrets::RegistrySecrets;
 use oci_distribution::Reference;
 use std::path::PathBuf;
 
@@ -23,6 +24,7 @@ impl Store for FileSystemStore {
         &self,
         image_ref: &Reference,
         _pull_policy: PullPolicy,
+        _secrets: &RegistrySecrets,
     ) -> anyhow::Result<Vec<u8>> {
         let path = PathBuf::from(image_ref.repository());
         Ok(tokio::fs::read(&path).await?)

--- a/crates/kubelet/src/store/mod.rs
+++ b/crates/kubelet/src/store/mod.rs
@@ -73,11 +73,6 @@ pub trait Store: Sync {
             pod.name()
         );
         // Fetch all of the container modules in parallel
-        // let containers = pod.containers();
-        // let container_module_futures = containers.iter().map(move |container| {
-        //     let reference = container
-        //         .image()
-        //         .expect("Could not parse image.")
         let init_containers = pod.init_containers();
         let containers = pod.containers();
         let all_containers = init_containers.iter().chain(containers.iter());

--- a/crates/kubelet/src/store/mod.rs
+++ b/crates/kubelet/src/store/mod.rs
@@ -67,7 +67,11 @@ pub trait Store: Sync {
     /// # Panics
     ///
     /// This panics if any of the pod's containers do not have an image associated with them
-    async fn fetch_pod_modules(&self, pod: &Pod, auth: &crate::secret::RegistryAuthResolver) -> anyhow::Result<HashMap<String, Vec<u8>>> {
+    async fn fetch_pod_modules(
+        &self,
+        pod: &Pod,
+        auth: &crate::secret::RegistryAuthResolver,
+    ) -> anyhow::Result<HashMap<String, Vec<u8>>> {
         debug!(
             "Fetching all the container modules for pod '{}'",
             pod.name()

--- a/crates/kubelet/src/store/oci/client.rs
+++ b/crates/kubelet/src/store/oci/client.rs
@@ -1,6 +1,7 @@
 //! Client for fetching container modules from OCI
 use async_trait::async_trait;
 use oci_distribution::client::ImageData;
+use oci_distribution::secrets::RegistrySecrets;
 
 use oci_distribution::Reference;
 
@@ -16,12 +17,13 @@ pub trait Client {
     /// use kubelet::store::oci::Client;
     /// use oci_distribution::Reference;
     /// use oci_distribution::client::ImageData;
+    /// use oci_distribution::secrets::RegistrySecrets;
     ///
     /// struct InMemoryClient(std::collections::HashMap<Reference, ImageData>);
     ///
     /// #[async_trait]
     /// impl Client for InMemoryClient {
-    ///     async fn pull(&mut self, image_ref: &Reference) -> anyhow::Result<ImageData> {
+    ///     async fn pull(&mut self, image_ref: &Reference, _secrets: &RegistrySecrets) -> anyhow::Result<ImageData> {
     ///         let image_data = self
     ///             .0
     ///             .get(image_ref)
@@ -30,15 +32,23 @@ pub trait Client {
     ///     }
     /// }
     /// ```
-    async fn pull(&mut self, image_ref: &Reference) -> anyhow::Result<ImageData>;
+    async fn pull(
+        &mut self,
+        image_ref: &Reference,
+        secrets: &RegistrySecrets,
+    ) -> anyhow::Result<ImageData>;
 
     /// Fetch the digest for the given image reference from a storage location.
     ///
     /// The default implementation pulls the image data and digest, and returns
     /// the digest. This is inefficient for most real-world clients, and so should
     /// be overridden.
-    async fn fetch_digest(&mut self, image_ref: &Reference) -> anyhow::Result<String> {
-        let image_data = self.pull(image_ref).await?;
+    async fn fetch_digest(
+        &mut self,
+        image_ref: &Reference,
+        secrets: &RegistrySecrets,
+    ) -> anyhow::Result<String> {
+        let image_data = self.pull(image_ref, secrets).await?;
         image_data
             .digest
             .ok_or_else(|| anyhow::anyhow!("image {} does not have a digest", image_ref))
@@ -47,11 +57,19 @@ pub trait Client {
 
 #[async_trait]
 impl Client for oci_distribution::Client {
-    async fn pull(&mut self, image: &Reference) -> anyhow::Result<ImageData> {
-        self.pull_image(image).await
+    async fn pull(
+        &mut self,
+        image: &Reference,
+        secrets: &RegistrySecrets,
+    ) -> anyhow::Result<ImageData> {
+        self.pull_image(image, secrets).await
     }
 
-    async fn fetch_digest(&mut self, image: &Reference) -> anyhow::Result<String> {
-        self.fetch_manifest_digest(image).await
+    async fn fetch_digest(
+        &mut self,
+        image: &Reference,
+        secrets: &RegistrySecrets,
+    ) -> anyhow::Result<String> {
+        self.fetch_manifest_digest(image, secrets).await
     }
 }

--- a/crates/oci-distribution/src/lib.rs
+++ b/crates/oci-distribution/src/lib.rs
@@ -5,6 +5,7 @@ pub mod client;
 pub mod errors;
 pub mod manifest;
 mod reference;
+pub mod secrets;
 
 #[doc(inline)]
 pub use client::Client;

--- a/crates/oci-distribution/src/secrets.rs
+++ b/crates/oci-distribution/src/secrets.rs
@@ -1,19 +1,19 @@
 //! Types for working with registry access secrets
 
-/// Contains secrets for accessing a set of registries
-pub struct RegistrySecrets {}
+/// A method for authenticating to a registry
+pub enum RegistryAuth {
+    /// Access the registry anonymously
+    Anonymous,
+}
 
-/// Contains a secret for accessing a registry
-pub struct RegistrySecret {}
+pub(crate) trait Authenticable {
+    fn apply_authentication(self, auth: &RegistryAuth) -> Self;
+}
 
-impl RegistrySecrets {
-    /// A `RegistrySecrets` that contains no secrets
-    pub fn none() -> Self {
-        RegistrySecrets {}
-    }
-
-    /// Gets the secret for the specified registry, if present
-    pub fn find_registry_secret(&self, _registry: &str) -> Option<RegistrySecret> {
-        None
+impl Authenticable for reqwest::RequestBuilder {
+    fn apply_authentication(self, auth: &RegistryAuth) -> Self {
+        match auth {
+            RegistryAuth::Anonymous => self,
+        }
     }
 }

--- a/crates/oci-distribution/src/secrets.rs
+++ b/crates/oci-distribution/src/secrets.rs
@@ -4,6 +4,8 @@
 pub enum RegistryAuth {
     /// Access the registry anonymously
     Anonymous,
+    /// Access the registry using HTTP Basic authentication
+    Basic(String, String),
 }
 
 pub(crate) trait Authenticable {
@@ -14,6 +16,7 @@ impl Authenticable for reqwest::RequestBuilder {
     fn apply_authentication(self, auth: &RegistryAuth) -> Self {
         match auth {
             RegistryAuth::Anonymous => self,
+            RegistryAuth::Basic(username, password) => self.basic_auth(username, Some(password)),
         }
     }
 }

--- a/crates/oci-distribution/src/secrets.rs
+++ b/crates/oci-distribution/src/secrets.rs
@@ -1,0 +1,19 @@
+//! Types for working with registry access secrets
+
+/// Contains secrets for accessing a set of registries
+pub struct RegistrySecrets {}
+
+/// Contains a secret for accessing a registry
+pub struct RegistrySecret {}
+
+impl RegistrySecrets {
+    /// A `RegistrySecrets` that contains no secrets
+    pub fn none() -> Self {
+        RegistrySecrets {}
+    }
+
+    /// Gets the secret for the specified registry, if present
+    pub fn find_registry_secret(&self, _registry: &str) -> Option<RegistrySecret> {
+        None
+    }
+}

--- a/crates/wascc-provider/src/lib.rs
+++ b/crates/wascc-provider/src/lib.rs
@@ -350,7 +350,7 @@ impl Provider for WasccProvider {
         validate_pod_runnable(&pod)?;
 
         let client = kube::Client::new(self.kubeconfig.clone());
-        let auth_resolver = kubelet::secret::RegistryAuthResolver::new(&client, &pod);
+        let auth_resolver = kubelet::secret::RegistryAuthResolver::new(client.clone(), &pod);
 
         info!("Starting containers for pod {:?}", pod.name());
         let mut modules = self.store.fetch_pod_modules(&pod, &auth_resolver).await?;

--- a/crates/wascc-provider/src/lib.rs
+++ b/crates/wascc-provider/src/lib.rs
@@ -349,10 +349,12 @@ impl Provider for WasccProvider {
 
         validate_pod_runnable(&pod)?;
 
-        info!("Starting containers for pod {:?}", pod.name());
-        let mut modules = self.store.fetch_pod_modules(&pod).await?;
-        let mut container_handles = HashMap::new();
         let client = kube::Client::new(self.kubeconfig.clone());
+        let auth_resolver = kubelet::secret::RegistryAuthResolver::new(&client, &pod);
+
+        info!("Starting containers for pod {:?}", pod.name());
+        let mut modules = self.store.fetch_pod_modules(&pod, &auth_resolver).await?;
+        let mut container_handles = HashMap::new();
         let volumes = Ref::volumes_from_pod(&self.volume_path, &pod, &client).await?;
 
         let mut run_context = ModuleRunContext {

--- a/crates/wasi-provider/src/lib.rs
+++ b/crates/wasi-provider/src/lib.rs
@@ -280,8 +280,10 @@ impl Provider for WasiProvider {
 
         let mut container_handles = ContainerHandleMap::new();
 
-        let mut modules = self.store.fetch_pod_modules(&pod).await?;
         let client = kube::Client::new(self.kubeconfig.clone());
+        let auth_resolver = kubelet::secret::RegistryAuthResolver::new(&client, &pod);
+        
+        let mut modules = self.store.fetch_pod_modules(&pod, &auth_resolver).await?;
         let volumes = Ref::volumes_from_pod(&self.volume_path, &pod, &client).await?;
 
         let (init_handles, init_error) = self

--- a/crates/wasi-provider/src/lib.rs
+++ b/crates/wasi-provider/src/lib.rs
@@ -282,7 +282,7 @@ impl Provider for WasiProvider {
 
         let client = kube::Client::new(self.kubeconfig.clone());
         let auth_resolver = kubelet::secret::RegistryAuthResolver::new(&client, &pod);
-        
+
         let mut modules = self.store.fetch_pod_modules(&pod, &auth_resolver).await?;
         let volumes = Ref::volumes_from_pod(&self.volume_path, &pod, &client).await?;
 

--- a/crates/wasi-provider/src/lib.rs
+++ b/crates/wasi-provider/src/lib.rs
@@ -281,7 +281,7 @@ impl Provider for WasiProvider {
         let mut container_handles = ContainerHandleMap::new();
 
         let client = kube::Client::new(self.kubeconfig.clone());
-        let auth_resolver = kubelet::secret::RegistryAuthResolver::new(&client, &pod);
+        let auth_resolver = kubelet::secret::RegistryAuthResolver::new(client.clone(), &pod);
 
         let mut modules = self.store.fetch_pod_modules(&pod, &auth_resolver).await?;
         let volumes = Ref::volumes_from_pod(&self.volume_path, &pod, &client).await?;


### PR DESCRIPTION
Fixes #257.

Do we have any thoughts on how to test it?  I can set up a private ACR registry, similar to `webassembly,azurecr.io`, and a SP with pull only permissions, but I'm a bit anxious about:

1. How do we keep track of/protect the registry so it doesn't accidentally get deleted in a tidy-up?
2. Posting a password, even a read-only one, in a public repo.

In the meantime I've tested it privately, and it seems okay though I'm worried that it seems to make the integration test flakes worse (and increasing the timeouts doesn't seem to help).