### PR TITLE
Clippy 1.49.0

### DIFF
--- a/crates/kubelet/src/bootstrapping/mod.rs
+++ b/crates/kubelet/src/bootstrapping/mod.rs
@@ -266,6 +266,9 @@ fn completed_csr_approval(cert_description: &str) -> String {
     )
 }
 
+// Known false positive for non_exhaustive struct `CertificateParams`
+// https://github.com/rust-lang/rust-clippy/issues/6559
+#[allow(clippy::field_reassign_with_default)]
 fn gen_auth_cert(config: &KubeletConfig) -> anyhow::Result<Certificate> {
     let mut params = CertificateParams::default();
     params.not_before = chrono::Utc::now();
@@ -286,6 +289,9 @@ fn gen_auth_cert(config: &KubeletConfig) -> anyhow::Result<Certificate> {
     Ok(Certificate::from_params(params)?)
 }
 
+// Known false positive for non_exhaustive struct `CertificateParams`
+// https://github.com/rust-lang/rust-clippy/issues/6559
+#[allow(clippy::field_reassign_with_default)]
 fn gen_tls_cert(config: &KubeletConfig) -> anyhow::Result<Certificate> {
     let mut params = CertificateParams::default();
     params.not_before = chrono::Utc::now();

--- a/crates/kubelet/src/node/mod.rs
+++ b/crates/kubelet/src/node/mod.rs
@@ -644,32 +644,41 @@ impl Builder {
 
     /// Build node definition from builder.
     pub fn build(self) -> Node {
-        let mut metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta =
-            Default::default();
-        metadata.name = Some(self.name);
-        metadata.annotations = Some(self.annotations);
-        metadata.labels = Some(self.labels);
+        let metadata = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
+            name: Some(self.name),
+            annotations: Some(self.annotations),
+            labels: Some(self.labels),
+            ..Default::default()
+        };
 
-        let mut spec: k8s_openapi::api::core::v1::NodeSpec = Default::default();
-        spec.pod_cidr = Some(self.pod_cidr);
-        spec.taints = Some(self.taints);
+        let spec = k8s_openapi::api::core::v1::NodeSpec {
+            pod_cidr: Some(self.pod_cidr),
+            taints: Some(self.taints),
+            ..Default::default()
+        };
 
-        let mut node_info: k8s_openapi::api::core::v1::NodeSystemInfo = Default::default();
-        node_info.architecture = self.architecture;
-        node_info.kube_proxy_version = self.kube_proxy_version;
-        node_info.kubelet_version = self.kubelet_version;
-        node_info.container_runtime_version = self.container_runtime_version;
-        node_info.operating_system = self.operating_system;
+        let node_info = k8s_openapi::api::core::v1::NodeSystemInfo {
+            architecture: self.architecture,
+            kube_proxy_version: self.kube_proxy_version,
+            kubelet_version: self.kubelet_version,
+            container_runtime_version: self.container_runtime_version,
+            operating_system: self.operating_system,
+            ..Default::default()
+        };
 
-        let mut status: k8s_openapi::api::core::v1::NodeStatus = Default::default();
-        status.node_info = Some(node_info);
-        status.capacity = Some(self.capacity);
-        status.allocatable = Some(self.allocatable);
-        status.daemon_endpoints = Some(k8s_openapi::api::core::v1::NodeDaemonEndpoints {
-            kubelet_endpoint: Some(k8s_openapi::api::core::v1::DaemonEndpoint { port: self.port }),
-        });
-        status.conditions = Some(self.conditions);
-        status.addresses = Some(self.addresses);
+        let status = k8s_openapi::api::core::v1::NodeStatus {
+            node_info: Some(node_info),
+            capacity: Some(self.capacity),
+            allocatable: Some(self.allocatable),
+            daemon_endpoints: Some(k8s_openapi::api::core::v1::NodeDaemonEndpoints {
+                kubelet_endpoint: Some(k8s_openapi::api::core::v1::DaemonEndpoint {
+                    port: self.port,
+                }),
+            }),
+            conditions: Some(self.conditions),
+            addresses: Some(self.addresses),
+            ..Default::default()
+        };
 
         let kube_node = k8s_openapi::api::core::v1::Node {
             metadata,

--- a/crates/oci-distribution/src/client.rs
+++ b/crates/oci-distribution/src/client.rs
@@ -634,18 +634,22 @@ impl Client {
         manifest.config.digest = sha256_digest(config_data);
 
         for layer in image_data.layers.clone() {
-            let mut descriptor: OciDescriptor = OciDescriptor::default();
-            descriptor.size = layer.data.len() as i64;
-            descriptor.digest = sha256_digest(&layer.data);
-            descriptor.media_type = layer.media_type;
+            let digest = sha256_digest(&layer.data);
 
             //TODO: Determine necessity of generating an image title
             let mut annotations = HashMap::new();
             annotations.insert(
                 "org.opencontainers.image.title".to_string(),
-                descriptor.digest.to_string(),
+                digest.to_string(),
             );
-            descriptor.annotations = Some(annotations);
+
+            let descriptor = OciDescriptor {
+                size: layer.data.len() as i64,
+                digest,
+                media_type: layer.media_type,
+                annotations: Some(annotations),
+                ..Default::default()
+            };
 
             manifest.layers.push(descriptor);
         }

--- a/crates/oci-distribution/src/reference.rs
+++ b/crates/oci-distribution/src/reference.rs
@@ -100,13 +100,13 @@ impl Reference {
     pub fn whole(&self) -> String {
         let mut s = self.full_name();
         if let Some(t) = self.tag() {
-            if s != "" {
+            if !s.is_empty() {
                 s.push(':');
             }
             s.push_str(t);
         }
         if let Some(d) = self.digest() {
-            if s != "" {
+            if !s.is_empty() {
                 s.push('@');
             }
             s.push_str(d);

--- a/crates/wascc-provider/src/states/container/waiting.rs
+++ b/crates/wascc-provider/src/states/container/waiting.rs
@@ -75,7 +75,7 @@ async fn assign_container_port(
                     );
                     return Err(anyhow::anyhow!("Port {} is currently in use", &host_port));
                 }
-            } else if container_port >= 0 && container_port <= 65536 {
+            } else if (0..=65536).contains(&container_port) {
                 port_assigned = find_available_port(&port_map, pod).await?;
             }
         }


### PR DESCRIPTION
Addresses new Clippy lints. 

Ignores one type of lint in two locations due to https://github.com/rust-lang/rust-clippy/issues/6559