### PR TITLE
ref(*): Updates state trait to make next have mut self

### DIFF
--- a/crates/kubelet/src/state.rs
+++ b/crates/kubelet/src/state.rs
@@ -33,7 +33,7 @@ pub trait AsyncDrop: Sized {
 pub trait State<PodState>: Sync + Send + 'static + std::fmt::Debug {
     /// Provider supplies method to be executed when in this state.
     async fn next(
-        &self,
+        &mut self,
         pod_state: &mut PodState,
         pod: &Pod,
     ) -> anyhow::Result<Transition<Box<dyn State<PodState>>, Box<dyn State<PodState>>>>;
@@ -90,7 +90,7 @@ pub struct Stub;
 #[async_trait::async_trait]
 impl<P: 'static + Sync + Send> State<P> for Stub {
     async fn next(
-        &self,
+        &mut self,
         _pod_state: &mut P,
         _pod: &Pod,
     ) -> anyhow::Result<Transition<Box<dyn State<P>>, Box<dyn State<P>>>> {

--- a/crates/kubelet/src/state/macros.rs
+++ b/crates/kubelet/src/state/macros.rs
@@ -18,7 +18,7 @@ macro_rules! state {
         #[async_trait::async_trait]
         impl State<$state> for $name {
             async fn next(
-                &self,
+                &mut self,
                 #[allow(unused_variables)] pod_state: &mut $state,
                 #[allow(unused_variables)] pod: &Pod,
             ) -> anyhow::Result<Transition<Box<dyn State<$state>>,Box<dyn State<$state>>>> {
@@ -51,7 +51,7 @@ macro_rules! state {
         #[async_trait::async_trait]
         impl State<$state> for $name {
             async fn next(
-                &self,
+                &mut self,
                 #[allow(unused_variables)] pod_state: &mut $state,
                 #[allow(unused_variables)] pod: &Pod,
             ) -> anyhow::Result<Transition<Box<dyn State<$state>>,Box<dyn State<$state>>>> {

--- a/crates/wascc-provider/src/states/error.rs
+++ b/crates/wascc-provider/src/states/error.rs
@@ -14,7 +14,7 @@ pub struct Error {
 #[async_trait::async_trait]
 impl State<PodState> for Error {
     async fn next(
-        &self,
+        &mut self,
         pod_state: &mut PodState,
         _pod: &Pod,
     ) -> anyhow::Result<Transition<Box<dyn State<PodState>>, Box<dyn State<PodState>>>> {

--- a/crates/wasi-provider/src/states/error.rs
+++ b/crates/wasi-provider/src/states/error.rs
@@ -14,7 +14,7 @@ pub struct Error {
 #[async_trait::async_trait]
 impl State<PodState> for Error {
     async fn next(
-        &self,
+        &mut self,
         pod_state: &mut PodState,
         _pod: &Pod,
     ) -> anyhow::Result<Transition<Box<dyn State<PodState>>, Box<dyn State<PodState>>>> {

--- a/crates/wasi-provider/src/states/initializing.rs
+++ b/crates/wasi-provider/src/states/initializing.rs
@@ -90,6 +90,7 @@ state!(
                 {
                     error!("Unable to patch status, will retry on next update: {:?}", e);
                 }
+
                 if let ContainerStatus::Terminated {
                     timestamp: _,
                     message,

--- a/crates/wasi-provider/src/states/running.rs
+++ b/crates/wasi-provider/src/states/running.rs
@@ -73,6 +73,7 @@ state!(
             if let Err(e) = patch_container_status(&client, &pod.name(), name, &status).await {
                 error!("Unable to patch status, will retry on next update: {:?}", e);
             }
+
             if let Status::Terminated {
                 timestamp: _,
                 message,

--- a/docs/topics/architecture.md
+++ b/docs/topics/architecture.md
@@ -29,6 +29,5 @@ containers (they definitely are not if you are using one of the providers implem
 repository), but Kubernetes still thinks of them as a "container." The basic workflow is like this:
 
 1. `kubelet` receives a pod event from the stream
-1. Depending on the event type (added, modified, deleted), it calls the corresponding `Provider`
-   method and creates, updates, or stops/deletes the "container"
-1. The `Provider` does work and returns an error if there is a problem
+1. Each event either a) spawns a new pod (implemented as a state machine) or b) triggers cleanup
+1. The `Provider` does its work and returns an error if there is a problem


### PR DESCRIPTION
This facilitates passing of non-shared data from state to state. A good
example of this is Initializing -> Starting in the wasi provider

Also includes a small doc change to account for the new provider interface