### PR TITLE
ref(*): Removes use of deprecated `Informer` from the `kube` crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: engineerd/setup-kind@v0.4.0
+        with:
+          version: "v0.9.0"
       - uses: engineerd/configurator@v0.0.1
         with:
           name: just
@@ -86,8 +88,8 @@ jobs:
           KUBECONFIG=${CONFIG_DIR}/kubeconfig-wascc ./target/debug/krustlet-wascc --node-name krustlet-wascc --port 3000 --bootstrap-file ${CONFIG_DIR}/bootstrap.conf --cert-file ./config/krustlet-wascc.crt --private-key-file ./config/krustlet-wascc.key &
           # Wait for things to start before approving certs and then delete so we don't overlap with the same hostname
           sleep 5 && kubectl certificate approve $(hostname)-tls
-          sleep 2 && kubectl delete csr $(hostname)-tls 
+          sleep 2 && kubectl delete csr $(hostname)-tls
           KUBECONFIG=${CONFIG_DIR}/kubeconfig-wasi ./target/debug/krustlet-wasi --node-name krustlet-wasi --port 3001 --bootstrap-file ${CONFIG_DIR}/bootstrap.conf --cert-file ./config/krustlet-wasi.crt --private-key-file ./config/krustlet-wasi.key &
           sleep 5 && kubectl certificate approve $(hostname)-tls
-          sleep 2 && kubectl delete csr $(hostname)-tls 
+          sleep 2 && kubectl delete csr $(hostname)-tls
           just test-e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           KUBECONFIG=${CONFIG_DIR}/kubeconfig-wascc ./target/debug/krustlet-wascc --node-name krustlet-wascc --port 3000 --bootstrap-file ${CONFIG_DIR}/bootstrap.conf --cert-file ./config/krustlet-wascc.crt --private-key-file ./config/krustlet-wascc.key &
           # Wait for things to start before approving certs and then delete so we don't overlap with the same hostname
           sleep 5 && kubectl certificate approve $(hostname)-tls
