### PR TITLE
The podsmiter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,9 @@ rustls-tls = ["kube/rustls-tls", "kubelet/rustls-tls", "wasi-provider/rustls-tls
 anyhow = "1.0"
 tokio = { version = "0.2", features = ["macros", "rt-threaded", "time"] }
 kube = { version= "0.35", default-features = false }
+k8s-openapi = { version = "0.8", default-features = false, features = ["v1_17"] }
 env_logger = "0.7"
+futures = "0.3"
 kubelet = { path = "./crates/kubelet", version = "0.4", default-features = false, features = ["cli"] }
 wascc-provider = { path = "./crates/wascc-provider", version = "0.4", default-features = false }
 wasi-provider = { path = "./crates/wasi-provider", version = "0.4", default-features = false }
@@ -52,11 +54,9 @@ hostname = "0.3"
 regex = "1.3"
 
 [dev-dependencies]
-futures = "0.3"
 serde_derive = "1.0"
 serde_json = "1.0"
 serde = "1.0"
-k8s-openapi = { version = "0.8", default-features = false, features = ["v1_17"] }
 reqwest = { version = "0.10", default-features = false }
 tempfile = "3.1"
 
@@ -76,3 +76,7 @@ path = "src/krustlet-wasi.rs"
 [[bin]]
 name = "oneclick"
 path = "tests/oneclick/src/main.rs"
+
+[[bin]]
+name = "podsmiter"
+path = "tests/podsmiter/src/main.rs"

--- a/docs/community/developers.md
+++ b/docs/community/developers.md
@@ -167,6 +167,17 @@ kind of Kubernetes cluster you're using and so doesn't know how to infer a node 
 _WARNING:_ The standalone integration tester has not been, er, tested on Windows.
 Hashtag irony.
 
+### Integration test debris
+
+There are some failure modes - for example image pull timeout - where the integration
+tests are not able to complete cleanup of their resources.  Specifically you can
+sometimes get pods stuck in `Terminating`, which prevents namespace cleanup and
+causes the next test run to break.
+
+You can forcibly clean up such debris by running `cargo run --bin podsmiter`.  You
+may need to way a couple of minutes after pod deletion for the namespaces to be
+collected.
+
 ## Creating your own Kubelets with Krustlet
 
 If you want to create your own Kubelet based on Krustlet, all you need to do is implement a

--- a/docs/community/developers.md
+++ b/docs/community/developers.md
@@ -175,7 +175,7 @@ sometimes get pods stuck in `Terminating`, which prevents namespace cleanup and
 causes the next test run to break.
 
 You can forcibly clean up such debris by running `cargo run --bin podsmiter`.  You
-may need to way a couple of minutes after pod deletion for the namespaces to be
+may need to wait a couple of minutes after pod deletion for the namespaces to be
 collected.
 
 ## Creating your own Kubelets with Krustlet

--- a/tests/podsmiter/src/main.rs
+++ b/tests/podsmiter/src/main.rs
@@ -31,7 +31,7 @@ async fn smite_all_integration_test_pods() -> anyhow::Result<&'static str> {
     if namespaces.is_empty() {
         return Ok("No e2e namespaces found");
     }
-    if namespaces.is_empty() || !confirm_smite(&namespaces) {
+    if !confirm_smite(&namespaces) {
         return Ok("Operation cancelled");
     }
 

--- a/tests/podsmiter/src/main.rs
+++ b/tests/podsmiter/src/main.rs
@@ -56,7 +56,7 @@ async fn smite_all_integration_test_pods() -> anyhow::Result<&'static str> {
     let (_, ns_smite_errors) = ns_smite_results.partition_success();
 
     if !ns_smite_errors.is_empty() {
-        return Err(smite_failure_error(&pod_smite_errors));
+        return Err(smite_failure_error(&ns_smite_errors));
     }
 
     Ok("All e2e pods force-deleted; namespace cleanup may take a couple of minutes")

--- a/tests/podsmiter/src/main.rs
+++ b/tests/podsmiter/src/main.rs
@@ -3,6 +3,8 @@ use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use k8s_openapi::Metadata;
 use kube::api::{Api, DeleteParams, ListParams};
 
+const E2E_NS_PREFIXES: &[&str] = &["wascc-e2e", "wasi-e2e"];
+
 #[tokio::main(threaded_scheduler)]
 async fn main() -> anyhow::Result<()> {
     let result = smite_all_integration_test_pods().await;
@@ -78,7 +80,9 @@ fn name_of(ns: &impl Metadata<Ty = ObjectMeta>) -> String {
 }
 
 fn is_e2e_namespace(namespace: &str) -> bool {
-    namespace.starts_with("wascc-e2e") || namespace.starts_with("wasi-e2e")
+    E2E_NS_PREFIXES
+        .iter()
+        .any(|prefix| namespace.starts_with(prefix))
 }
 
 async fn smite_namespace_pods(client: kube::Client, namespace: &str) -> anyhow::Result<()> {

--- a/tests/podsmiter/src/main.rs
+++ b/tests/podsmiter/src/main.rs
@@ -1,0 +1,112 @@
+use k8s_openapi::api::core::v1::{Namespace, Pod};
+use k8s_openapi::Metadata;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use kube::api::{Api, DeleteParams, ListParams};
+
+#[tokio::main(threaded_scheduler)]
+async fn main() -> anyhow::Result<()> {
+    let result = smite_all_integration_test_pods().await;
+
+    if let Err(e) = &result {
+        eprintln!("{}", e);
+    } else {
+        println!("All e2e pods force-deleted; namespace cleanup may take a couple of minutes");
+    }
+
+    result
+}
+
+async fn smite_all_integration_test_pods() -> anyhow::Result<()> {
+    let client = match kube::Client::try_default().await {
+        Ok(c) => c,
+        Err(e) => return Err(anyhow::anyhow!("Failed to acquire Kubernetes client: {}", e)),
+    };
+
+    let namespaces = list_e2e_namespaces(client.clone()).await?;
+
+    let smite_operations = namespaces.iter().map(|ns| smite_namespace_pods(client.clone(), ns));
+    let smite_results = futures::future::join_all(smite_operations).await;
+    let (_, errors) = smite_results.partition_success();
+
+    if !errors.is_empty() {
+        return Err(anyhow::anyhow!(smite_failure_message(&errors)))
+    }
+
+
+    Ok(())
+}
+
+async fn list_e2e_namespaces(client: kube::Client) -> anyhow::Result<Vec<String>> {
+    println!("Finding e2e namespaces...");
+
+    let nsapi: Api<Namespace> = Api::all(client.clone());
+    let nslist = nsapi.list(&ListParams::default()).await?;
+
+    Ok(nslist.iter().map(name_of).filter(|n| is_e2e_namespace(n)).collect())
+}
+
+fn name_of(ns: &impl Metadata<Ty = ObjectMeta>) -> String {
+    ns.metadata().unwrap().name.as_ref().unwrap().to_owned()
+}
+
+fn is_e2e_namespace(namespace: &str) -> bool {
+    namespace.starts_with("wascc-e2e") || namespace.starts_with("wasi-e2e")
+}
+
+async fn smite_namespace_pods(client: kube::Client, namespace: &str) -> anyhow::Result<()> {
+    println!("Finding pods in namespace {}...", namespace);
+
+    let podapi: Api<Pod> = Api::namespaced(client.clone(), namespace);
+    let pods = podapi.list(&ListParams::default()).await?;
+
+    println!("Deleting pods in namespace {}...", namespace);
+
+    let delete_operations = pods.iter().map(|p| smite_pod(&podapi, p));
+    let delete_results = futures::future::join_all(delete_operations).await;
+    let (_, errors) = delete_results.partition_success();
+
+    if !errors.is_empty() {
+        return Err(anyhow::anyhow!(smite_pods_failure_message(namespace, &errors)))
+    }
+
+    Ok(())
+}
+
+async fn smite_pod(podapi: &Api<Pod>, pod: &Pod) -> anyhow::Result<()> {
+    let pod_name = name_of(pod);
+    let _ = podapi.delete(&pod_name, &DeleteParams { grace_period_seconds: Some(0), ..DeleteParams::default() }).await?;
+    Ok(())
+}
+
+fn smite_failure_message(errors: &Vec<anyhow::Error>) -> String {
+    let message_list = errors.iter().map(|e| format!("{}", e)).collect::<Vec<_>>().join("\n");
+    format!("Some integration test resources were not cleaned up:\n{}", message_list)
+}
+
+fn smite_pods_failure_message(namespace: &str, errors: &Vec<anyhow::Error>) -> String {
+    let message_list = errors.iter().map(|e| format!("  - {}", e)).collect::<Vec<_>>().join("\n");
+    format!("- Namespace {}: pod delete(s) failed:\n{}", namespace, message_list)
+}
+
+// TODO: deduplicate with oneclick
+
+trait ResultSequence {
+    type SuccessItem;
+    type FailureItem;
+    fn partition_success(self) -> (Vec<Self::SuccessItem>, Vec<Self::FailureItem>);
+}
+
+impl<T, E: std::fmt::Debug> ResultSequence for Vec<Result<T, E>> {
+    type SuccessItem = T;
+    type FailureItem = E;
+    fn partition_success(self) -> (Vec<Self::SuccessItem>, Vec<Self::FailureItem>) {
+        let (success_results, error_results): (Vec<_>, Vec<_>) =
+            self.into_iter().partition(|r| r.is_ok());
+        let success_values = success_results.into_iter().map(|r| r.unwrap()).collect();
+        let error_values = error_results
+            .into_iter()
+            .map(|r| r.err().unwrap())
+            .collect();
+        (success_values, error_values)
+    }
+}


### PR DESCRIPTION
Fixes #366.  If integration tests fail in a way that leaves pods stuck in `Terminating`, you can `cargo run --bin podsmiter` to delete the pods, after which the namespaces will clear up automatically.

(As an alternative to a post-test cleanup script, we could modify the integration tests to force-delete the pods in its cleanup; I haven't done that because I thought there might be cases where we'd want to look at stuck ones before blowing them away; but it would certainly be easier if we didn't care about that.  Having a script also allows cleanup if the test process fails to clean up for whatever reason.)