### PR TITLE
Check if service field is provided by auth challenge

### DIFF
--- a/crates/oci-distribution/src/client.rs
+++ b/crates/oci-distribution/src/client.rs
@@ -266,15 +266,21 @@ impl Client {
 
         let challenge = &challenge_opt[0];
         let realm = challenge.realm.as_ref().unwrap();
-        let service = challenge.service.as_ref().unwrap();
+        let service = challenge.service.as_ref();
+        let mut query = vec![("scope", &scope)];
+
+        if service.is_some() {
+            query.push(("service", service.unwrap()))
+        }
 
         // TODO: At some point in the future, we should support sending a secret to the
         // server for auth. This particular workflow is for read-only public auth.
         debug!("Making authentication call to {}", realm);
+
         let auth_res = self
             .client
             .get(realm)
-            .query(&[("service", service), ("scope", &scope)])
+            .query(&query)
             .apply_authentication(authentication)
             .send()
             .await?;


### PR DESCRIPTION
This solves #469 It should be a no brainer.

Trying to request the image from Google Artifacts returns `Bearer realm="https://europe-west1-docker.pkg.dev/v2/token"` without the `service` field. The [Distribution Spec](https://github.com/opencontainers/distribution-spec/blob/master/spec.md) doesn't tell anything about authentication AFAIK.

I found about the service field in the [Docker Registry docs](https://docs.docker.com/registry/configuration/#silly), so it's probably not needed anymore in Artifacts?