### PR TITLE
ref(pod): switch from tuple to regular struct; use Pod::from

### DIFF
--- a/crates/kubelet/src/kubelet.rs
+++ b/crates/kubelet/src/kubelet.rs
@@ -355,7 +355,7 @@ mod test {
         labels.insert("label".to_string(), "value".to_string());
         let mut annotations = BTreeMap::new();
         annotations.insert("annotation".to_string(), "value".to_string());
-        let pod = Pod::new(KubePod {
+        let pod = Pod::from(KubePod {
             metadata: ObjectMeta {
                 labels: Some(labels),
                 annotations: Some(annotations),

--- a/crates/kubelet/src/node/mod.rs
+++ b/crates/kubelet/src/node/mod.rs
@@ -201,7 +201,7 @@ pub async fn evict_pods(client: &kube::Client, node_name: &str) -> anyhow::Resul
     info!("Evicting {} pods.", pods.len());
 
     for pod in pods {
-        let pod = Pod::new(pod);
+        let pod = Pod::from(pod);
         if pod.is_daemonset() {
             info!("Skipping eviction of DaemonSet '{}'", pod.name());
             continue;
@@ -267,7 +267,7 @@ async fn evict_pod(
         info!("Waiting for pod '{}' eviction.", name);
         while let Some(event) = stream.try_next().await? {
             if let kube::api::WatchEvent::Deleted(s) = event {
-                let pod = Pod::new(s);
+                let pod = Pod::from(s);
                 if name == pod.name() && namespace == pod.namespace() {
                     info!("Pod '{}' evicted.", name);
                     break;

--- a/crates/wascc-provider/src/states/registered.rs
+++ b/crates/wascc-provider/src/states/registered.rs
@@ -97,7 +97,7 @@ mod test {
             }
         }))
         .unwrap();
-        Pod::new(kube_pod)
+        Pod::from(kube_pod)
     }
 
     #[test]


### PR DESCRIPTION
Pod is a wrapper struct around k8s_openapi's Pod, but many callers use `Pod::new(pod)` instead of `Pod::from(pod)`.

This commit removes the constructor, forcing the caller to rely on calling `::from` to instantiate a new Pod. This also allows a Pod to expose more fields in the future (such as a pod's current state).

conflicts with #344, which should be merged prior to this PR to prevent another rebase.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>