### PR TITLE
[WIP] Upgrade Tokio to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "tokio",
+ "tokio 0.2.22",
  "tokio-util 0.2.0",
 ]
 
@@ -37,7 +37,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project",
- "tokio",
+ "tokio 0.2.22",
  "tokio-util 0.3.1",
 ]
 
@@ -161,7 +161,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "smallvec",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -177,7 +177,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "log",
- "mio",
+ "mio 0.6.22",
  "mio-uds",
  "num_cpus",
  "slab",
@@ -1454,7 +1454,7 @@ dependencies = [
  "http 0.2.1",
  "indexmap",
  "slab",
- "tokio",
+ "tokio 0.2.22",
  "tokio-util 0.3.1",
  "tracing",
 ]
@@ -1590,7 +1590,7 @@ dependencies = [
  "itoa",
  "pin-project",
  "socket2",
- "tokio",
+ "tokio 0.2.22",
  "tower-service",
  "tracing",
  "want",
@@ -1607,7 +1607,7 @@ dependencies = [
  "hyper",
  "log",
  "rustls",
- "tokio",
+ "tokio 0.2.22",
  "tokio-rustls",
  "webpki",
 ]
@@ -1621,7 +1621,7 @@ dependencies = [
  "bytes 0.5.6",
  "hyper",
  "native-tls",
- "tokio",
+ "tokio 0.2.22",
  "tokio-tls",
 ]
 
@@ -1801,7 +1801,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tempfile",
- "tokio",
+ "tokio 0.3.0",
  "wascc-provider",
  "wasi-provider",
 ]
@@ -1833,7 +1833,7 @@ dependencies = [
  "static_assertions",
  "thiserror",
  "time 0.2.22",
- "tokio",
+ "tokio 0.2.22",
  "url 2.1.1",
 ]
 
