### PR TITLE
increase type length limit

### DIFF
--- a/src/krustlet-wascc.rs
+++ b/src/krustlet-wascc.rs
@@ -1,3 +1,4 @@
+#![type_length_limit = "1271125"]
 use kubelet::config::Config;
 use kubelet::store::composite::ComposableStore;
 use kubelet::store::oci::FileStore;

--- a/src/krustlet-wasi.rs
+++ b/src/krustlet-wasi.rs
@@ -1,3 +1,4 @@
+#![type_length_limit = "1271125"]
 use kubelet::config::Config;
 use kubelet::store::composite::ComposableStore;
 use kubelet::store::oci::FileStore;


### PR DESCRIPTION
supersedes #378 by increasing the type length limit to work around an issue in the Rust compiler with nested closure wrappers (see https://github.com/rust-lang/rust/issues/54540 and https://github.com/rust-lang/rust/issues/75992 for more information).