### PR TITLE
PVC mount support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1980,6 +1980,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "k8s-csi"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "199b989c1b16edd6bb7734b09eded95e01d96330461083200e8fbc06c618a512"
+dependencies = [
+ "prost",
+ "prost-build",
+ "prost-types",
+ "tonic",
+ "tonic-build 0.2.0",
+]
+
+[[package]]
 name = "k8s-openapi"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2143,6 +2156,7 @@ dependencies = [
  "hyper",
  "iovec",
  "json-patch",
+ "k8s-csi",
  "k8s-openapi",
  "kernel32-sys",
  "krator",
@@ -2169,7 +2183,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tonic",
- "tonic-build",
+ "tonic-build 0.3.1",
  "tower",
  "url 2.1.1",
  "uuid",
@@ -4164,6 +4178,7 @@ dependencies = [
  "prost",
  "prost-derive",
  "tokio",
+ "tokio-rustls",
  "tokio-util 0.3.1",
  "tower",
  "tower-balance",
@@ -4172,6 +4187,18 @@ dependencies = [
  "tower-service",
  "tracing",
  "tracing-futures",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d8d21cb568e802d77055ab7fcd43f0992206de5028de95c8d3a41118d32e8e"
+dependencies = [
+ "proc-macro2",
+ "prost-build",
+ "quote 1.0.7",
+ "syn 1.0.42",
 ]
 
 [[package]]

--- a/crates/kubelet/Cargo.toml
+++ b/crates/kubelet/Cargo.toml
@@ -50,6 +50,7 @@ tokio  = { version = "0.2", features = ["fs", "stream", "macros", "signal", "uds
 kube = { version = "0.42", default-features = false }
 kube-runtime = { version= "0.42", default-features = false }
 k8s-openapi = { version = "0.9", default-features = false, features = ["v1_18"] }
+k8s-csi = "0.2"
 chrono = { version = "0.4", features = ["serde"] }
 structopt = { version = "0.3", features = ["wrap_help"], optional = true }
 hostname = "0.3"
@@ -63,6 +64,7 @@ rcgen = "0.8"
 uuid = { version = "0.8.1", features = ["v4"] }
 krator = { path = "../krator", version = "0.1", default-features = false }
 json-patch = "0.2"
+tempdir = "0.3"
 tonic = "0.3"
 # prost is needed for the files built by the protobuf
 prost = "0.6"
@@ -84,7 +86,6 @@ ws2_32-sys = "0.2.1"
 bytes = "0.3"
 env_logger = { version = "0.4", default-features = false }
 slab = "0.4"
-tempdir = "0.3"
 version-sync = "0.5"
 
 [dev-dependencies]

--- a/crates/kubelet/proto/pluginregistration/v1/pluginregistration.proto
+++ b/crates/kubelet/proto/pluginregistration/v1/pluginregistration.proto
@@ -4,55 +4,52 @@
 // kubernetes
 syntax = 'proto3';
 
-// NOTE: This has been modified with a more descriptive name and the section
-// with the gogoproto has been removed (as this is not Go). Everything else is
+// NOTE: The section with the gogoproto has been removed (as this is not Go). Everything else is
 // unchanged
-package pluginregistration.v1;
+package pluginregistration;
 
-// PluginInfo is the message sent from a plugin to the Kubelet pluginwatcher for
-// plugin registration
+// PluginInfo is the message sent from a plugin to the Kubelet pluginwatcher for plugin registration
 message PluginInfo {
-  // Type of the Plugin. CSIPlugin or DevicePlugin
-  string type = 1;
-  // Plugin name that uniquely identifies the plugin for the given plugin type.
-  // For DevicePlugin, this is the resource name that the plugin manages and
-  // should follow the extended resource name convention.
-  // For CSI, this is the CSI driver registrar name.
-  string name = 2;
-  // Optional endpoint location. If found set by Kubelet component,
-  // Kubelet component will use this endpoint for specific requests.
-  // This allows the plugin to register using one endpoint and possibly use
-  // a different socket for control operations. CSI uses this model to delegate
-  // its registration external from the plugin.
-  string endpoint = 3;
-  // Plugin service API versions the plugin supports.
-  // For DevicePlugin, this maps to the deviceplugin API versions the
-  // plugin supports at the given socket.
-  // The Kubelet component communicating with the plugin should be able
-  // to choose any preferred version from this list, or returns an error
-  // if none of the listed versions is supported.
-  repeated string supported_versions = 4;
+	// Type of the Plugin. CSIPlugin or DevicePlugin
+	string type = 1;
+	// Plugin name that uniquely identifies the plugin for the given plugin type.
+	// For DevicePlugin, this is the resource name that the plugin manages and
+	// should follow the extended resource name convention.
+	// For CSI, this is the CSI driver registrar name.
+	string name = 2;
+	// Optional endpoint location. If found set by Kubelet component,
+	// Kubelet component will use this endpoint for specific requests.
+	// This allows the plugin to register using one endpoint and possibly use
+	// a different socket for control operations. CSI uses this model to delegate
+	// its registration external from the plugin.
+	string endpoint = 3;
+	// Plugin service API versions the plugin supports.
+	// For DevicePlugin, this maps to the deviceplugin API versions the
+	// plugin supports at the given socket.
+	// The Kubelet component communicating with the plugin should be able
+	// to choose any preferred version from this list, or returns an error
+	// if none of the listed versions is supported.
+	repeated string supported_versions = 4;
 }
 
-// RegistrationStatus is the message sent from Kubelet pluginwatcher to the
-// plugin for notification on registration status
+// RegistrationStatus is the message sent from Kubelet pluginwatcher to the plugin for notification on registration status
 message RegistrationStatus {
-  // True if plugin gets registered successfully at Kubelet
-  bool plugin_registered = 1;
-  // Error message in case plugin fails to register, empty string otherwise
-  string error = 2;
+	// True if plugin gets registered successfully at Kubelet
+	bool plugin_registered  = 1;
+	// Error message in case plugin fails to register, empty string otherwise
+	string error  = 2;
 }
 
-// RegistrationStatusResponse is sent by plugin to kubelet in response to
-// RegistrationStatus RPC
-message RegistrationStatusResponse {}
+// RegistrationStatusResponse is sent by plugin to kubelet in response to RegistrationStatus RPC
+message RegistrationStatusResponse {
+}
 
 // InfoRequest is the empty request message from Kubelet
-message InfoRequest {}
+message InfoRequest {
+}
 
 // Registration is the service advertised by the Plugins.
 service Registration {
-  rpc GetInfo(InfoRequest) returns (PluginInfo) {}
-  rpc NotifyRegistrationStatus(RegistrationStatus)
-      returns (RegistrationStatusResponse) {}
+	rpc GetInfo(InfoRequest) returns (PluginInfo) {}
+	rpc NotifyRegistrationStatus(RegistrationStatus) returns (RegistrationStatusResponse) {}
 }

--- a/crates/kubelet/src/lib.rs
+++ b/crates/kubelet/src/lib.rs
@@ -8,6 +8,7 @@
 //! ```rust,no_run
 //! use kubelet::Kubelet;
 //! use kubelet::config::Config;
+//! use kubelet::plugin_watcher::PluginRegistry;
 //! use kubelet::pod::Pod;
 //! use kubelet::provider::Provider;
 //! use std::sync::Arc;
@@ -43,7 +44,11 @@
 //!     fn provider_state(&self) -> SharedState<ProviderState> {
 //!         Arc::new(RwLock::new(ProviderState {}))
 //!     }
-//!    
+//!
+//!     fn plugin_registry(&self) -> Option<Arc<PluginRegistry>> {
+//!         Some(Arc::new(Default::default()))
+//!     }
+//!
 //!     async fn initialize_pod_state(&self, _pod: &Pod) -> anyhow::Result<Self::PodState> {
 //!         Ok(PodState)
 //!     }
@@ -79,9 +84,9 @@ pub(crate) mod kubeconfig;
 pub(crate) mod webserver;
 pub(crate) mod plugin_registration_api {
     pub(crate) mod v1 {
-        pub const API_VERSION: &str = "v1";
+        pub const API_VERSION: &str = "1.0.0";
 
-        tonic::include_proto!("pluginregistration.v1");
+        tonic::include_proto!("pluginregistration");
     }
 }
 pub(crate) mod fs_watch;
@@ -89,7 +94,6 @@ pub(crate) mod grpc_sock;
 #[cfg(target_family = "windows")]
 #[allow(dead_code)]
 pub(crate) mod mio_uds_windows;
-pub(crate) mod plugin_watcher;
 
 pub mod backoff;
 pub mod config;
@@ -97,6 +101,7 @@ pub mod container;
 pub mod handle;
 pub mod log;
 pub mod node;
+pub mod plugin_watcher;
 pub mod pod;
 pub mod provider;
 pub mod secret;

--- a/crates/kubelet/src/plugin_watcher/mod.rs
+++ b/crates/kubelet/src/plugin_watcher/mod.rs
@@ -1,3 +1,4 @@
+//! The Kubelet plugin manager. Used to lookup which plugins are registered with this node.
 use crate::fs_watch::FileSystemWatcher;
 use crate::grpc_sock;
 use crate::plugin_registration_api::v1::{

--- a/crates/kubelet/src/state/common/mod.rs
+++ b/crates/kubelet/src/state/common/mod.rs
@@ -3,6 +3,7 @@
 //! states in many providers; instead, the provider need only implement the
 //! GenericProviderState and GenericPodState traits for its state types.
 
+use crate::plugin_watcher::PluginRegistry;
 use crate::pod::state::prelude::PodStatus;
 use crate::pod::Pod;
 use krator::{ObjectState, State};
@@ -43,6 +44,10 @@ pub trait GenericProviderState: 'static + Send + Sync {
     fn store(&self) -> std::sync::Arc<dyn crate::store::Store + Sync + Send>;
     /// Gets the path at which to construct temporary directories for volumes.
     fn volume_path(&self) -> std::path::PathBuf;
+    /// Gets the plugin registry used to fetch volume plugins
+    fn plugin_registry(&self) -> Option<std::sync::Arc<PluginRegistry>> {
+        None
+    }
     /// Stops the specified pod. This typically involves tearing down a
     /// runtime or other execution environment.
     async fn stop(&self, pod: &crate::pod::Pod) -> anyhow::Result<()>;

--- a/crates/kubelet/src/state/common/terminated.rs
+++ b/crates/kubelet/src/state/common/terminated.rs
@@ -1,7 +1,10 @@
 //! Pod was deleted.
+use log::error;
 
 use super::{GenericProvider, GenericProviderState};
 use crate::pod::state::prelude::*;
+use crate::state::common::error::Error;
+use crate::volume::Ref;
 
 /// Pod was deleted.
 pub struct Terminated<P: GenericProvider> {
@@ -33,6 +36,24 @@ impl<P: GenericProvider> State<P::PodState> for Terminated<P> {
         let pod = pod.latest();
 
         let state_reader = provider_state.read().await;
+        // TODO: move this out of the state machine and into krator via a
+        // deregistration hook
+        //
+        // https://github.com/deislabs/krustlet/issues/504
+        match Ref::unmount_volumes_from_pod(
+            &state_reader.volume_path(),
+            &pod,
+            &state_reader.client(),
+            state_reader.plugin_registry(),
+        )
+        .await
+        {
+            Ok(_) => {}
+            Err(e) => {
+                // report the error, but carry on. Volume unmount failures should not result in a panic()
+                error!("{:?}", e);
+            }
+        };
         // TODO: In original code, pod key was stored in state rather than
         // re-derived.  Is this important e.g. could pod mutate in ways
         // that invalidate the key assigned on startup?

--- a/crates/kubelet/src/volume/configmap.rs
+++ b/crates/kubelet/src/volume/configmap.rs
@@ -1,0 +1,42 @@
+use std::path::PathBuf;
+
+use k8s_openapi::api::core::v1::{ConfigMap, KeyToPath};
+
+use super::*;
+
+pub(crate) async fn populate(
+    config_map: ConfigMap,
+    path: &PathBuf,
+    items: &Option<Vec<KeyToPath>>,
+) -> anyhow::Result<VolumeType> {
+    tokio::fs::create_dir_all(path).await?;
+    let binary_data = config_map.binary_data.unwrap_or_default();
+    let binary_data = binary_data.into_iter().map(|(key, data)| async move {
+        match mount_setting_for(&key, items) {
+            ItemMount::MountAt(mount_path) => {
+                let file_path = path.join(mount_path);
+                tokio::fs::write(file_path, &data.0).await
+            }
+            ItemMount::DoNotMount => Ok(()),
+        }
+    });
+    let binary_data = futures::future::join_all(binary_data);
+    let data = config_map.data.unwrap_or_default();
+    let data = data.into_iter().map(|(key, data)| async move {
+        match mount_setting_for(&key, items) {
+            ItemMount::MountAt(mount_path) => {
+                let file_path = path.join(mount_path);
+                tokio::fs::write(file_path, data).await
+            }
+            ItemMount::DoNotMount => Ok(()),
+        }
+    });
+    let data = futures::future::join_all(data);
+    let (binary_data, data) = futures::future::join(binary_data, data).await;
+    binary_data
+        .into_iter()
+        .chain(data)
+        .collect::<tokio::io::Result<_>>()?;
+
+    Ok(VolumeType::ConfigMap)
+}

--- a/crates/kubelet/src/volume/hostpath.rs
+++ b/crates/kubelet/src/volume/hostpath.rs
@@ -1,0 +1,9 @@
+use k8s_openapi::api::core::v1::HostPathVolumeSource;
+
+use super::*;
+
+pub(crate) async fn populate(hostpath: &HostPathVolumeSource) -> anyhow::Result<VolumeType> {
+    // Check the the directory exists on the host
+    tokio::fs::metadata(&hostpath.path).await?;
+    Ok(VolumeType::HostPath)
+}

--- a/crates/kubelet/src/volume/mod.rs
+++ b/crates/kubelet/src/volume/mod.rs
@@ -1,41 +1,59 @@
-//! A module for use in managing volumes in providers. Use of this module is not mandatory to create
-//! a Provider, but it does provide common implementation logic for supported volume providers.
+//! A module for use in managing volumes in providers. Use of this module is not
+//! mandatory to create a Provider, but it does provide common implementation
+//! logic for supported volume providers.
 use std::collections::HashMap;
 use std::ops::Deref;
 use std::path::PathBuf;
+use std::sync::Arc;
 
-use k8s_openapi::api::core::v1::Volume as KubeVolume;
-use k8s_openapi::api::core::v1::{ConfigMap, KeyToPath, Secret};
-use k8s_openapi::ByteString;
+use tokio::task;
+
+use k8s_openapi::api::core::v1::KeyToPath;
+use k8s_openapi::api::core::v1::{ConfigMap, PersistentVolumeClaim, Secret, Volume as KubeVolume};
 use kube::api::Api;
 use log::{debug, error};
 
+use crate::plugin_watcher::PluginRegistry;
 use crate::pod::Pod;
 
+mod configmap;
+mod hostpath;
+mod persistentvolumeclaim;
+mod secret;
+
+/// type of volume
 #[derive(Debug)]
-enum Type {
+pub enum VolumeType {
+    /// configmap volume
     ConfigMap,
+    /// secret volume
     Secret,
+    /// PVC volume
+    PersistentVolumeClaim,
+    /// hostpath volume
     HostPath,
 }
 
-/// A smart wrapper around the location of a volume on the host system. If this is a ConfigMap or
-/// Secret volume, dropping this reference will clean up the temporary volume. [AsRef] and
-/// [std::ops::Deref] are implemented for this type so you can still use it like a normal PathBuf
+/// A smart wrapper around the location of a volume on the host system. If this
+/// is a ConfigMap or Secret volume, dropping this reference will clean up the
+/// temporary volume. [AsRef] and [std::ops::Deref] are implemented for this
+/// type so you can still use it like a normal PathBuf
 #[derive(Debug)]
 pub struct Ref {
     host_path: PathBuf,
-    volume_type: Type,
+    volume_type: VolumeType,
 }
 
 impl Ref {
-    /// Resolves the volumes for a pod, including preparing temporary directories containing the
-    /// contents of secrets and configmaps. Returns a HashMap of volume names to a PathBuf for the
-    /// directory where the volume is mounted
+    /// Resolves the volumes for a pod, including preparing temporary
+    /// directories containing the contents of secrets and configmaps. Returns a
+    /// HashMap of volume names to a PathBuf for the directory where the volume
+    /// is mounted
     pub async fn volumes_from_pod(
         volume_dir: &PathBuf,
         pod: &Pod,
         client: &kube::Client,
+        plugin_registry: Option<Arc<PluginRegistry>>,
     ) -> anyhow::Result<HashMap<String, Self>> {
         let base_path = volume_dir.join(pod_dir_name(pod));
         tokio::fs::create_dir_all(&base_path).await?;
@@ -43,12 +61,14 @@ impl Ref {
             let volumes = vols.iter().map(|v| {
                 let mut host_path = base_path.clone();
                 host_path.push(&v.name);
+                let pr = plugin_registry.clone();
                 async move {
-                    let volume_type = configure(v, pod.namespace(), client, &host_path).await?;
+                    let volume_type = configure(v, pod.namespace(), client, pr, &host_path).await?;
                     Ok((
                         v.name.to_owned(),
-                        // Every other volume type should mount to the given host_path except for a
-                        // hostpath volume type. So we need to handle that special case here
+                        // Every other volume type should mount to the given
+                        // host_path except for a hostpath volume type. So we
+                        // need to handle that special case here
                         match &v.host_path {
                             Some(hostpath) => Ref {
                                 host_path: PathBuf::from(&hostpath.path),
@@ -70,6 +90,33 @@ impl Ref {
             Ok(HashMap::default())
         }
     }
+
+    /// Unmounts any volumes mounted to the pod. Usually called when dropping
+    /// the pod out of scope.
+    pub async fn unmount_volumes_from_pod(
+        volume_dir: &PathBuf,
+        pod: &Pod,
+        client: &kube::Client,
+        plugin_registry: Option<Arc<PluginRegistry>>,
+    ) -> anyhow::Result<()> {
+        if let Some(vols) = pod.volumes() {
+            let base_path = volume_dir.join(pod_dir_name(pod));
+            for vol in vols {
+                if let Some(pvc_source) = &vol.persistent_volume_claim {
+                    let vol_path = base_path.join(&vol.name);
+                    persistentvolumeclaim::unpopulate(
+                        pvc_source,
+                        client,
+                        pod.namespace(),
+                        plugin_registry.clone(),
+                        &vol_path,
+                    )
+                    .await?;
+                }
+            }
+        }
+        Ok(())
+    }
 }
 
 impl AsRef<PathBuf> for Ref {
@@ -88,8 +135,9 @@ impl Deref for Ref {
 
 impl Drop for Ref {
     fn drop(&mut self) {
-        if matches!(self.volume_type, Type::ConfigMap | Type::Secret) {
-            // TODO: Currently there is no way to do this async (though there is an async destructors proposal)
+        if matches!(self.volume_type, VolumeType::ConfigMap | VolumeType::Secret) {
+            // TODO: Currently there is no way to do this async (though there is
+            // an async destructors proposal)
             debug!(
                 "deleting {:?} directory {:?}",
                 self.volume_type, self.host_path
@@ -102,116 +150,6 @@ impl Drop for Ref {
             });
         }
     }
-}
-
-/// This is a gnarly function to check all of the supported data members of the Volume struct.
-/// Because it isn't a HashMap, we need to check all fields individually
-async fn configure(
-    vol: &KubeVolume,
-    namespace: &str,
-    client: &kube::Client,
-    path: &PathBuf,
-) -> anyhow::Result<Type> {
-    if let Some(cm) = &vol.config_map {
-        populate_from_config_map(
-            &cm.name
-                .as_ref()
-                .ok_or_else(|| anyhow::anyhow!("no configmap name was given"))?,
-            namespace,
-            client,
-            path,
-            &cm.items,
-        )
-        .await
-    } else if let Some(s) = &vol.secret {
-        populate_from_secret(
-            &s.secret_name
-                .as_ref()
-                .ok_or_else(|| anyhow::anyhow!("no secret name was given"))?,
-            namespace,
-            client,
-            path,
-            &s.items,
-        )
-        .await
-    } else if let Some(hostpath) = &vol.host_path {
-        // Check the the directory exists on the host
-        tokio::fs::metadata(&hostpath.path).await?;
-        Ok(Type::HostPath)
-    } else {
-        Err(anyhow::anyhow!(
-            "Unsupported volume type. Currently supported types: ConfigMap, Secret, and HostPath"
-        ))
-    }
-}
-
-async fn populate_from_secret(
-    name: &str,
-    namespace: &str,
-    client: &kube::Client,
-    path: &PathBuf,
-    items: &Option<Vec<KeyToPath>>,
-) -> anyhow::Result<Type> {
-    tokio::fs::create_dir_all(path).await?;
-    let secret_client: Api<Secret> = Api::namespaced(client.clone(), namespace);
-    let secret = secret_client.get(name).await?;
-    let data = secret.data.unwrap_or_default();
-    let data = data.iter().map(|(key, ByteString(data))| async move {
-        match mount_setting_for(key, items) {
-            ItemMount::MountAt(mount_path) => {
-                let file_path = path.join(mount_path);
-                tokio::fs::write(file_path, &data).await
-            }
-            ItemMount::DoNotMount => Ok(()),
-        }
-    });
-    futures::future::join_all(data)
-        .await
-        .into_iter()
-        .collect::<tokio::io::Result<_>>()?;
-
-    Ok(Type::Secret)
-}
-
-async fn populate_from_config_map(
-    name: &str,
-    namespace: &str,
-    client: &kube::Client,
-    path: &PathBuf,
-    items: &Option<Vec<KeyToPath>>,
-) -> anyhow::Result<Type> {
-    tokio::fs::create_dir_all(path).await?;
-    let cm_client: Api<ConfigMap> = Api::namespaced(client.clone(), namespace);
-    let config_map = cm_client.get(name).await?;
-    let binary_data = config_map.binary_data.unwrap_or_default();
-    let binary_data = binary_data.iter().map(|(key, data)| async move {
-        match mount_setting_for(key, items) {
-            ItemMount::MountAt(mount_path) => {
-                let file_path = path.join(mount_path);
-                tokio::fs::write(file_path, &data.0).await
-            }
-            ItemMount::DoNotMount => Ok(()),
-        }
-    });
-    let binary_data = futures::future::join_all(binary_data);
-    let data = config_map.data.unwrap_or_default();
-    let data = data.iter().map(|(key, data)| async move {
-        match mount_setting_for(key, items) {
-            ItemMount::MountAt(mount_path) => {
-                let file_path = path.join(mount_path);
-                tokio::fs::write(file_path, data).await
-            }
-            ItemMount::DoNotMount => Ok(()),
-        }
-    });
-    let data = futures::future::join_all(data);
-    let (binary_data, data) = futures::future::join(binary_data, data).await;
-    binary_data
-        .into_iter()
-        .chain(data)
-        .collect::<tokio::io::Result<_>>()?;
-
-    Ok(Type::ConfigMap)
 }
 
 fn pod_dir_name(pod: &Pod) -> String {
@@ -241,5 +179,42 @@ impl From<Option<String>> for ItemMount {
             None => ItemMount::DoNotMount,
             Some(path) => ItemMount::MountAt(path),
         }
+    }
+}
+
+/// This is a gnarly function to check all of the supported data members of the
+/// Volume struct. Because it isn't a HashMap, we need to check all fields
+/// individually
+async fn configure(
+    vol: &KubeVolume,
+    namespace: &str,
+    client: &kube::Client,
+    plugin_registry: Option<Arc<PluginRegistry>>,
+    path: &PathBuf,
+) -> anyhow::Result<VolumeType> {
+    if let Some(cm) = &vol.config_map {
+        let name = &cm
+            .name
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("no configmap name was given"))?;
+        let cm_client: Api<ConfigMap> = Api::namespaced(client.clone(), namespace);
+        let config_map = cm_client.get(name).await?;
+        configmap::populate(config_map, path, &cm.items).await
+    } else if let Some(s) = &vol.secret {
+        let name = &s
+            .secret_name
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("no secret name was given"))?;
+        let secret_client: Api<Secret> = Api::namespaced(client.clone(), namespace);
+        let secret = secret_client.get(name).await?;
+        secret::populate(secret, path, &s.items).await
+    } else if let Some(pvc_source) = &vol.persistent_volume_claim {
+        persistentvolumeclaim::populate(pvc_source, client, namespace, plugin_registry, path).await
+    } else if let Some(hp) = &vol.host_path {
+        hostpath::populate(hp).await
+    } else {
+        Err(anyhow::anyhow!(
+            "Unsupported volume type. Currently supported types: ConfigMap, Secret, PersistentVolumeClaim, and HostPath"
+        ))
     }
 }

--- a/crates/kubelet/src/volume/persistentvolumeclaim.rs
+++ b/crates/kubelet/src/volume/persistentvolumeclaim.rs
@@ -1,0 +1,423 @@
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use kube;
+
+use k8s_csi::v1_3_0::node_client::NodeClient;
+use k8s_csi::v1_3_0::node_service_capability::{rpc, Rpc, Type as CapabilityType};
+use k8s_csi::v1_3_0::volume_capability::access_mode::Mode as CSIMode;
+use k8s_csi::v1_3_0::volume_capability::{
+    AccessMode as CSIAccessMode, AccessType as CSIAccessType, MountVolume as CSIMountVolume,
+};
+use k8s_csi::v1_3_0::{
+    NodeGetCapabilitiesRequest, NodePublishVolumeRequest, NodeStageVolumeRequest,
+    NodeUnpublishVolumeRequest, NodeUnstageVolumeRequest, VolumeCapability,
+};
+
+use k8s_openapi::api::core::v1::{
+    CSIPersistentVolumeSource, PersistentVolume, PersistentVolumeClaimSpec,
+    PersistentVolumeClaimVolumeSource,
+};
+use k8s_openapi::api::storage::v1::StorageClass;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector;
+
+use tempdir::TempDir;
+use thiserror::Error;
+
+use crate::grpc_sock;
+use crate::plugin_watcher::PluginRegistry;
+
+use super::*;
+
+/// VolumeError describes the possible error states when mounting persistent volume claims.
+#[derive(Error, Debug)]
+enum VolumeError {
+    #[error("bad volume mode")]
+    BadVolumeMode,
+    #[error("bad reclaim policy")]
+    BadReclaimPolicy,
+    #[error("bad access mode")]
+    BadAccessMode,
+}
+
+// Kubernetes supports two volumeModes of PersistentVolumes: Filesystem and
+// Block.
+//
+// volumeMode is an optional API parameter. Filesystem is the default mode used
+// when volumeMode parameter is omitted.
+//
+// A volume with volumeMode: Filesystem is mounted into Pods into a directory.
+// If the volume is backed by a block device and the device is empty,
+// Kuberneretes creates a filesystem on the device before mounting it for the
+// first time.
+//
+// You can set the value of volumeMode to Block to use a volume as a raw block
+// device. Such volume is presented into a Pod as a block device, without any
+// filesystem on it. This mode is useful to provide a Pod the fastest possible
+// way to access a volume, without any filesystem layer between the Pod and the
+// volume. On the other hand, the application running in the Pod must know how
+// to handle a raw block device. See Raw Block Volume Support for an example on
+// how to use a volume with volumeMode: Block in a Pod.
+//
+// https://kubernetes.io/docs/concepts/storage/persistent-volumes/#volume-mode
+#[derive(Debug)]
+enum VolumeMode {
+    Block,
+    Filesystem,
+}
+
+impl FromStr for VolumeMode {
+    type Err = VolumeError;
+
+    // defines what type of volume is required by the claim. The "filesystem"
+    // mode is implied when not included in the claim spec.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Block" => Ok(VolumeMode::Block),
+            "Filesystem" => Ok(VolumeMode::Filesystem),
+            "" => Ok(VolumeMode::Filesystem),
+            _ => Err(VolumeError::BadVolumeMode),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum ReclaimPolicy {
+    Delete,
+    Recycle,
+    Retain,
+}
+
+impl FromStr for ReclaimPolicy {
+    type Err = VolumeError;
+
+    // defines what type of reclaim policy is requested. The "delete" mode is
+    // implied when not included in the storage class or persistent volume.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Delete" => Ok(ReclaimPolicy::Delete),
+            "Recycle" => Ok(ReclaimPolicy::Recycle),
+            "Retain" => Ok(ReclaimPolicy::Retain),
+            "" => Ok(ReclaimPolicy::Delete),
+            _ => Err(VolumeError::BadReclaimPolicy),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum AccessMode {
+    ReadOnlyMany,
+    ReadWriteMany,
+    ReadWriteOnce,
+}
+
+impl FromStr for AccessMode {
+    type Err = VolumeError;
+
+    // defines what type of access mode is requested. An error is returned when
+    // an invalid access mode is provided.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ReadOnlyMany" => Ok(AccessMode::ReadOnlyMany),
+            "ReadWriteMany" => Ok(AccessMode::ReadWriteMany),
+            "ReadWriteOnce" => Ok(AccessMode::ReadWriteOnce),
+            _ => Err(VolumeError::BadAccessMode),
+        }
+    }
+}
+
+// Validates a PersistentVolumeClaimSpec.
+// https://github.com/kubernetes/kubernetes/blob/c970a46bc1bcc100bbbfabd5c12bd4c5d87f8aea/pkg/apis/core/validation/validation.go#L1965
+pub(crate) fn validate(spec: &PersistentVolumeClaimSpec) -> anyhow::Result<()> {
+    match &spec.access_modes {
+        Some(a) => {
+            if a.is_empty() {
+                return Err(anyhow::anyhow!("at least 1 access mode is required"));
+            } else {
+                for access_mode in a {
+                    // validate access modes are correct
+                    AccessMode::from_str(access_mode)?;
+                }
+            }
+        }
+        None => {
+            return Err(anyhow::anyhow!("at least 1 access mode is required"));
+        }
+    }
+
+    if let Some(selector) = &spec.selector {
+        validate_label_selector(selector)?;
+    }
+
+    match &spec.storage_class_name {
+        // no storage class name specified or set to the empty string
+        // means the user requested the "default" storage class. there
+        // is no "default" storage class for Krustlet at this time, so
+        // we treat this as an error case.
+        //
+        // TODO: implement a "default" storage class
+        None => {
+            return Err(anyhow::anyhow!(
+                "PersistentVolumeClaim must specify a storage class"
+            ));
+        }
+        Some(s) => {
+            if s == "" {
+                return Err(anyhow::anyhow!(
+                    "PersistentVolumeClaim must specify a storage class"
+                ));
+            }
+            s
+        }
+    };
+
+    // TODO: validate volume mode
+
+    // TODO: validate data source
+
+    Ok(())
+}
+
+fn validate_label_selector(_selector: &LabelSelector) -> anyhow::Result<()> {
+    // TODO: validate label selectors
+    Ok(())
+}
+
+pub(crate) async fn populate(
+    pvc_source: &PersistentVolumeClaimVolumeSource,
+    client: &kube::Client,
+    namespace: &str,
+    pr: Option<Arc<PluginRegistry>>,
+    path: &PathBuf,
+) -> anyhow::Result<VolumeType> {
+    if pr.is_none() {
+        return Err(anyhow::anyhow!(format!(
+            "failed to mount volume {}: CSI driver support not implemented",
+            &pvc_source.claim_name
+        )));
+    }
+    let plugin_registry = pr.unwrap();
+
+    let spec = get_pvc_spec(pvc_source, client, namespace).await?;
+    let mut csi_client = get_csi_client(client, &spec, plugin_registry).await?;
+    let csi = get_csi(client, pvc_source, &spec).await?;
+    let stage_unstage_volume = supports_stage_unstage(&mut csi_client).await?;
+
+    // we keep this around even if the driver does not support STAGE_UNSTAGE_VOLUME. unmount() still needs it.
+    tokio::fs::create_dir_all(path).await?;
+    // TODO(bacongobbler): implement node_unstage_volume(). We'll need to
+    // persist the staging_path somewhere so we can recall that information
+    // during unpopulate()
+    let staging_path = TempDir::new(&csi.volume_handle)?;
+    if stage_unstage_volume {
+        stage_volume(&mut csi_client, &csi, staging_path.path()).await?;
+    }
+    publish_volume(
+        &mut csi_client,
+        &csi,
+        staging_path.path(),
+        stage_unstage_volume,
+        path,
+    )
+    .await?;
+
+    Ok(VolumeType::PersistentVolumeClaim)
+}
+
+pub(crate) async fn unpopulate(
+    pvc_source: &PersistentVolumeClaimVolumeSource,
+    client: &kube::Client,
+    namespace: &str,
+    pr: Option<Arc<PluginRegistry>>,
+    path: &PathBuf,
+) -> anyhow::Result<()> {
+    if pr.is_none() {
+        return Err(anyhow::anyhow!(format!(
+            "failed to unmount volume {}: CSI driver support not implemented",
+            &pvc_source.claim_name
+        )));
+    }
+    let plugin_registry = pr.unwrap();
+
+    let spec = get_pvc_spec(pvc_source, client, namespace).await?;
+    let mut csi_client = get_csi_client(client, &spec, plugin_registry).await?;
+    let csi = get_csi(client, pvc_source, &spec).await?;
+
+    // https://github.com/kubernetes/kubernetes/blob/6d5cb36d36f34cb4f5735b6adcd5ea8ebb4440ba/pkg/volume/csi/csi_mounter.go#L390
+    unpublish_volume(&mut csi_client, &csi, path).await?;
+    std::fs::remove_dir_all(path)?;
+
+    Ok(())
+}
+
+// checks if the plugin supports the node_stage/unstage_volume API. Assume false if not specified.
+async fn supports_stage_unstage(
+    csi_client: &mut NodeClient<tonic::transport::Channel>,
+) -> anyhow::Result<bool> {
+    let mut stage_unstage_volume = false;
+    let response = csi_client
+        .node_get_capabilities(NodeGetCapabilitiesRequest {})
+        .await?;
+    for capability in &response.get_ref().capabilities {
+        if let Some(typ) = &capability.r#type {
+            let _typ_stage_unstage_volume = rpc::Type::StageUnstageVolume as i32;
+            match typ {
+                CapabilityType::Rpc(Rpc {
+                    r#type: _typ_stage_unstage_volume,
+                }) => {
+                    stage_unstage_volume = true;
+                }
+            }
+        }
+    }
+    Ok(stage_unstage_volume)
+}
+
+async fn stage_volume(
+    csi_client: &mut NodeClient<tonic::transport::Channel>,
+    csi: &CSIPersistentVolumeSource,
+    staging_path: &Path,
+) -> anyhow::Result<()> {
+    // TODO: grab the publish_context and volume_context using the volume attachments API
+    csi_client
+        .node_stage_volume(NodeStageVolumeRequest {
+            volume_id: csi.volume_handle.clone(),
+            staging_target_path: staging_path.to_string_lossy().to_string(),
+            volume_capability: Some(VolumeCapability {
+                // TODO: determine the correct access mode and mount flags from the volume
+                // https://github.com/kubernetes/kubernetes/blob/734889ed822d1a60c6dd61ccd8f1ed0e8ab31ea5/pkg/volume/csi/csi_attacher.go#L325-L333
+                access_mode: Some(CSIAccessMode {
+                    mode: CSIMode::SingleNodeWriter as i32,
+                }),
+                access_type: Some(CSIAccessType::Mount(CSIMountVolume {
+                    fs_type: csi.fs_type.as_ref().map_or("".to_owned(), |s| s.clone()),
+                    mount_flags: Default::default(),
+                })),
+            }),
+            secrets: Default::default(),
+            publish_context: Default::default(),
+            volume_context: Default::default(),
+        })
+        .await?;
+    Ok(())
+}
+
+async fn publish_volume(
+    csi_client: &mut NodeClient<tonic::transport::Channel>,
+    csi: &CSIPersistentVolumeSource,
+    staging_path: &Path,
+    stage_unstage_volume: bool,
+    path: &PathBuf,
+) -> anyhow::Result<()> {
+    let mut req = NodePublishVolumeRequest {
+        volume_id: csi.volume_handle.clone(),
+        target_path: path.to_string_lossy().to_string(),
+        staging_target_path: "".to_owned(),
+        volume_capability: Some(VolumeCapability {
+            // TODO: determine the correct access mode and mount flags from the volume
+            // https://github.com/kubernetes/kubernetes/blob/734889ed822d1a60c6dd61ccd8f1ed0e8ab31ea5/pkg/volume/csi/csi_attacher.go#L325-L333
+            access_mode: Some(CSIAccessMode {
+                mode: CSIMode::SingleNodeWriter as i32,
+            }),
+            access_type: Some(CSIAccessType::Mount(CSIMountVolume {
+                fs_type: csi.fs_type.clone().unwrap_or("".to_owned()),
+                mount_flags: Default::default(),
+            })),
+        }),
+        // hardcode to read/write for now
+        // TODO: determine the correct access mode and mount flags from the volume
+        // https://github.com/kubernetes/kubernetes/blob/734889ed822d1a60c6dd61ccd8f1ed0e8ab31ea5/pkg/volume/csi/csi_attacher.go#L325-L333
+        readonly: false,
+        secrets: Default::default(),
+        publish_context: Default::default(),
+        volume_context: Default::default(),
+    };
+    if stage_unstage_volume {
+        req.staging_target_path = staging_path.to_string_lossy().to_string();
+    }
+    csi_client.node_publish_volume(req).await?;
+    Ok(())
+}
+
+async fn unpublish_volume(
+    csi_client: &mut NodeClient<tonic::transport::Channel>,
+    csi: &CSIPersistentVolumeSource,
+    path: &PathBuf,
+) -> anyhow::Result<()> {
+    let req = NodeUnpublishVolumeRequest {
+        volume_id: csi.volume_handle.clone(),
+        target_path: path.to_string_lossy().to_string(),
+    };
+    csi_client.node_unpublish_volume(req).await?;
+    Ok(())
+}
+
+async fn get_csi_client(
+    client: &kube::Client,
+    spec: &PersistentVolumeClaimSpec,
+    plugin_registry: Arc<PluginRegistry>,
+) -> anyhow::Result<NodeClient<tonic::transport::Channel>> {
+    let storage_class_client: Api<StorageClass> = Api::all(client.clone());
+    // NOTE(bacongobbler): should be safe to unwrap() here after calling
+    // validate(). Storage class names are required as we do not define
+    // a default storage class.
+    //
+    // If we do implement a default storage class, then we'll have to
+    // revisit this assumption (omission of this field implies the
+    // default).
+    //
+    // https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class-1
+    let storage_class = storage_class_client
+        .get(spec.storage_class_name.as_ref().unwrap())
+        .await?;
+    let endpoint = plugin_registry
+        .get_endpoint(&storage_class.provisioner)
+        .await
+        .ok_or(anyhow::anyhow!("could not get CSI plugin endpoint"))?;
+    let chan = grpc_sock::client::socket_channel(endpoint).await?;
+    Ok(NodeClient::new(chan))
+}
+
+async fn get_csi(
+    client: &kube::Client,
+    pvc_source: &PersistentVolumeClaimVolumeSource,
+    spec: &PersistentVolumeClaimSpec,
+) -> anyhow::Result<CSIPersistentVolumeSource> {
+    let volume_name = spec.volume_name.as_ref().ok_or(anyhow::anyhow!(format!(
+        "volume name for PVC {} must exist",
+        pvc_source.claim_name
+    )))?;
+    // TODO(bacongobbler): When a PVC specifies a selector in addition to
+    // requesting a StorageClass, the requirements are ANDed together: only
+    // a PV of the requested class and with the requested labels may be
+    // bound to the PVC.
+    // https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class-1
+    let pv_client: Api<PersistentVolume> = Api::all(client.clone());
+    let pv = pv_client.get(&volume_name).await?;
+
+    // https://github.com/kubernetes/kubernetes/blob/734889ed822d1a60c6dd61ccd8f1ed0e8ab31ea5/pkg/volume/csi/csi_attacher.go#L295-L298
+    let csi = pv
+        .spec
+        .ok_or(anyhow::anyhow!("no PersistentVolume spec defined"))?
+        .csi
+        .ok_or(anyhow::anyhow!("no CSI spec defined"))?;
+    Ok(csi)
+}
+
+async fn get_pvc_spec(
+    pvc_source: &PersistentVolumeClaimVolumeSource,
+    client: &kube::Client,
+    namespace: &str,
+) -> anyhow::Result<PersistentVolumeClaimSpec> {
+    let pvc_client: Api<PersistentVolumeClaim> = Api::namespaced(client.clone(), namespace);
+
+    let pvc = pvc_client.get(&pvc_source.claim_name).await?;
+    let spec = match pvc.spec {
+        Some(s) => s,
+        None => {
+            return Err(anyhow::anyhow!("PersistentVolumeClaim must specify a spec"));
+        }
+    };
+    validate(&spec)?;
+    Ok(spec)
+}

--- a/crates/kubelet/src/volume/secret.rs
+++ b/crates/kubelet/src/volume/secret.rs
@@ -1,0 +1,30 @@
+use std::path::PathBuf;
+
+use k8s_openapi::api::core::v1::{KeyToPath, Secret};
+use k8s_openapi::ByteString;
+
+use super::*;
+
+pub(crate) async fn populate(
+    secret: Secret,
+    path: &PathBuf,
+    items: &Option<Vec<KeyToPath>>,
+) -> anyhow::Result<VolumeType> {
+    tokio::fs::create_dir_all(path).await?;
+    let data = secret.data.unwrap_or_default();
+    let data = data.into_iter().map(|(key, ByteString(data))| async move {
+        match mount_setting_for(&key, items) {
+            ItemMount::MountAt(mount_path) => {
+                let file_path = path.join(mount_path);
+                tokio::fs::write(file_path, &data).await
+            }
+            ItemMount::DoNotMount => Ok(()),
+        }
+    });
+    futures::future::join_all(data)
+        .await
+        .into_iter()
+        .collect::<tokio::io::Result<_>>()?;
+
+    Ok(VolumeType::Secret)
+}

--- a/demos/wasi/hello-csi/README.md
+++ b/demos/wasi/hello-csi/README.md
@@ -1,0 +1,71 @@
+# Hello World Rust for WASI
+
+This is a variant of the hello world example, demonstrating how to use Krustlet
+with the [Container Storage Interface](../../../docs/topics/csi.md).
+
+A simple hello world example in Rust that will print:
+
+- The environment variables available to the process
+- Text to both stdout and stderr.
+- Any args passed to the process
+
+It is meant to be a simple demo for the wasi-provider with Krustlet.
+
+## Running the example
+
+First create the pod, storageclass, and persistentvolumeclaim:
+
+```shell
+$ kubectl apply -f k8s.yaml
+```
+
+You should then be able to get the logs and see the output from the wasm module
+run:
+
+```shell
+$ kubectl logs hello-world-wasi-rust
+hello from stdout!
+hello from stderr!
+FOO=bar
+CONFIG_MAP_VAL=cool stuff
+POD_NAME=hello-world-wasi-rust
+Args are: []
+```
+
+## Building from Source
+
+If you want to compile the demo and inspect it, you'll need to do the following.
+
+### Prerequisites
+
+You'll need to have Rust installed with `wasm32-wasi` target installed:
+
+```shell
+$ rustup target add wasm32-wasi
+```
+
+If you don't have Krustlet with the WASI provider running locally, see the
+instructions in the [tutorial](../../../docs/intro/tutorial03.md) for running
+locally.
+
+You will also need to register the [host-path CSI
+driver](https://github.com/kubernetes-csi/csi-driver-host-path). Details on how
+to register the driver can be found in the [CSI HOWTO
+guide](../../../docs/howto/csi.md).
+
+### Building
+
+Run:
+
+```shell
+$ cd ../hello-world-rust
+$ cargo build --target wasm32-wasi --release
+```
+
+### Pushing
+
+Detailed instructions for pushing a module can be found [here](../../../docs/intro/tutorial02.md).
+
+We hope to improve and streamline the build and push process in the future.
+However, for test purposes, the image has been pushed to the `webassembly`
+Azure Container Registry.

--- a/demos/wasi/hello-csi/k8s.yaml
+++ b/demos/wasi/hello-csi/k8s.yaml
@@ -1,0 +1,57 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-hostpath-sc
+provisioner: hostpath.csi.k8s.io
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+allowVolumeExpansion: true
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: csi-pvc
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: csi-hostpath-sc
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello-world-wasi-rust
+spec:
+  containers:
+    - name: hello-world-wasi-rust
+      image: webassembly.azurecr.io/hello-world-wasi-rust:v0.2.0
+      env:
+        - name: FOO
+          value: bar
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+      volumeMounts:
+        - name: storage
+          mountPath: /mnt/storage
+  volumes:
+    - name: storage
+      persistentVolumeClaim:
+        claimName: csi-pvc
+  nodeSelector:
+    kubernetes.io/arch: "wasm32-wasi"
+  tolerations:
+    - key: "kubernetes.io/arch"
+      operator: "Equal"
+      value: "wasm32-wasi"
+      effect: "NoExecute"
+    - key: "node.kubernetes.io/network-unavailable"
+      operator: "Exists"
+      effect: "NoSchedule"
+    - key: "kubernetes.io/arch"
+      operator: "Equal"
+      value: "wasm32-wasi"
+      effect: "NoSchedule"

--- a/docs/howto/README.md
+++ b/docs/howto/README.md
@@ -20,3 +20,4 @@ quickly accomplish common tasks.
 - [Running Kubernetes on Minikube](kubernetes-on-minikube.md)
 
 - [Running Web Assembly (WASM) workloads in Kubernetes](wasm.md)
+- [Registering a CSI driver](csi.md)

--- a/docs/howto/csi.md
+++ b/docs/howto/csi.md
@@ -1,0 +1,130 @@
+# Registering a CSI Driver
+
+For more information on what is the Container Storage Interface and how it
+relates to a CSI driver, see the [topic guide](../topics/csi.md) for more
+information.
+
+A Krustlet Provider with CSI support will check for new drivers registered to
+the `plugins/` directory (by default, this is `$HOME/.krustlet/plugins`). You
+will need to inform your CSI driver to bind its socket at that location in order
+for a Provider to recognize and register the driver.
+
+You will also need to install and run the following projects so that the
+PersistentVolumeClaim's volume will be provisioned and readily available for
+use:
+
+- [node-driver-registrar](https://github.com/kubernetes-csi/node-driver-registrar)
+- [external-provisioner](https://github.com/kubernetes-csi/external-provisioner)
+
+Do keep in mind that some CSI drivers rely on linux-specific command line
+tooling like `mount`, so these tools may only work on Linux. Cross-platform
+support is not guaranteed. Refer to the driver's documentation for more
+information.
+
+## How do I use a CSI Volume?
+
+Assuming a CSI storage plugin is already deployed on your cluster, you can use
+it through familiar Kubernetes storage primitives: PersistentVolumeClaims,
+PersistentVolumes, and StorageClasses.
+
+A basic example to start with would be the [host-path CSI
+driver](https://github.com/kubernetes-csi/csi-driver-host-path). This project is
+not recommended for use in production, but will work as an example.
+
+To start, we'll need to create a StorageClass. A StorageClass provides a way for
+administrators to describe the "classes" of storage they offer. Different
+classes might map to quality-of-service levels, or to backup policies, or to
+arbitrary policies determined by the cluster administrators. Kubernetes itself
+is unopinionated about what classes represent. This concept is sometimes called
+"profiles" in other storage systems.
+
+The following StorageClass enables dynamic creation of "csi-hostpath-sc" volumes
+by a CSI volume plugin called "hostpath.csi.k8s.io". This storage class will
+also allow for [volume
+expansion](https://github.com/kubernetes-csi/external-resizer).
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-hostpath-sc
+provisioner: hostpath.csi.k8s.io
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+allowVolumeExpansion: true
+```
+
+After installing a StorageClass, we can start creating PersistentVolumeClaims to
+provision and prepare volumes. These will be mounted to Kubernetes Pods that
+request it as a volume. Note how the PVC requests the same StorageClass we
+created earlier.
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: csi-pvc
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: csi-hostpath-sc
+```
+
+A Pod can then request that volume to be mounted by using the `volumes` API.
+
+```yaml
+kind: Pod
+apiVersion: v1
+metadata:
+  name: my-frontend
+spec:
+  containers:
+    - name: my-frontend
+      image: example.com/my-frontend:v1.0.0
+      volumeMounts:
+      - mountPath: "/data"
+        name: my-csi-volume
+  volumes:
+    - name: my-csi-volume
+      persistentVolumeClaim:
+        claimName: csi-pvc
+```
+
+When the pod referencing a CSI volume is scheduled, Krustlet will trigger the
+appropriate operations against the external CSI plugin (ControllerPublishVolume,
+NodePublishVolume, etc.) to ensure the specified volume is attached, mounted,
+and ready to use by the containers in the pod.
+
+## Addendum: Role-based Access Control
+
+In the event that the Pod is erroring saying that the kubelet doesn't have the
+correct admission controls to access storage classes, you'll have to create the
+following cluster role and role binding to allow the `system:nodes` group to
+access them:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: storageclass-reader
+rules:
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: node-storageclass-reader
+subjects:
+  - kind: Group
+    name: system:nodes
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: storageclass-reader
+```

--- a/docs/topics/README.md
+++ b/docs/topics/README.md
@@ -5,5 +5,6 @@ Introductions to all the key components of Krustlet in more detail:
 - [Krustlet architecture](architecture.md)
 - [Providers](providers.md)
 - [Configuration](configuration.md)
+- [The Container Storage Interface](csi.md)
 - [Glossary](glossary.md)
 - [Plugin system](plugin_system.md)

--- a/docs/topics/csi.md
+++ b/docs/topics/csi.md
@@ -1,0 +1,42 @@
+# The Container Storage Interface
+
+The Container Storage Interface (CSI) is a standardized plugin system that
+enables many different types of storage systems to
+
+1. Automatically provision storage volumes as needed
+1. Mount volumes to pods as needed
+1. Unmount volumes from deleted or removed pods, and
+1. Destroy storage volumes after they've been de-commissioned.
+
+Krustlet introduced this feature in v0.6.0 and is currently in alpha status.
+Many features that Kubernetes supports such as "Block" mounting or read-only
+access modes are currently unavailable, but will become available as the feature
+stabilizes.
+
+## Why CSI?
+
+Without CSI support, adding a new storage system to a Provider requires checking
+code into the core Krustlet repository, and it requires each Provider to call
+this code in order to support the new volume type. Any changes to the storage
+system won't become available until the next Krustlet release, and could be
+painful for many Providers to adopt these new changes.
+
+CSI addresses these issues by enabling storage plugins to be developed
+out-of-tree, deployed alongside a Krustlet Provider, and consumed through
+standard Kubernetes storage primitives: PersistentVolumeClaims (PVC),
+PersistentVolumes (PV), and StorageClasses (SC).
+
+## How do I deploy a CSI driver alongside a Krustlet Provider?
+
+Please see the [HOWTO guide](../howto/csi.md) for more information.
+
+## How do I use a CSI Volume?
+
+Please see the [HOWTO guide](../howto/csi.md) for more information.
+
+## Where can I find CSI Drivers?
+
+CSI drivers are maintained and distributed by the community. You can find
+example CSI drivers in the [kubernetes-csi](https://github.com/kubernetes-csi)
+organization on GitHub. These are provided purely for illustrative purposes, and
+are not intended for use in production.

--- a/docs/topics/plugin_system.md
+++ b/docs/topics/plugin_system.md
@@ -38,8 +38,8 @@ registering plugins:
 
 ### Additional information
 
-In normal Kubernetes land, most CSI plugins register themselves with the
-Kubelet using the
-[Node Driver Registrar](https://github.com/kubernetes-csi/node-driver-registrar)
-sidecar container that runs with the actual CSI driver. It has the
-responsibilty for creating the socket that Kubelet discovers.
+In normal Kubernetes land, most CSI plugins register themselves with the Kubelet
+using the [Node Driver
+Registrar](https://github.com/kubernetes-csi/node-driver-registrar) sidecar
+container that runs with the actual CSI driver. It has the responsibilty for
+creating the socket that Kubelet discovers.

--- a/src/krustlet-wascc.rs
+++ b/src/krustlet-wascc.rs
@@ -1,4 +1,5 @@
 use kubelet::config::Config;
+use kubelet::plugin_watcher::PluginRegistry;
 use kubelet::store::composite::ComposableStore;
 use kubelet::store::oci::FileStore;
 use kubelet::Kubelet;
@@ -17,8 +18,9 @@ async fn main() -> anyhow::Result<()> {
     let kubeconfig = kubelet::bootstrap(&config, &config.bootstrap_file, notify_bootstrap).await?;
 
     let store = make_store(&config);
+    let plugin_registry = Arc::new(PluginRegistry::new(&config.plugins_dir));
 
-    let provider = WasccProvider::new(store, &config, kubeconfig.clone()).await?;
+    let provider = WasccProvider::new(store, &config, kubeconfig.clone(), plugin_registry).await?;
     let kubelet = Kubelet::new(provider, kubeconfig, config).await?;
     kubelet.start().await
 }

--- a/src/krustlet-wasi.rs
+++ b/src/krustlet-wasi.rs
@@ -1,4 +1,5 @@
 use kubelet::config::Config;
+use kubelet::plugin_watcher::PluginRegistry;
 use kubelet::store::composite::ComposableStore;
 use kubelet::store::oci::FileStore;
 use kubelet::Kubelet;
@@ -17,8 +18,9 @@ async fn main() -> anyhow::Result<()> {
     let kubeconfig = kubelet::bootstrap(&config, &config.bootstrap_file, notify_bootstrap).await?;
 
     let store = make_store(&config);
+    let plugin_registry = Arc::new(PluginRegistry::new(&config.plugins_dir));
 
-    let provider = WasiProvider::new(store, &config, kubeconfig.clone()).await?;
+    let provider = WasiProvider::new(store, &config, kubeconfig.clone(), plugin_registry).await?;
     let kubelet = Kubelet::new(provider, kubeconfig, config).await?;
     kubelet.start().await
 }


### PR DESCRIPTION
Adds support for mounting PersistentVolumeClaims to a Pod via the Container Storage Interface.

Closes #182