### PR TITLE
update rust and install rustfmt/clippy on macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,14 @@ jobs:
           OS=$(echo "${{ runner.os }}" | tr '[:upper:]' '[:lower:]')
           echo ::set-env name=RUNNER_OS::$OS
 
+      # hack(bacongobbler): install rustfmt to work around darwin toolchain issues
+      - name: "(macOS) install dev tools"
+        if: runner.os == 'macOS'
+        run: |
+          rustup component add rustfmt --toolchain stable-x86_64-apple-darwin
+          rustup component add clippy --toolchain stable-x86_64-apple-darwin
+          rustup update stable
+
       - name: build release
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
release builds are failing because the macOS runners uses an older version of Rust. Adding the same hack from the build workflow should resolve the issue.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>