-          sleep 2 && kubectl delete csr $(hostname)-tls
+          sleep 2 && kubectl delete csr $(hostname)-tls && sleep 2
           KUBECONFIG=${CONFIG_DIR}/kubeconfig-wasi ./target/debug/krustlet-wasi --node-name krustlet-wasi --port 3001 --bootstrap-file ${CONFIG_DIR}/bootstrap.conf --cert-file ./config/krustlet-wasi.crt --private-key-file ./config/krustlet-wasi.key &
           sleep 5 && kubectl certificate approve $(hostname)-tls
           sleep 2 && kubectl delete csr $(hostname)-tls

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
+name = "ahash"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
+dependencies = [
+ "const-random",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,6 +675,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f1af9ac737b2dd2d577701e59fd09ba34822f6f2ebdb30a7647405d9e55e16a"
+dependencies = [
+ "const-random-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e4c606eb459dd29f7c57b2e0879f2b6f14ee130918c2b78ccb58a9624e6c7a"
+dependencies = [
+ "getrandom",
+ "proc-macro-hack",
+]
+
+[[package]]
 name = "const_fn"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,10 +940,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "3.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f260e2fc850179ef410018660006951c1b55b79e8087e87111a2c388994b9b5"
+dependencies = [
+ "ahash",
+ "cfg-if",
+ "num_cpus",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4d0e2d24e5ee3b23a01de38eefdcd978907890701f08ffffd4cb457ca4ee8d6"
+
+[[package]]
+name = "derivative"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "derive_more"
@@ -990,6 +1041,12 @@ name = "discard"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dtoa"
@@ -1518,7 +1575,7 @@ dependencies = [
  "futures-util",
  "hyper",
  "log",
- "rustls 0.18.1",
+ "rustls",
  "tokio",
  "tokio-rustls",
  "webpki",
@@ -1665,20 +1722,6 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae6d236dfb2b60d27cdbcb3d20511713aff6d23f9bf2f3d6b594c232ea99e04"
-dependencies = [
- "base64 0.12.3",
- "bytes 0.5.6",
- "chrono",
- "serde",
- "serde-value 0.6.0",
- "serde_json",
-]
-
-[[package]]
-name = "k8s-openapi"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57f95fd36c08ce592e67400a0f1a66f432196997d5a7e9a97e8743c33d8a9312"
@@ -1686,9 +1729,12 @@ dependencies = [
  "base64 0.12.3",
  "bytes 0.5.6",
  "chrono",
+ "http 0.2.1",
+ "percent-encoding 2.1.0",
  "serde",
- "serde-value 0.7.0",
+ "serde-value",
  "serde_json",
+ "url 2.1.1",
 ]
 
 [[package]]
@@ -1710,8 +1756,9 @@ dependencies = [
  "env_logger",
  "futures",
  "hostname",
- "k8s-openapi 0.8.0",
- "kube 0.35.1",
+ "k8s-openapi",
+ "kube",
+ "kube-runtime",
  "kubelet",
  "oci-distribution",
  "regex",
@@ -1727,39 +1774,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.35.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0578635e15e33e500d784ce9bdb82b2a0cd18eda82fdc88108eba405b02709"
-dependencies = [
- "Inflector",
- "base64 0.12.3",
- "bytes 0.5.6",
- "chrono",
- "dirs 2.0.2",
- "either",
- "futures",
- "futures-util",
- "http 0.2.1",
- "k8s-openapi 0.8.0",
- "log",
- "openssl",
- "pem",
- "reqwest",
- "rustls 0.17.0",
- "serde",
- "serde_json",
- "serde_yaml",
- "thiserror",
- "time 0.2.17",
- "tokio",
- "url 2.1.1",
-]
-
-[[package]]
-name = "kube"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be34ed86dca3021a649b574a1628917d694bb75650a3b50c492e1786589a5ac6"
+checksum = "f4f52dbe2c0e7ca54e43f1bc7b77b916750e63d7694e5a18c09b11307acc6b9d"
 dependencies = [
  "Inflector",
  "base64 0.12.3",
@@ -1770,12 +1787,12 @@ dependencies = [
  "futures",
  "futures-util",
  "http 0.2.1",
- "k8s-openapi 0.9.0",
+ "k8s-openapi",
  "log",
  "openssl",
  "pem",
  "reqwest",
- "rustls 0.18.1",
+ "rustls",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1784,6 +1801,24 @@ dependencies = [
  "time 0.2.17",
  "tokio",
  "url 2.1.1",
+]
+
+[[package]]
+name = "kube-runtime"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78d0d3673ec4eff2c5276bd10db8e596106ce9dee8e035e01650a8c84454ac78"
+dependencies = [
+ "dashmap",
+ "derivative",
+ "futures",
+ "k8s-openapi",
+ "kube",
+ "pin-project",
+ "serde",
+ "smallvec",
+ "snafu",
+ "tokio",
 ]
 
 [[package]]
@@ -1799,8 +1834,9 @@ dependencies = [
  "hostname",
  "http 0.2.1",
  "hyper",
- "k8s-openapi 0.9.0",
- "kube 0.40.0",
+ "k8s-openapi",
+ "kube",
+ "kube-runtime",
  "lazy_static",
  "log",
  "native-tls",
@@ -2184,15 +2220,6 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "ordered-float"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3741934be594d77de1c8461ebcbbe866f585ea616a9753aa78f2bdc69f0e4579"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -2660,7 +2687,7 @@ dependencies = [
  "native-tls",
  "percent-encoding 2.1.0",
  "pin-project-lite",
- "rustls 0.18.1",
+ "rustls",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2752,19 +2779,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver",
-]
-
-[[package]]
-name = "rustls"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d4a31f5d68413404705d6982529b0e11a9aacd4839d1d6222ee3b8cb4015e1"
-dependencies = [
- "base64 0.11.0",
- "log",
- "ring",
- "sct",
- "webpki",
 ]
 
 [[package]]
@@ -2893,21 +2907,11 @@ dependencies = [
 
 [[package]]
 name = "serde-value"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a65a7291a8a568adcae4c10a677ebcedbc6c9cec91c054dee2ce40b0e3290eb"
-dependencies = [
- "ordered-float 1.1.0",
- "serde",
-]
-
-[[package]]
-name = "serde-value"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
- "ordered-float 2.0.0",
+ "ordered-float",
  "serde",
 ]
 
@@ -3075,6 +3079,29 @@ name = "smallvec"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
+
+[[package]]
+name = "snafu"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c4e6046e4691afe918fd1b603fd6e515bcda5388a1092a9edbada307d159f09"
+dependencies = [
+ "doc-comment",
+ "futures-core",
+ "pin-project",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7073448732a89f2f3e6581989106067f403d378faeafb4a50812eb814170d3e5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "socket2"
@@ -3425,7 +3452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
 dependencies = [
  "futures-core",
- "rustls 0.18.1",
+ "rustls",
  "tokio",
  "webpki",
 ]
@@ -3919,8 +3946,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "k8s-openapi 0.9.0",
- "kube 0.40.0",
+ "k8s-openapi",
+ "kube",
  "kubelet",
  "log",
  "oci-distribution",
@@ -3980,8 +4007,8 @@ dependencies = [
  "backtrace",
  "chrono",
  "futures",
- "k8s-openapi 0.9.0",
- "kube 0.40.0",
+ "k8s-openapi",
+ "kube",
  "kubelet",
  "log",
  "oci-distribution",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,12 +37,14 @@ maintenance = { status = "actively-developed" }
 default = ["native-tls"]
 native-tls = [
     "kube/native-tls",
+    "kube-runtime/native-tls",
     "kubelet/kube-native-tls",
     "wascc-provider/native-tls",
     "oci-distribution/native-tls"
 ]
 rustls-tls = [
     "kube/rustls-tls",
+    "kube-runtime/rustls-tls",
     "kubelet/rustls-tls",
     "wascc-provider/rustls-tls",
     "oci-distribution/rustls-tls"
@@ -69,7 +71,7 @@ serde_json = "1.0"
 serde = "1.0"
 reqwest = { version = "0.10", default-features = false }
 tempfile = "3.1"
-kube-runtime = "0.42"
+kube-runtime = { version= "0.42", default-features = false }
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,8 +51,8 @@ rustls-tls = [
 [dependencies]
 anyhow = "1.0"
 tokio = { version = "0.2", features = ["macros", "rt-threaded", "time"] }
-kube = { version= "0.35", default-features = false }
-k8s-openapi = { version = "0.8", default-features = false, features = ["v1_17"] }
+kube = { version= "0.42", default-features = false }
+k8s-openapi = { version = "0.9", default-features = false, features = ["v1_18"] }
 env_logger = "0.7"
 futures = "0.3"
 kubelet = { path = "./crates/kubelet", version = "0.5", default-features = false, features = ["cli"] }
@@ -69,6 +69,7 @@ serde_json = "1.0"
 serde = "1.0"
 reqwest = { version = "0.10", default-features = false }
 tempfile = "3.1"
+kube-runtime = "0.42"
 
 [workspace]
 members = [

--- a/crates/kubelet/Cargo.toml
+++ b/crates/kubelet/Cargo.toml
@@ -45,8 +45,9 @@ hyper = { version = "0.13", default-features = false, features = ["stream"] }
 log = "0.4"
 reqwest = { version = "0.10", default-features = false, features = ["json", "stream"]}
 tokio  = { version = "0.2", features = ["fs", "stream", "macros", "signal"] }
-kube = { version= "0.40", default-features = false }
-k8s-openapi = { version = "0.9", default-features = false, features = ["v1_17"] }
+kube = { version= "0.42", default-features = false }
+kube-runtime = "0.42"
+k8s-openapi = { version = "0.9", default-features = false, features = ["v1_18"] }
 chrono = { version = "0.4", features = ["serde"] }
 structopt = { version = "0.3", features = ["wrap_help"], optional = true }
 hostname = "0.3"

--- a/crates/kubelet/Cargo.toml
+++ b/crates/kubelet/Cargo.toml
@@ -27,8 +27,8 @@ maintenance = { status = "actively-developed" }
 
 [features]
 default = ["kube-native-tls"]
-kube-native-tls = ["kube/native-tls", "oci-distribution/native-tls", "reqwest/native-tls"]
-rustls-tls = ["kube/rustls-tls", "oci-distribution/rustls-tls", "reqwest/rustls-tls"]
+kube-native-tls = ["kube/native-tls", "kube-runtime/native-tls", "oci-distribution/native-tls", "reqwest/native-tls"]
+rustls-tls = ["kube/rustls-tls", "kube-runtime/rustls-tls","oci-distribution/rustls-tls", "reqwest/rustls-tls"]
 cli = ["structopt"]
 docs = ["cli"]
 
@@ -46,7 +46,7 @@ log = "0.4"
 reqwest = { version = "0.10", default-features = false, features = ["json", "stream"]}
 tokio  = { version = "0.2", features = ["fs", "stream", "macros", "signal"] }
 kube = { version= "0.42", default-features = false }
-kube-runtime = "0.42"
+kube-runtime = { version= "0.42", default-features = false }
 k8s-openapi = { version = "0.9", default-features = false, features = ["v1_18"] }
 chrono = { version = "0.4", features = ["serde"] }
 structopt = { version = "0.3", features = ["wrap_help"], optional = true }

--- a/crates/kubelet/src/config.rs
+++ b/crates/kubelet/src/config.rs
@@ -658,7 +658,7 @@ mod test {
         assert_eq!(config.node_labels.get("label1"), Some(&("val1".to_owned())));
         assert_eq!(config.insecure_registries.clone().unwrap().len(), 2);
         assert_eq!(&config.insecure_registries.clone().unwrap()[0], "local");
-        assert_eq!(&config.insecure_registries.clone().unwrap()[1], "dev");
+        assert_eq!(&config.insecure_registries.unwrap()[1], "dev");
     }
 
     #[test]

--- a/crates/kubelet/src/pod/handle.rs
+++ b/crates/kubelet/src/pod/handle.rs
@@ -98,12 +98,21 @@ impl<H: StopHandler, F> Handle<H, F> {
 
 /// Generates a unique human readable key for storing a handle to a pod in a
 /// hash. This is a convenience wrapper around [pod_key].
+#[deprecated(
+    since = "0.6.0",
+    note = "Please use the new kubelet::pod::PodKey type. This function will be removed in 0.7"
+)]
 pub fn key_from_pod(pod: &Pod) -> String {
+    #[allow(deprecated)]
     pod_key(pod.namespace(), pod.name())
 }
 
 /// Generates a unique human readable key for storing a handle to a pod if you
 /// already have the namespace and pod name.
+#[deprecated(
+    since = "0.6.0",
+    note = "Please use the new kubelet::pod::PodKey type. This function will be removed in 0.7"
+)]
 pub fn pod_key<N: AsRef<str>, T: AsRef<str>>(namespace: N, pod_name: T) -> String {
     format!("{}:{}", namespace.as_ref(), pod_name.as_ref())
 }

--- a/crates/kubelet/src/pod/queue.rs
+++ b/crates/kubelet/src/pod/queue.rs
@@ -2,8 +2,9 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use k8s_openapi::api::core::v1::Pod as KubePod;
-use kube::api::{Meta, WatchEvent};
+use kube::api::Meta;
 use kube::Client as KubeClient;
+use kube_runtime::watcher::Event;
 use log::{debug, error, warn};
 use tokio::sync::RwLock;
 
@@ -20,7 +21,7 @@ use crate::state::{run_to_completion, AsyncDrop};
 /// modify will be handled, which is ok given that each event contains the whole pod object
 pub(crate) struct Queue<P> {
     provider: Arc<P>,
-    handlers: HashMap<String, tokio::sync::mpsc::Sender<WatchEvent<KubePod>>>,
+    handlers: HashMap<String, tokio::sync::mpsc::Sender<Event<KubePod>>>,
     client: KubeClient,
 }
 
@@ -35,92 +36,24 @@ impl<P: 'static + Provider + Sync + Send> Queue<P> {
 
     async fn run_pod(
         &self,
-        initial_event: WatchEvent<KubePod>,
-    ) -> anyhow::Result<tokio::sync::mpsc::Sender<WatchEvent<KubePod>>> {
-        let (sender, mut receiver) = tokio::sync::mpsc::channel::<WatchEvent<KubePod>>(16);
+        initial_event: Event<KubePod>,
+    ) -> anyhow::Result<tokio::sync::mpsc::Sender<Event<KubePod>>> {
+        let (sender, mut receiver) = tokio::sync::mpsc::channel::<Event<KubePod>>(16);
 
         let pod_deleted = Arc::new(RwLock::new(false));
-        let check_pod_deleted = Arc::clone(&pod_deleted);
 
         match initial_event {
-            WatchEvent::Added(pod) => {
-                let task_client = self.client.clone();
+            Event::Applied(pod) => {
                 let pod = Pod::from(pod);
-
-                let mut pod_state: P::PodState = self.provider.initialize_pod_state(&pod).await?;
-                tokio::spawn(async move {
-                    let state: P::InitialState = Default::default();
-                    let name = pod.name().to_string();
-
-                    let check = async {
-                        loop {
-                            tokio::time::delay_for(std::time::Duration::from_secs(1)).await;
-                            if *check_pod_deleted.read().await {
-                                break;
-                            }
-                        }
-                    };
-
-                    tokio::select! {
-                        result = run_to_completion(&task_client, state, &mut pod_state, &pod) => match result {
-                            Ok(()) => debug!("Pod {} state machine exited without error", name),
-                            Err(e) => {
-                                error!("Pod {} state machine exited with error: {:?}", name, e);
-                                let api: kube::Api<KubePod> = kube::Api::namespaced(task_client.clone(), pod.namespace());
-                                let patch = serde_json::json!(
-                                    {
-                                        "metadata": {
-                                            "resourceVersion": "",
-                                        },
-                                        "status": {
-                                            "phase": Phase::Failed,
-                                            "reason": format!("{:?}", e),
-                                        }
-                                    }
-                                );
-                                let data = serde_json::to_vec(&patch).unwrap();
-                                api.patch_status(&pod.name(), &kube::api::PatchParams::default(), data)
-                                    .await.unwrap();
-                            },
-                        },
-                        _ = check => {
-                            let state: P::TerminatedState = Default::default();
-                            debug!("Pod {} terminated. Jumping to state {:?}.", name, state);
-                            match run_to_completion(&task_client, state, &mut pod_state, &pod).await {
-                                Ok(()) => debug!("Pod {} state machine exited without error", name),
-                                Err(e) => error!("Pod {} state machine exited with error: {:?}", name, e),
-                            }
-                        }
-                    }
-
-                    debug!("Pod {} waiting for deregistration.", name);
-                    loop {
-                        tokio::time::delay_for(std::time::Duration::from_secs(1)).await;
-                        if *check_pod_deleted.read().await {
-                            debug!("Pod {} deleted.", name);
-                            break;
-                        }
-                    }
-                    pod_state.async_drop().await;
-
-                    let pod_client: kube::Api<KubePod> =
-                        kube::Api::namespaced(task_client, pod.namespace());
-                    let dp = kube::api::DeleteParams {
-                        grace_period_seconds: Some(0),
-                        ..Default::default()
-                    };
-                    match pod_client.delete(&pod.name(), &dp).await {
-                        Ok(_) => {
-                            debug!("Pod {} deregistered.", name);
-                        }
-                        Err(e) => {
-                            // This could happen if Pod was force deleted.
-                            warn!("Unable to deregister {} with Kubernetes API: {:?}", name, e);
-                        }
-                    }
-                });
+                let pod_state = self.provider.initialize_pod_state(&pod).await?;
+                tokio::spawn(start_task::<P>(
+                    self.client.clone(),
+                    pod,
+                    pod_state,
+                    Arc::clone(&pod_deleted),
+                ));
             }
-            _ => anyhow::bail!("Pod with initial event not Added: {:?}", &initial_event),
+            _ => return Err(anyhow::anyhow!("Got non-apply event when starting pod")),
         }
 
         tokio::spawn(async move {
@@ -128,16 +61,17 @@ impl<P: 'static + Provider + Sync + Send> Queue<P> {
                 // Watch errors are handled before an event ever gets here, so it should always have
                 // a pod
                 match event {
-                    WatchEvent::Modified(pod) => {
+                    Event::Applied(pod) => {
                         // Not really using this right now but will be useful for detecting changes.
-                        let p = Pod::from(pod);
-                        debug!("Pod {} modified.", p.name());
+                        let pod = Pod::from(pod);
+                        debug!("Pod {} applied.", pod.name());
+
                         // TODO, detect other changes we want to support, or should this just forward the new pod def to state machine?
-                        if let Some(_timestamp) = p.deletion_timestamp() {
+                        if let Some(_timestamp) = pod.deletion_timestamp() {
                             *(pod_deleted.write().await) = true;
                         }
                     }
-                    WatchEvent::Deleted(pod) => {
+                    Event::Deleted(pod) => {
                         // I'm not sure if this matters, we get notified of pod deletion with a
                         // Modified event, and I think we only get this after *we* delete the pod.
                         // There is the case where someone force deletes, but we want to go through
@@ -146,6 +80,7 @@ impl<P: 'static + Provider + Sync + Send> Queue<P> {
                         *(pod_deleted.write().await) = true;
                         break;
                     }
+                    // TODO: Figure out restarts
                     _ => warn!("Pod got unexpected event, ignoring: {:?}", &event),
                 }
             }
@@ -153,9 +88,9 @@ impl<P: 'static + Provider + Sync + Send> Queue<P> {
         Ok(sender)
     }
 
-    pub async fn enqueue(&mut self, event: WatchEvent<KubePod>) -> anyhow::Result<()> {
+    pub async fn enqueue(&mut self, event: Event<KubePod>) -> anyhow::Result<()> {
         match &event {
-            WatchEvent::Added(pod) | WatchEvent::Modified(pod) => {
+            Event::Applied(pod) => {
                 let pod_name = pod.name();
                 let pod_namespace = pod.namespace().unwrap_or_default();
                 let key = pod_key(&pod_namespace, &pod_name);
@@ -163,15 +98,15 @@ impl<P: 'static + Provider + Sync + Send> Queue<P> {
                 // mutex
                 let sender = match self.handlers.get_mut(&key) {
                     Some(s) => {
-                        debug!("Found existing event handler.");
+                        debug!("Found existing event handler for pod {}", pod.name());
                         s
                     }
                     None => {
-                        debug!("Creating event handler.");
+                        debug!("Creating event handler for pod {}", pod.name());
                         self.handlers.insert(
                             key.clone(),
                             // TODO Do we want to capture join handles? Worker wasnt using them.
-                            // TODO Does this mean we handle the Add event twice?
+                            // TODO: This ends up sending the initial event twice
                             // TODO How do we drop this sender / handler?
                             self.run_pod(event.clone()).await?,
                         );
@@ -190,7 +125,7 @@ impl<P: 'static + Provider + Sync + Send> Queue<P> {
                 }
                 Ok(())
             }
-            WatchEvent::Deleted(pod) => {
+            Event::Deleted(pod) => {
                 let pod_name = pod.name();
                 let pod_namespace = pod.namespace().unwrap_or_default();
                 let key = pod_key(&pod_namespace, &pod_name);
@@ -199,8 +134,85 @@ impl<P: 'static + Provider + Sync + Send> Queue<P> {
                 }
                 Ok(())
             }
-            WatchEvent::Bookmark(_) => Ok(()),
-            WatchEvent::Error(e) => Err(e.clone().into()),
+            // TODO: Figure out how to handle restarted. It might need to be handled at a higher level (as to be reenqueued properly)
+            Event::Restarted(_) => Ok(()),
+        }
+    }
+}
+
+async fn start_task<P: Provider>(
+    task_client: KubeClient,
+    pod: Pod,
+    mut pod_state: P::PodState,
+    check_pod_deleted: Arc<RwLock<bool>>,
+) {
+    let state: P::InitialState = Default::default();
+    let name = pod.name().to_string();
+
+    let check = async {
+        loop {
+            tokio::time::delay_for(std::time::Duration::from_secs(1)).await;
+            if *check_pod_deleted.read().await {
+                break;
+            }
+        }
+    };
+
+    tokio::select! {
+        result = run_to_completion(&task_client, state, &mut pod_state, &pod) => match result {
+            Ok(()) => debug!("Pod {} state machine exited without error", name),
+            Err(e) => {
+                error!("Pod {} state machine exited with error: {:?}", name, e);
+                let api: kube::Api<KubePod> = kube::Api::namespaced(task_client.clone(), pod.namespace());
+                let patch = serde_json::json!(
+                    {
+                        "metadata": {
+                            "resourceVersion": "",
+                        },
+                        "status": {
+                            "phase": Phase::Failed,
+                            "reason": format!("{:?}", e),
+                        }
+                    }
+                );
+                let data = serde_json::to_vec(&patch).unwrap();
+                // FIXME: Add retry to this patch
+                api.patch_status(&pod.name(), &kube::api::PatchParams::default(), data)
+                    .await.unwrap();
+            },
+        },
+        _ = check => {
+            let state: P::TerminatedState = Default::default();
+            debug!("Pod {} terminated. Jumping to state {:?}.", name, state);
+            match run_to_completion(&task_client, state, &mut pod_state, &pod).await {
+                Ok(()) => debug!("Pod {} state machine exited without error", name),
+                Err(e) => error!("Pod {} state machine exited with error: {:?}", name, e),
+            }
+        }
+    }
+
+    debug!("Pod {} waiting for deregistration.", name);
+    loop {
+        tokio::time::delay_for(std::time::Duration::from_secs(1)).await;
+        if *check_pod_deleted.read().await {
+            debug!("Pod {} deleted.", name);
+            break;
+        }
+    }
+    pod_state.async_drop().await;
+
+    let pod_client: kube::Api<KubePod> = kube::Api::namespaced(task_client, pod.namespace());
+    let dp = kube::api::DeleteParams {
+        grace_period_seconds: Some(0),
+        ..Default::default()
+    };
+    match pod_client.delete(&pod.name(), &dp).await {
+        Ok(_) => {
+            debug!("Pod {} deregistered.", name);
+        }
+        Err(e) => {
+            // This could happen if Pod was force deleted.
+            warn!("Unable to deregister {} with Kubernetes API: {:?}", name, e);
         }
     }
 }

--- a/crates/kubelet/src/store/oci/file.rs
+++ b/crates/kubelet/src/store/oci/file.rs
@@ -180,7 +180,7 @@ mod test {
             client
         }
 
-        fn update(&mut self, key: &str, content: Vec<u8>, digest: &str) -> () {
+        fn update(&mut self, key: &str, content: Vec<u8>, digest: &str) {
             let mut images = self
                 .images
                 .write()
@@ -217,7 +217,7 @@ mod test {
     }
 
     impl Drop for TemporaryDirectory {
-        fn drop(&mut self) -> () {
+        fn drop(&mut self) {
             std::fs::remove_dir_all(&self.path).expect("Failed to remove temp directory");
         }
     }

--- a/crates/oci-distribution/src/client.rs
+++ b/crates/oci-distribution/src/client.rs
@@ -689,7 +689,7 @@ mod test {
                 .await
                 .expect("failed to pull manifest");
 
-            assert!(image_data.content.len() != 0);
+            assert!(!image_data.content.is_empty());
             assert!(image_data.digest.is_some());
         }
     }

--- a/crates/wascc-provider/Cargo.toml
+++ b/crates/wascc-provider/Cargo.toml
@@ -26,7 +26,7 @@ log = "0.4"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-kube = { version= "0.40", default-features = false }
+kube = { version= "0.42", default-features = false }
 kubelet = { path = "../kubelet", version = "0.5", default-features = false }
 tokio = { version = "0.2", features = ["fs", "macros"] }
 chrono = { version = "0.4", features = ["serde"] }
@@ -35,7 +35,7 @@ wascc-codec = "0.7"
 wascc-fs = { version = "0.1", features = ["static_plugin"] }
 wascc-logging = { path = "../wascc-logging", version = "0.1", features = ["static_plugin"] }
 wascc-httpsrv = { version = "0.7", features = ["static_plugin"] }
-k8s-openapi = { version = "0.9", default-features = false, features = ["v1_17"] }
+k8s-openapi = { version = "0.9", default-features = false, features = ["v1_18"] }
 rand = "0.7.3"
 
 [dev-dependencies]

--- a/crates/wasi-provider/Cargo.toml
+++ b/crates/wasi-provider/Cargo.toml
@@ -22,7 +22,7 @@ rustls-tls = ["kube/rustls-tls", "kubelet/rustls-tls"]
 anyhow = "1.0"
 async-trait = "0.1"
 backtrace = "0.3"
-kube = { version= "0.40", default-features = false }
+kube = { version= "0.42", default-features = false }
 log = "0.4"
 wasmtime = "0.19"
 wasmtime-wasi = "0.19"
@@ -36,7 +36,7 @@ wat = "1.0"
 tokio = { version = "0.2", features = ["fs", "stream", "macros", "io-util", "sync"] }
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
-k8s-openapi = { version = "0.9", default-features = false, features = ["v1_17"] }
+k8s-openapi = { version = "0.9", default-features = false, features = ["v1_18"] }
 
 [dev-dependencies]
 oci-distribution = { path = "../oci-distribution", version = "0.4" }

--- a/crates/wasi-provider/src/states/initializing.rs
+++ b/crates/wasi-provider/src/states/initializing.rs
@@ -7,7 +7,7 @@ use k8s_openapi::api::core::v1::Pod as KubePod;
 use kube::api::{Api, PatchParams};
 use kubelet::backoff::BackoffStrategy;
 use kubelet::container::{ContainerKey, Status as ContainerStatus};
-use kubelet::pod::{key_from_pod, Handle};
+use kubelet::pod::{Handle, PodKey};
 use kubelet::state::prelude::*;
 
 use super::error::Error;
@@ -119,7 +119,7 @@ impl State<PodState> for Initializing {
                         // If we are in a failed state, insert in the init containers we already ran
                         // into a pod handle so they are available for future log fetching
                         let pod_handle = Handle::new(container_handles, pod.clone(), None).await?;
-                        let pod_key = key_from_pod(&pod);
+                        let pod_key = PodKey::from(pod);
                         {
                             let mut handles = pod_state.shared.handles.write().await;
                             handles.insert(pod_key, pod_handle);

--- a/crates/wasi-provider/src/states/starting.rs
+++ b/crates/wasi-provider/src/states/starting.rs
@@ -7,7 +7,7 @@ use log::{debug, info};
 use tokio::sync::Mutex;
 
 use kubelet::container::{Container, ContainerKey};
-use kubelet::pod::{key_from_pod, Handle};
+use kubelet::pod::{Handle, PodKey};
 use kubelet::provider;
 use kubelet::state::prelude::*;
 use kubelet::volume::Ref;
@@ -119,7 +119,7 @@ impl State<PodState> for Starting {
         }
 
         let pod_handle = Handle::new(container_handles, pod.clone(), None).await?;
-        let pod_key = key_from_pod(&pod);
+        let pod_key = PodKey::from(pod);
         {
             let mut handles = pod_state.shared.handles.write().await;
             handles.insert(pod_key, pod_handle);

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -64,7 +64,7 @@ async fn verify_wascc_node(node: Node) -> () {
         "expected node to support the wasm-wasi architecture"
     );
 
-    let node_meta = node.metadata.expect("node reported no metadata");
+    let node_meta = node.metadata;
     assert_eq!(
         node_meta
             .labels
@@ -172,7 +172,7 @@ async fn verify_wasi_node(node: Node) -> () {
         "expected node to support the wasm-wasi architecture"
     );
 
-    let node_meta = node.metadata.expect("node reported no metadata");
+    let node_meta = node.metadata;
     assert_eq!(
         node_meta
             .labels

--- a/tests/podsmiter/src/main.rs
+++ b/tests/podsmiter/src/main.rs
@@ -76,7 +76,7 @@ async fn list_e2e_namespaces(client: kube::Client) -> anyhow::Result<Vec<String>
 }
 
 fn name_of(ns: &impl Metadata<Ty = ObjectMeta>) -> String {
-    ns.metadata().unwrap().name.as_ref().unwrap().to_owned()
+    ns.metadata().name.as_ref().unwrap().to_owned()
 }
 
 fn is_e2e_namespace(namespace: &str) -> bool {

--- a/tests/test_resource_manager.rs
+++ b/tests/test_resource_manager.rs
@@ -93,7 +93,7 @@ impl TestResourceManager {
 
         // k8s seems to need a bit of time for namespace permissions to flow
         // through the system.  TODO: make this less worse
-        tokio::time::delay_for(tokio::time::Duration::from_millis(100)).await;
+        tokio::time::delay_for(tokio::time::Duration::from_millis(1000)).await;
 
         let image_pull_secret_opt = std::env::var("KRUSTLET_E2E_IMAGE_PULL_SECRET");
 

--- a/tests/test_resource_manager.rs
+++ b/tests/test_resource_manager.rs
@@ -213,7 +213,7 @@ async fn clean_up_resources(resources: Vec<TestResource>, namespace: String) -> 
     }
 }
 
-async fn clean_up_resource(resource: TestResource, namespace: &String) -> Option<String> {
+async fn clean_up_resource(resource: TestResource, namespace: &str) -> Option<String> {
     let client = kube::Client::try_default()
         .await
         .expect("Failed to create client");
@@ -241,7 +241,7 @@ async fn clean_up_resource(resource: TestResource, namespace: &String) -> Option
     }
 }
 
-async fn clean_up_namespace(namespace: &String) -> Option<String> {
+async fn clean_up_namespace(namespace: &str) -> Option<String> {
     let client = kube::Client::try_default()
         .await
         .expect("Failed to create client");


### PR DESCRIPTION
This replaces all uses of the `Informer` with the new `watcher` type from the `kube_runtime` crate. I also fixed a bunch of clippy lints I found along the way

This also contains a refactor around pod keys by introducing the new `PodKey` type. This serves 2 main purposes. The first is it makes it clear that we are using key for a pod rather than it just being a `String`. The second is that instead of it being an arbitrary string, it now has separate fields that define the key. Arbitrary strings and separators (even with an alias type) can come back to bite, so this makes it a concrete type with separate fields. As part of this, I have deprecated, but not removed, the old pod key methods