### PR TITLE
fix(kubelet): Removes node role label for compatibility with k8s 1.19

### DIFF
--- a/crates/kubelet/src/node/mod.rs
+++ b/crates/kubelet/src/node/mod.rs
@@ -443,7 +443,6 @@ fn node_labels_definition(arch: &str, config: &Config, builder: &mut Builder) {
     // Add mandatory static labels
     builder.add_label("beta.kubernetes.io/os", "linux");
     builder.add_label("kubernetes.io/os", "linux");
-    builder.add_label("kubernetes.io/role", "agent");
     builder.add_label("type", "krustlet");
     // add the mandatory labels that are dependent on injected values
     builder.add_label("beta.kubernetes.io/arch", arch);
@@ -458,7 +457,6 @@ fn node_labels_definition(arch: &str, config: &Config, builder: &mut Builder) {
         "kubernetes.io/arch",
         "kubernetes.io/hostname",
         "kubernetes.io/os",
-        "kubernetes.io/role",
         "type",
     ];
     let allowed_k8s_namespace_labels = [
@@ -764,7 +762,6 @@ mod test {
 
         let result = builder.labels;
 
-        assert!(result.contains_key("kubernetes.io/role"));
         assert!(result.contains_key("foo"));
         assert!(result.contains_key("kubelet.kubernetes.io/allowed-prefix"));
         assert!(!result.contains_key("not-allowed.kubernetes.io"));

--- a/demos/wascc/fileserver/k8s.yaml
+++ b/demos/wascc/fileserver/k8s.yaml
@@ -21,7 +21,6 @@ spec:
         path: /tmp
         type: Directory
   nodeSelector:
-    kubernetes.io/role: agent
     beta.kubernetes.io/os: linux
     beta.kubernetes.io/arch: wasm32-wascc
   tolerations:

--- a/demos/wascc/greet/greet-wascc.yaml
+++ b/demos/wascc/greet/greet-wascc.yaml
@@ -13,7 +13,6 @@ spec:
         - containerPort: 8080
           hostPort: 8080
   nodeSelector:
-    kubernetes.io/role: agent
     beta.kubernetes.io/os: linux
     beta.kubernetes.io/arch: wasm32-wascc
   tolerations:

--- a/demos/wascc/uppercase/uppercase-wascc.yaml
+++ b/demos/wascc/uppercase/uppercase-wascc.yaml
@@ -13,7 +13,6 @@ spec:
         - containerPort: 8080
           hostPort: 8080
   nodeSelector:
-    kubernetes.io/role: agent
     beta.kubernetes.io/os: linux
     beta.kubernetes.io/arch: wasm32-wascc
   tolerations:


### PR DESCRIPTION
This was causing failures when trying to register the node. See the [KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/0000-20170814-bounding-self-labeling-kubelets.md#proposal) for more information