### PR TITLE
WASCC pods should transition to error state instead of kerploding

### DIFF
--- a/crates/wascc-provider/src/states/terminated.rs
+++ b/crates/wascc-provider/src/states/terminated.rs
@@ -14,7 +14,7 @@ impl State<PodState> for Terminated {
     ) -> anyhow::Result<Transition<PodState>> {
         let mut lock = pod_state.shared.handles.write().await;
         if let Some(handle) = lock.get_mut(&pod_state.key) {
-            handle.stop().await.unwrap()
+            handle.stop().await?;
         }
         Ok(Transition::Complete(Ok(())))
     }

--- a/crates/wasi-provider/src/states/terminated.rs
+++ b/crates/wasi-provider/src/states/terminated.rs
@@ -14,7 +14,7 @@ impl State<PodState> for Terminated {
     ) -> anyhow::Result<Transition<PodState>> {
         let mut lock = pod_state.shared.handles.write().await;
         if let Some(handle) = lock.get_mut(&pod_state.key) {
-            handle.stop().await.unwrap()
+            handle.stop().await?;
         }
         Ok(Transition::Complete(Ok(())))
     }


### PR DESCRIPTION
There are a few places in the WASCC provider where it unwraps an error (causing a panic) or returns an error from a state runner (causing the run loop to terminate).  These should all or mostly transition the pod to the Error state instead.  This PR does that.

The work here suggests a possible change to the design of the state `next` function: instead of returning a `Result<Transition, ...>` it should perhaps strictly return a `Transition`, thus preventing maintainers lazily letting an unhandled error sneak up to the run loop.  If a provider needs an "everything has turned to custard and we just want to die and never come back" behaviour, then we could add a `Transition::Fatal` member to the Transition enum, which the run loop could check for.  This would force authors to specifically identify errors that they want to be fatal instead of that being the path of least resistance.