### PR TITLE
ref(reference): add custom error types to match docker/distribution

### DIFF
--- a/crates/kubelet/src/container/mod.rs
+++ b/crates/kubelet/src/container/mod.rs
@@ -159,7 +159,7 @@ impl Container {
     /// Get image of container as `oci_distribution::Reference`.
     pub fn image(&self) -> anyhow::Result<Option<Reference>> {
         match self.0.image.as_ref() {
-            Some(s) => Some(s.clone().try_into()).transpose(),
+            Some(s) => Ok(Some(s.clone().try_into()?)),
             None => Ok(None),
         }
     }

--- a/crates/kubelet/src/store/oci/file.rs
+++ b/crates/kubelet/src/store/oci/file.rs
@@ -205,7 +205,7 @@ mod test {
                 .images
                 .read()
                 .expect("should be able to read from images");
-            match images.get(image_ref.whole()) {
+            match images.get(&image_ref.whole()) {
                 Some(v) => Ok(v.clone()),
                 None => Err(anyhow::anyhow!("error pulling module")),
             }


### PR DESCRIPTION
This is a starting number of changes to the reference parser. With these changes, the following occurs:

- we have access to concrete string types after parsing
- reference now returns its own custom types. This way, the errors reported from reference.rs are known
- an error is raised if the length exceeds the name total max length

Follow-up PRs will start refactoring the parser to match the one in docker/distribution. That way we can handle cases like #397.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>