### PR TITLE
Run secrets tests only when secrets are available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: Build and Test
 on:
-  pull_request:
+  push:
+    branches:
+      - master
     paths-ignore:
       - "docs/**"
 jobs:
@@ -76,6 +78,8 @@ jobs:
           KRUSTLET_NODE_IP: "172.17.0.1"
           # The default location for the cert is not accessible on build hosts, so do it in the current dir
           CONFIG_DIR: "./config"
+          KRUSTLET_TEST_ENV: "ci"
+          KRUSTLET_E2E_IMAGE_PULL_SECRET: ${{ secrets.KRUSTLET_E2E_IMAGE_PULL_SECRET }}
         run: |
           just bootstrap
           just build


### PR DESCRIPTION
Currently E2E tests on PRs are failing because... well, okay, lots of reasons right now, but a fundamental one is that PRs don't have access to the secret needed to run the image pull secrets test, and there's no way we know of to grant that access to 'approved' PRs.

This PR therefore separates the `build.yml` workflow that does public E2E tests and can run on every PR and a new `ci.yml` workflow that also runs tests that use secrets, and runs only after a PR merges to the main branch.

Ironically, I can't see a way to test the on-merge-to-master workflow without, er, merging it to master.

**REVIEWERS:** It's a bit awful duplicating the bodies of the workflows, but I couldn't see a way to conditionally set environment variables depending on the trigger, nor to pull out the bulk into a shared workflow with configurable knobs.  Let me know if you know ways of doing one of these!