@@ -1852,7 +1852,7 @@ dependencies = [
  "serde",
  "smallvec",
  "snafu",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -1883,7 +1883,7 @@ dependencies = [
  "serde_yaml",
  "structopt",
  "thiserror",
- "tokio",
+ "tokio 0.3.0",
  "tokio-tls",
  "url 2.1.1",
  "uuid",
@@ -2048,10 +2048,23 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log",
- "miow",
+ "miow 0.2.1",
  "net2",
  "slab",
  "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e53a6ea5f38c0a48ca42159868c6d8e1bd56c0451238856cc08d58563643bdc3"
+dependencies = [
+ "libc",
+ "log",
+ "miow 0.3.5",
+ "ntapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2062,7 +2075,7 @@ checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
  "iovec",
  "libc",
- "mio",
+ "mio 0.6.22",
 ]
 
 [[package]]
@@ -2075,6 +2088,16 @@ dependencies = [
  "net2",
  "winapi 0.2.8",
  "ws2_32-sys",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
+dependencies = [
+ "socket2",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2143,6 +2166,15 @@ dependencies = [
  "rand 0.7.3",
  "signatory",
  "signatory-dalek",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a31937dea023539c72ddae0e3571deadc1414b300483fa7aaec176168cfa9d2"
+dependencies = [
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2215,7 +2247,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
- "tokio",
+ "tokio 0.3.0",
  "www-authenticate",
 ]
 
@@ -2739,7 +2771,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio",
+ "tokio 0.2.22",
  "tokio-rustls",
  "tokio-tls",
  "url 2.1.1",
@@ -3475,8 +3507,27 @@ dependencies = [
  "lazy_static",
  "libc",
  "memchr",
- "mio",
+ "mio 0.6.22",
  "mio-uds",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "slab",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "tokio"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7137dbb0abee577362ccdc7df21605cfcbb949243aeab47dac9ea6ef7d830e21"
+dependencies = [
+ "bytes 0.5.6",
+ "fnv",
+ "futures-core",
+ "lazy_static",
+ "libc",
+ "memchr",
+ "mio 0.7.3",
  "num_cpus",
  "pin-project-lite",
  "signal-hook-registry",
@@ -3487,9 +3538,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "0.2.5"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
+checksum = "d48caa7b66c7a6ec943edf78d21a594fbeb24e536c781da67d5c32edec54103f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3504,7 +3555,7 @@ checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
 dependencies = [
  "futures-core",
  "rustls",
- "tokio",
+ "tokio 0.2.22",
  "webpki",
 ]
 
@@ -3515,7 +3566,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
 dependencies = [
  "native-tls",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -3527,7 +3578,7 @@ dependencies = [
  "futures-util",
  "log",
  "pin-project",
- "tokio",
+ "tokio 0.2.22",
  "tungstenite",
 ]
 
@@ -3542,7 +3593,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -3556,7 +3607,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -3633,7 +3684,7 @@ dependencies = [
  "rand 0.7.3",
  "smallvec",
  "socket2",
- "tokio",
+ "tokio 0.2.22",
  "url 2.1.1",
 ]
 
@@ -3652,7 +3703,7 @@ dependencies = [
  "lru-cache",
  "resolv-conf",
  "smallvec",
- "tokio",
+ "tokio 0.2.22",
  "trust-dns-proto",
 ]
 
@@ -3883,7 +3934,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio",
+ "tokio 0.2.22",
  "tokio-rustls",
  "tokio-tungstenite",
  "tower-service",
@@ -4006,7 +4057,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tempfile",
- "tokio",
+ "tokio 0.3.0",
  "wascc-codec",
  "wascc-fs",
  "wascc-host",
@@ -4066,7 +4117,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tempfile",
- "tokio",
+ "tokio 0.3.0",
  "wasi-common",
  "wasmtime",
  "wasmtime-wasi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ rustls-tls = [
 
 [dependencies]
 anyhow = "1.0"
-tokio = { version = "0.2", features = ["macros", "rt-threaded", "time"] }
+tokio = { version = "0.3", features = ["macros", "rt-multi-thread", "time"] }
 kube = { version= "0.42", default-features = false }
 k8s-openapi = { version = "0.9", default-features = false, features = ["v1_18"] }
 env_logger = "0.7"

--- a/crates/kubelet/Cargo.toml
+++ b/crates/kubelet/Cargo.toml
@@ -46,7 +46,7 @@ serde_yaml = "0.8"
 hyper = { version = "0.13", default-features = false, features = ["stream"] }
 log = "0.4"
 reqwest = { version = "0.10", default-features = false, features = ["json", "stream"]}
-tokio  = { version = "0.2", features = ["fs", "stream", "macros", "signal"] }
+tokio  = { version = "0.3", features = ["fs", "stream", "macros", "signal"] }
 kube = { version= "0.42", default-features = false }
 kube-runtime = { version= "0.42", default-features = false }
 k8s-openapi = { version = "0.9", default-features = false, features = ["v1_18"] }

--- a/crates/kubelet/src/backoff/mod.rs
+++ b/crates/kubelet/src/backoff/mod.rs
@@ -11,7 +11,7 @@ pub trait BackoffStrategy: Send {
     fn next_duration(&mut self) -> Duration;
     /// Waits the prescribed amount of time (as per `next_duration`).
     async fn wait(&mut self) {
-        tokio::time::delay_for(self.next_duration()).await
+        tokio::time::sleep(self.next_duration()).await
     }
 }
 

--- a/crates/kubelet/src/kubelet.rs
+++ b/crates/kubelet/src/kubelet.rs
@@ -196,7 +196,7 @@ async fn start_node_updater(client: kube::Client, node_name: String) -> anyhow::
     let sleep_interval = std::time::Duration::from_secs(10);
     loop {
         node::update(&client, &node_name).await;
-        tokio::time::delay_for(sleep_interval).await;
+        tokio::time::sleep(sleep_interval).await;
     }
 }
 
@@ -213,7 +213,7 @@ async fn start_signal_handler(
             node::drain(&client, &node_name).await?;
             break Ok(());
         }
-        tokio::time::delay_for(duration).await;
+        tokio::time::sleep(duration).await;
     }
 }
 

--- a/crates/kubelet/src/log/mod.rs
+++ b/crates/kubelet/src/log/mod.rs
@@ -165,7 +165,7 @@ pub async fn stream<R: AsyncRead + std::marker::Unpin>(
                 Err(SendError::Abnormal(e)) => bail!(e),
             }
 
-            tokio::time::delay_for(std::time::Duration::from_millis(500)).await;
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
         }
     }
 

--- a/crates/kubelet/src/node/mod.rs
+++ b/crates/kubelet/src/node/mod.rs
@@ -33,7 +33,7 @@ macro_rules! retry {
                     if $on_err(e, n) {
                         break result;
                     };
-                    tokio::time::delay_for(duration).await;
+                    tokio::time::sleep(duration).await;
                     duration *= (n + 1) as u32;
                     if n == $num_times {
                         break result;

--- a/crates/oci-distribution/Cargo.toml
+++ b/crates/oci-distribution/Cargo.toml
@@ -39,7 +39,7 @@ regex = "1.3"
 reqwest = { version = "0.10", default-features = false, features = ["json", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version  = "0.2", features = ["macros", "fs"] }
+tokio = { version  = "0.3", features = ["macros", "fs"] }
 www-authenticate = "0.3"
 
 [dev-dependencies]

--- a/crates/wascc-provider/Cargo.toml
+++ b/crates/wascc-provider/Cargo.toml
@@ -29,7 +29,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 kube = { version= "0.42", default-features = false }
 kubelet = { path = "../kubelet", version = "0.5", default-features = false, features = ["derive"] }
-tokio = { version = "0.2", features = ["fs", "macros"] }
+tokio = { version = "0.3", features = ["fs", "macros"] }
 chrono = { version = "0.4", features = ["serde"] }
 tempfile = "3.1"
 wascc-codec = "0.8"

--- a/crates/wascc-provider/src/states/error.rs
+++ b/crates/wascc-provider/src/states/error.rs
@@ -20,7 +20,7 @@ impl State<PodState> for Error {
             pod_state.errors = 0;
             Transition::next(self, CrashLoopBackoff)
         } else {
-            tokio::time::delay_for(std::time::Duration::from_secs(5)).await;
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
             Transition::next(self, Registered)
         }
     }

--- a/crates/wascc-provider/src/states/running.rs
+++ b/crates/wascc-provider/src/states/running.rs
@@ -16,7 +16,7 @@ impl State<PodState> for Running {
         // Wascc has no notion of exiting so we just sleep.
         // I _think_ that periodically awaiting will allow the task to be interrupted.
         loop {
-            tokio::time::delay_for(std::time::Duration::from_secs(10)).await;
+            tokio::time::sleep(std::time::Duration::from_secs(10)).await;
         }
     }
 

--- a/crates/wasi-provider/Cargo.toml
+++ b/crates/wasi-provider/Cargo.toml
@@ -34,7 +34,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 kubelet = { path = "../kubelet", version = "0.5", default-features = false, features= ["derive"] }
 wat = "1.0"
-tokio = { version = "0.2", features = ["fs", "stream", "macros", "io-util", "sync"] }
+tokio = { version = "0.3", features = ["fs", "stream", "macros", "io-util", "sync"] }
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
 k8s-openapi = { version = "0.9", default-features = false, features = ["v1_18"] }

--- a/crates/wasi-provider/src/states/error.rs
+++ b/crates/wasi-provider/src/states/error.rs
@@ -20,7 +20,7 @@ impl State<PodState> for Error {
             pod_state.errors = 0;
             Transition::next(self, CrashLoopBackoff)
         } else {
-            tokio::time::delay_for(std::time::Duration::from_secs(5)).await;
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
             Transition::next(self, Registered)
         }
     }

--- a/src/krustlet-wascc.rs
+++ b/src/krustlet-wascc.rs
@@ -6,7 +6,7 @@ use kubelet::Kubelet;
 use std::sync::Arc;
 use wascc_provider::WasccProvider;
 
-#[tokio::main(threaded_scheduler)]
+#[tokio::main(flavor = "multi_thread")]
 async fn main() -> anyhow::Result<()> {
     // The provider is responsible for all the "back end" logic. If you are creating
     // a new Kubelet, all you need to implement is a provider.

--- a/src/krustlet-wasi.rs
+++ b/src/krustlet-wasi.rs
@@ -6,7 +6,7 @@ use kubelet::Kubelet;
 use std::sync::Arc;
 use wasi_provider::WasiProvider;
 
-#[tokio::main(threaded_scheduler)]
+#[tokio::main(flavor = "multi_thread")]
 async fn main() -> anyhow::Result<()> {
     // The provider is responsible for all the "back end" logic. If you are creating
     // a new Kubelet, all you need to implement is a provider.

--- a/tests/podsmiter/src/main.rs
+++ b/tests/podsmiter/src/main.rs
@@ -5,7 +5,7 @@ use kube::api::{Api, DeleteParams, ListParams};
 
 const E2E_NS_PREFIXES: &[&str] = &["wascc-e2e", "wasi-e2e"];
 
-#[tokio::main(threaded_scheduler)]
+#[tokio::main(flavor = "multi_thread")]
 async fn main() -> anyhow::Result<()> {
     let result = smite_all_integration_test_pods().await;
 


### PR DESCRIPTION
This commit updates Krustlet's Tokio version to `0.3.0` and updates Krustlet's
use of Tokio API wherever there were breaking changes. As a result, it compiles.

Krustlet will not run, however, and tests will not pass because futures created
by crates which have not been updated will panic due to the lack of a compatible runtime.

To run these futures, we must identify each one, bring `tokio_compat_02::FutureExt` in scope,
and call `compat()` on the future. This appears to work quite nicely and I have not noticed
any issues with tasks from both version interacting with each other (in limited testing).

The concern I have is that this will run `0.2.x` tasks in a separate, single-threaded runtime.
I believe this may have some performance issues, but this will be made more clear once we compile
a list of the futures in question.