### PR TITLE
use test fixtures for parsing references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2165,6 +2165,7 @@ dependencies = [
  "hyperx",
  "log",
  "reqwest",
+ "rstest",
  "serde",
  "serde_json",
  "tokio",
@@ -2746,6 +2747,19 @@ dependencies = [
  "byteorder",
  "rmp",
  "serde",
+]
+
+[[package]]
+name = "rstest"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec448bc157977efdc0a71369cf923915b0c4806b1b2449c3fb011071d6f7c38"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
 ]
 
 [[package]]

--- a/crates/oci-distribution/Cargo.toml
+++ b/crates/oci-distribution/Cargo.toml
@@ -38,3 +38,6 @@ www-authenticate = "0.3"
 hyperx = "0.13"
 futures-util = "0.3"
 log = "0.4"
+
+[dev-dependencies]
+rstest = "0.6"


### PR DESCRIPTION
ref: https://github.com/la10736/rstest

This PR asserts the same test cases currently tested, but in a more compact and readable fashion. This makes it easier and more efficient to add additional test cases in the future as we restructure the reference parser.

inspired by #363.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>