### PR TITLE
pass all environment variables to each capability

### DIFF
--- a/crates/wascc-provider/src/states/starting.rs
+++ b/crates/wascc-provider/src/states/starting.rs
@@ -14,11 +14,12 @@ use kubelet::state::prelude::*;
 use crate::rand::Rng;
 use crate::PodState;
 use crate::VolumeBinding;
-use crate::{wascc_run, ActorHandle, LogHandleFactory, WasccProvider};
+use crate::{
+    fail_fatal, transition_to_error, wascc_run, ActorHandle, LogHandleFactory, WasccProvider,
+};
 
 use super::error::Error;
 use super::running::Running;
-use crate::{fail_fatal, transition_to_error};
 
 #[derive(Debug)]
 struct PortAllocationError;


### PR DESCRIPTION
Prior versions only passed a shortlist of known configuration to each capability. This PR passes the entire environment variable tree to each waSCC capabililty.

This effectively does nothing at the moment, but if we are to implement a way for users to provide their own capability providers, then they can populate those capabilities with their pod's environment variables.

closes #338