### PR TITLE
ref(oci): Fixes nit I missed in inital review

### DIFF
--- a/crates/oci-distribution/src/client.rs
+++ b/crates/oci-distribution/src/client.rs
@@ -269,8 +269,8 @@ impl Client {
         let service = challenge.service.as_ref();
         let mut query = vec![("scope", &scope)];
 
-        if service.is_some() {
-            query.push(("service", service.unwrap()))
+        if let Some(s) = service {
+            query.push(("service", s))
         }
 
         // TODO: At some point in the future, we should support sending a secret to the


### PR DESCRIPTION
I missed this nit when I was reviewing #474. Also contains a `Cargo.lock` update that happened when I built 

cc @bacongobbler 