### PR TITLE
oci-distribution Push functionality

### DIFF
--- a/crates/kubelet/src/store/oci/file.rs
+++ b/crates/kubelet/src/store/oci/file.rs
@@ -89,7 +89,7 @@ impl Storer for FileStorer {
         if image_data.layers.is_empty() {
             return Err(anyhow::anyhow!("No module layer present in image data"));
         }
-        tokio::fs::write(&module_path, &image_data.layers[0]).await?;
+        tokio::fs::write(&module_path, &image_data.layers[0].data).await?;
         if let Some(d) = image_data.digest {
             tokio::fs::write(&digest_path, d).await?;
         }
@@ -131,7 +131,7 @@ mod test {
     use super::*;
     use crate::container::PullPolicy;
     use crate::store::Store;
-    use oci_distribution::client::ImageData;
+    use oci_distribution::client::{ImageData, ImageLayer};
     use oci_distribution::secrets::RegistryAuth;
     use std::collections::HashMap;
     use std::convert::TryFrom;
@@ -176,7 +176,7 @@ mod test {
                 images.insert(
                     name.to_owned(),
                     ImageData {
-                        layers: vec![content],
+                        layers: vec![ImageLayer::oci_v1(content)],
                         digest: Some(digest.to_owned()),
                     },
                 );
@@ -192,7 +192,7 @@ mod test {
             images.insert(
                 key.to_owned(),
                 ImageData {
-                    layers: vec![content],
+                    layers: vec![ImageLayer::oci_v1(content)],
                     digest: Some(digest.to_owned()),
                 },
             );

--- a/crates/oci-distribution/Cargo.toml
+++ b/crates/oci-distribution/Cargo.toml
@@ -39,6 +39,7 @@ regex = "1.3"
 reqwest = { version = "0.10", default-features = false, features = ["json", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha2 = "0.9.2"
 tokio = { version  = "0.2", features = ["macros", "fs"] }
 www-authenticate = "0.3"
 

--- a/crates/oci-distribution/src/manifest.rs
+++ b/crates/oci-distribution/src/manifest.rs
@@ -3,6 +3,8 @@ use std::collections::HashMap;
 
 /// The mediatype for WASM layers.
 pub const WASM_LAYER_MEDIA_TYPE: &str = "application/vnd.wasm.content.layer.v1+wasm";
+/// The mediatype for a WASM image config.
+pub const WASM_CONFIG_MEDIA_TYPE: &str = "application/vnd.wasm.config.v1+json";
 /// The mediatype for an OCI manifest.
 pub const IMAGE_MANIFEST_MEDIA_TYPE: &str = "application/vnd.docker.distribution.manifest.v2+json";
 /// The mediatype for an image config (manifest).
@@ -26,7 +28,7 @@ pub const IMAGE_LAYER_NONDISTRIBUTABLE_GZIP_MEDIA_TYPE: &str =
 ///
 /// It is part of the OCI specification, and is defined here:
 /// https://github.com/opencontainers/image-spec/blob/master/manifest.md
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OciManifest {
     /// This is a schema version.
@@ -90,7 +92,7 @@ pub struct Versioned {
 ///
 /// It is defined in the OCI Image Specification:
 /// https://github.com/opencontainers/image-spec/blob/master/descriptor.md#properties
-#[derive(Clone, Debug, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OciDescriptor {
     /// The media type of this descriptor.

--- a/crates/oci-distribution/src/secrets.rs
+++ b/crates/oci-distribution/src/secrets.rs
@@ -8,6 +8,14 @@ pub enum RegistryAuth {
     Basic(String, String),
 }
 
+/// Desired operation for registry authentication
+pub enum RegistryOperation {
+    /// Authenticate for push operations
+    Push,
+    /// Authenticate for pull operations
+    Pull,
+}
+
 pub(crate) trait Authenticable {
     fn apply_authentication(self, auth: &RegistryAuth) -> Self;
 }


### PR DESCRIPTION
This PR includes the `push` function, which implements https://github.com/opencontainers/distribution-spec/blob/master/spec.md#push.

There are two tests that I didn't include as they involved a private registry and credentials:
- Pushing a wasm to a registry with Basic authentication [PASS]
- Pushing a non-wasm file (wascc provider archive) to a registry with Basic authentication [PASS]

I have also used a registry `oci.registry.local`, which I've pointed to a local unauthenticated docker registry, for my tests, and I'm open to modifying that depending on how this project aims to test this crate.

It involves a semver bump to `0.5.0` because the API for `auth` and `pull` changed to include the type of authentication, which is stored as the `RegistryOperation` enum.

Looking forward to your feedback! 🚀 