### PR TITLE
Warn if a kubelet crashes during integration testing

### DIFF
--- a/tests/oneclick/src/main.rs
+++ b/tests/oneclick/src/main.rs
@@ -479,9 +479,12 @@ fn run_tests(readiness: BootstrapReadiness) -> anyhow::Result<()> {
 
 fn warn_if_premature_exit(process: &mut OwnedChildProcess, name: &str) {
     match process.exited() {
-        Err(e) => eprintln!("FAILED checking kubelet process {} exit state ({})", name, e),
+        Err(e) => eprintln!(
+            "FAILED checking kubelet process {} exit state ({})",
+            name, e
+        ),
         Ok(false) => eprintln!("WARNING: Kubelet process {} exited prematurely", name),
-        _ => ()
+        _ => (),
     };
 }
 


### PR DESCRIPTION
Previously, if a kubelet crashed during integration testing, you got a bunch of cryptic errors about "unable to fetch terminating state" and "can't retrieve logs."  This PR provides additional diagnostics in `just test-e2e-standalone` if someone - some Moriarty of Montreal, say, or some Charles Augustus Milverton of Manitoba, some Irene Adler of Alberta - does something that causes this to happen.