### PR TITLE
remove unused flags

### DIFF
--- a/docs/howto/krustlet-on-wsl2.md
+++ b/docs/howto/krustlet-on-wsl2.md
@@ -4,6 +4,7 @@ This how-to guide demonstrates how to boot a Krustlet node in Docker Desktop for
 backend.
 
 ## Information
+
 This tutorial will work on current Windows 10 Insider Slow ring and Docker Desktop for Windows
 stable release.
 
@@ -82,7 +83,7 @@ Once you have done that, run the following commands to run Krustlet's WASI provi
 # Since you are running locally, this step is important. Otherwise krustlet will pick up on your
 # local config and not be able to update the node status properly
 $ export KUBECONFIG=~/.krustlet/config/kubeconfig
-$ krustlet-wasi --node-ip $mainIP --node-name krustlet --cert-file=~/.krustlet/config/krustlet.crt --private-key-file=~/.krustlet/config/krustlet.key --bootstrap-file=~/.krustlet/config/bootstrap.conf
+$ krustlet-wasi --node-ip $mainIP --node-name krustlet --bootstrap-file=~/.krustlet/config/bootstrap.conf
 ```
 
 ### Step 3a: Approving the serving CSR


### PR DESCRIPTION
These flags are not referenced or utilized anywhere in the HOWTO guide, and are using the default values for these flags, so they are safe to remove from the flag list. It just confuses the reader.

ref: #447

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>