### PR TITLE
fix workflow syntax

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
       - uses: actions/upload-artifact@v1
         with:
           name: krustlet
-          path: _dist/krustlet-${RELEASE_VERSION}-${RUNNER_OS}-${{ matrix.config.arch }}.tar.gz
+          path: _dist/krustlet-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
   publish:
     name: publish release assets
     runs-on: ubuntu-latest


### PR DESCRIPTION
Arguments need to use the context and expression syntax rather than bash variables.

https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions#contexts

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>