### PR TITLE
Krator Support for Modified Events

### DIFF
--- a/crates/krator/src/lib.rs
+++ b/crates/krator/src/lib.rs
@@ -2,12 +2,14 @@
 
 #![deny(missing_docs)]
 
+mod manifest;
 mod object;
 mod operator;
 mod runtime;
 
 pub mod state;
 
+pub use manifest::Manifest;
 pub use object::{ObjectState, ObjectStatus};
 pub use operator::Operator;
 pub use runtime::OperatorRuntime;

--- a/crates/krator/src/manifest.rs
+++ b/crates/krator/src/manifest.rs
@@ -1,8 +1,11 @@
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use tokio::stream::Stream;
 use tokio::sync::watch::{channel, Receiver, Sender};
 
-#[derive(Clone)]
 /// Wrapper for `ObjectState::Manifest` type which reflects
 /// the latest version of the object's manifest.
+#[derive(Clone)]
 pub struct Manifest<T: Clone> {
     rx: Receiver<T>,
 }
@@ -20,13 +23,10 @@ impl<T: Clone> Manifest<T> {
     }
 }
 
-impl<T: Clone> tokio::stream::Stream for Manifest<T> {
+impl<T: Clone> Stream for Manifest<T> {
     type Item = T;
 
-    fn poll_next(
-        mut self: core::pin::Pin<&mut Self>,
-        cx: &mut core::task::Context,
-    ) -> core::task::Poll<Option<Self::Item>> {
-        core::pin::Pin::new(&mut self.rx).poll_next(cx)
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.rx).poll_next(cx)
     }
 }

--- a/crates/krator/src/manifest.rs
+++ b/crates/krator/src/manifest.rs
@@ -1,0 +1,32 @@
+use tokio::sync::watch::{channel, Receiver, Sender};
+
+#[derive(Clone)]
+/// Wrapper for `ObjectState::Manifest` type which reflects
+/// the latest version of the object's manifest.
+pub struct Manifest<T: Clone> {
+    rx: Receiver<T>,
+}
+
+impl<T: Clone> Manifest<T> {
+    /// Create a new Manifest wrapper from the initial object manifest.
+    pub fn new(inner: T) -> (Sender<T>, Self) {
+        let (tx, rx) = channel(inner);
+        (tx, Manifest { rx })
+    }
+
+    /// Obtain a clone of the latest object manifest.
+    pub fn latest(&self) -> T {
+        self.rx.borrow().clone()
+    }
+}
+
+impl<T: Clone> tokio::stream::Stream for Manifest<T> {
+    type Item = T;
+
+    fn poll_next(
+        mut self: core::pin::Pin<&mut Self>,
+        cx: &mut core::task::Context,
+    ) -> core::task::Poll<Option<Self::Item>> {
+        core::pin::Pin::new(&mut self.rx).poll_next(cx)
+    }
+}

--- a/crates/krator/src/operator.rs
+++ b/crates/krator/src/operator.rs
@@ -3,6 +3,7 @@ use std::fmt::Debug;
 
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use k8s_openapi::Metadata;
+use tokio::sync::watch::Receiver;
 
 use crate::object::{ObjectState, ObjectStatus};
 use crate::state::{SharedState, State};
@@ -44,7 +45,7 @@ pub trait Operator: 'static + Sync + Send {
     /// Called before the state machine is run.
     async fn registration_hook(
         &self,
-        _manifest: SharedState<Self::Manifest>,
+        mut _manifest: Receiver<Self::Manifest>,
     ) -> anyhow::Result<()> {
         Ok(())
     }

--- a/crates/krator/src/operator.rs
+++ b/crates/krator/src/operator.rs
@@ -3,10 +3,10 @@ use std::fmt::Debug;
 
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use k8s_openapi::Metadata;
-use tokio::sync::watch::Receiver;
 
 use crate::object::{ObjectState, ObjectStatus};
 use crate::state::{SharedState, State};
+use crate::Manifest;
 
 #[async_trait::async_trait]
 /// Interface for creating an operator.
@@ -45,7 +45,7 @@ pub trait Operator: 'static + Sync + Send {
     /// Called before the state machine is run.
     async fn registration_hook(
         &self,
-        mut _manifest: Receiver<Self::Manifest>,
+        mut _manifest: Manifest<Self::Manifest>,
     ) -> anyhow::Result<()> {
         Ok(())
     }

--- a/crates/krator/src/runtime.rs
+++ b/crates/krator/src/runtime.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use futures::{StreamExt, TryStreamExt};
 use log::{debug, error, info, warn};
 use tokio::sync::mpsc::Sender;
+use tokio::sync::watch::{channel, Receiver};
 use tokio::sync::Notify;
-use tokio::sync::RwLock;
 
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use k8s_openapi::Metadata;
@@ -123,16 +123,15 @@ impl<O: Operator> OperatorRuntime<O> {
 
         let deleted = Arc::new(Notify::new());
 
-        let (shared_manifest, object_state) = match initial_event {
+        let (manifest, object_state) = match initial_event {
             Event::Applied(manifest) => {
                 let object_state = self.operator.initialize_object_state(&manifest).await?;
-                let manifest = Arc::new(RwLock::new(manifest));
                 (manifest, object_state)
             }
             _ => return Err(anyhow::anyhow!("Got non-apply event when starting pod")),
         };
 
-        let reflector_manifest = Arc::clone(&shared_manifest);
+        let (manifest_tx, manifest_rx) = channel(manifest);
         let reflector_deleted = Arc::clone(&deleted);
 
         // Two tasks are spawned for each resource. The first updates shared state (manifest and
@@ -154,7 +153,13 @@ impl<O: Operator> OperatorRuntime<O> {
                         if meta.deletion_timestamp.is_some() {
                             reflector_deleted.notify();
                         }
-                        *reflector_manifest.write().await = manifest;
+                        match manifest_tx.broadcast(manifest) {
+                            Ok(()) => (),
+                            Err(e) => {
+                                warn!("Unable to broadcast manifest update: {:?}", e);
+                                return;
+                            }
+                        }
                     }
                     Event::Deleted(manifest) => {
                         // I'm not sure if this matters, we get notified of pod deletion with a
@@ -167,6 +172,13 @@ impl<O: Operator> OperatorRuntime<O> {
                             manifest.namespace()
                         );
                         reflector_deleted.notify();
+                        match manifest_tx.broadcast(manifest) {
+                            Ok(()) => (),
+                            Err(e) => {
+                                warn!("Unable to broadcast manifest update: {:?}", e);
+                                return;
+                            }
+                        }
                         break;
                     }
                     _ => warn!("Resource got unexpected event, ignoring: {:?}", &event),
@@ -176,7 +188,7 @@ impl<O: Operator> OperatorRuntime<O> {
 
         tokio::spawn(run_object_task::<O>(
             self.client.clone(),
-            shared_manifest,
+            manifest_rx,
             self.operator.shared_state().await,
             object_state,
             deleted,
@@ -249,33 +261,38 @@ impl<O: Operator> OperatorRuntime<O> {
 
 async fn run_object_task<O: Operator>(
     client: Client,
-    manifest: Arc<RwLock<O::Manifest>>,
+    mut manifest: Receiver<O::Manifest>,
     shared: SharedState<<O::ObjectState as ObjectState>::SharedState>,
     mut object_state: O::ObjectState,
     deleted: Arc<Notify>,
     operator: Arc<O>,
 ) {
     debug!("Running registration hook.");
-    match operator.registration_hook(Arc::clone(&manifest)).await {
-        Ok(()) => debug!("Running hook complete."),
-        Err(e) => {
-            error!("Operator registration hook failed: {:?}", e);
-            return;
-        }
-    }
-
     let state: O::InitialState = Default::default();
     let (namespace, name) = {
-        let m = manifest.read().await;
+        let m = match manifest.recv().await {
+            Some(manifest) => manifest,
+            None => {
+                warn!("Manifest sender dropped.");
+                return;
+            }
+        };
+        match operator.registration_hook(manifest.clone()).await {
+            Ok(()) => debug!("Running hook complete."),
+            Err(e) => {
+                error!("Operator registration hook failed: {:?}", e);
+                return;
+            }
+        }
         (m.namespace(), m.name())
     };
 
     tokio::select! {
-        _ = run_to_completion(&client, state, shared.clone(), &mut object_state, Arc::clone(&manifest)) => (),
+        _ = run_to_completion(&client, state, shared.clone(), &mut object_state, manifest.clone()) => (),
         _ = deleted.notified() => {
             let state: O::DeletedState = Default::default();
             debug!("Object {} in namespace {:?} terminated. Jumping to state {:?}.", name, &namespace, state);
-            run_to_completion(&client, state, shared.clone(), &mut object_state, Arc::clone(&manifest)).await;
+            run_to_completion(&client, state, shared.clone(), &mut object_state, manifest.clone()).await;
         }
     }
 

--- a/crates/kubelet/src/pod/state.rs
+++ b/crates/kubelet/src/pod/state.rs
@@ -37,6 +37,7 @@ impl<PodState: ResourceState<Manifest = Pod, Status = PodStatus>> State<PodState
 mod test {
     use crate::pod::{Pod, Status as PodStatus};
     use crate::state::{ResourceState, SharedState, State, Transition, TransitionTo};
+    use tokio::sync::watch::Receiver;
 
     #[derive(Debug)]
     struct ProviderState;
@@ -61,7 +62,7 @@ mod test {
             self: Box<Self>,
             _provider_state: SharedState<ProviderState>,
             _pod_state: &mut PodState,
-            _pod: &Pod,
+            _pod: Receiver<Pod>,
         ) -> Transition<PodState> {
             Transition::Complete(Ok(()))
         }
@@ -84,7 +85,7 @@ mod test {
                 self: Box<Self>,
                 _provider_state: SharedState<ProviderState>,
                 _pod_state: &mut PodState,
-                _pod: &Pod,
+                _pod: Receiver<Pod>,
             ) -> Transition<PodState> {
                 Transition::next(self, ValidState)
             }

--- a/crates/kubelet/src/pod/state.rs
+++ b/crates/kubelet/src/pod/state.rs
@@ -1,7 +1,7 @@
 //! Functions for running Pod state machines.
 use crate::pod::{Pod, Status as PodStatus};
 use crate::state::{ResourceState, SharedState, State, Transition};
-use tokio::sync::watch::Receiver;
+use krator::Manifest;
 
 /// Prelude for Pod state machines.
 pub mod prelude {
@@ -10,7 +10,7 @@ pub mod prelude {
         Status as PodStatus,
     };
     pub use crate::state::{ResourceState, SharedState, State, Transition, TransitionTo};
-    pub use tokio::sync::watch::Receiver;
+    pub use krator::Manifest;
 }
 
 #[derive(Default, Debug)]
@@ -23,7 +23,7 @@ impl<PodState: ResourceState<Manifest = Pod, Status = PodStatus>> State<PodState
         self: Box<Self>,
         _shared_state: SharedState<PodState::SharedState>,
         _pod_state: &mut PodState,
-        _pod: Receiver<Pod>,
+        _pod: Manifest<Pod>,
     ) -> Transition<PodState> {
         Transition::Complete(Ok(()))
     }
@@ -37,7 +37,7 @@ impl<PodState: ResourceState<Manifest = Pod, Status = PodStatus>> State<PodState
 mod test {
     use crate::pod::{Pod, Status as PodStatus};
     use crate::state::{ResourceState, SharedState, State, Transition, TransitionTo};
-    use tokio::sync::watch::Receiver;
+    use krator::Manifest;
 
     #[derive(Debug)]
     struct ProviderState;
@@ -62,7 +62,7 @@ mod test {
             self: Box<Self>,
             _provider_state: SharedState<ProviderState>,
             _pod_state: &mut PodState,
-            _pod: Receiver<Pod>,
+            _pod: Manifest<Pod>,
         ) -> Transition<PodState> {
             Transition::Complete(Ok(()))
         }
@@ -85,7 +85,7 @@ mod test {
                 self: Box<Self>,
                 _provider_state: SharedState<ProviderState>,
                 _pod_state: &mut PodState,
-                _pod: Receiver<Pod>,
+                _pod: Manifest<Pod>,
             ) -> Transition<PodState> {
                 Transition::next(self, ValidState)
             }

--- a/crates/kubelet/src/pod/state.rs
+++ b/crates/kubelet/src/pod/state.rs
@@ -1,6 +1,7 @@
 //! Functions for running Pod state machines.
 use crate::pod::{Pod, Status as PodStatus};
 use crate::state::{ResourceState, SharedState, State, Transition};
+use tokio::sync::watch::Receiver;
 
 /// Prelude for Pod state machines.
 pub mod prelude {
@@ -9,6 +10,7 @@ pub mod prelude {
         Status as PodStatus,
     };
     pub use crate::state::{ResourceState, SharedState, State, Transition, TransitionTo};
+    pub use tokio::sync::watch::Receiver;
 }
 
 #[derive(Default, Debug)]
@@ -21,7 +23,7 @@ impl<PodState: ResourceState<Manifest = Pod, Status = PodStatus>> State<PodState
         self: Box<Self>,
         _shared_state: SharedState<PodState::SharedState>,
         _pod_state: &mut PodState,
-        _pod: &Pod,
+        _pod: Receiver<Pod>,
     ) -> Transition<PodState> {
         Transition::Complete(Ok(()))
     }

--- a/crates/kubelet/src/state.rs
+++ b/crates/kubelet/src/state.rs
@@ -30,7 +30,7 @@
 //!         self: Box<Self>,
 //!         _provider_state: SharedState<ProviderState>,
 //!         _state: &mut PodState,
-//!         _pod: &Pod,
+//!         _pod: Receiver<Pod>,
 //!     ) -> Transition<PodState> {
 //!         Transition::next(self, TestState)
 //!     }

--- a/crates/kubelet/src/state.rs
+++ b/crates/kubelet/src/state.rs
@@ -30,7 +30,7 @@
 //!         self: Box<Self>,
 //!         _provider_state: SharedState<ProviderState>,
 //!         _state: &mut PodState,
-//!         _pod: Receiver<Pod>,
+//!         _pod: Manifest<Pod>,
 //!     ) -> Transition<PodState> {
 //!         Transition::next(self, TestState)
 //!     }

--- a/crates/kubelet/src/state/common/crash_loop_backoff.rs
+++ b/crates/kubelet/src/state/common/crash_loop_backoff.rs
@@ -29,7 +29,7 @@ impl<P: GenericProvider> State<P::PodState> for CrashLoopBackoff<P> {
         self: Box<Self>,
         _provider_state: SharedState<P::ProviderState>,
         pod_state: &mut P::PodState,
-        _pod: &Pod,
+        _pod: Receiver<Pod>,
     ) -> Transition<P::PodState> {
         pod_state.backoff(BackoffSequence::CrashLoop).await;
         let next = Registered::<P>::default();

--- a/crates/kubelet/src/state/common/crash_loop_backoff.rs
+++ b/crates/kubelet/src/state/common/crash_loop_backoff.rs
@@ -29,7 +29,7 @@ impl<P: GenericProvider> State<P::PodState> for CrashLoopBackoff<P> {
         self: Box<Self>,
         _provider_state: SharedState<P::ProviderState>,
         pod_state: &mut P::PodState,
-        _pod: Receiver<Pod>,
+        _pod: Manifest<Pod>,
     ) -> Transition<P::PodState> {
         pod_state.backoff(BackoffSequence::CrashLoop).await;
         let next = Registered::<P>::default();

--- a/crates/kubelet/src/state/common/error.rs
+++ b/crates/kubelet/src/state/common/error.rs
@@ -34,7 +34,7 @@ impl<P: GenericProvider> State<P::PodState> for Error<P> {
         self: Box<Self>,
         _provider_state: SharedState<P::ProviderState>,
         pod_state: &mut P::PodState,
-        _pod: &Pod,
+        _pod: Receiver<Pod>,
     ) -> Transition<P::PodState> {
         match pod_state.record_error().await {
             ThresholdTrigger::Triggered => {

--- a/crates/kubelet/src/state/common/error.rs
+++ b/crates/kubelet/src/state/common/error.rs
@@ -34,7 +34,7 @@ impl<P: GenericProvider> State<P::PodState> for Error<P> {
         self: Box<Self>,
         _provider_state: SharedState<P::ProviderState>,
         pod_state: &mut P::PodState,
-        _pod: Receiver<Pod>,
+        _pod: Manifest<Pod>,
     ) -> Transition<P::PodState> {
         match pod_state.record_error().await {
             ThresholdTrigger::Triggered => {

--- a/crates/kubelet/src/state/common/image_pull.rs
+++ b/crates/kubelet/src/state/common/image_pull.rs
@@ -32,12 +32,9 @@ impl<P: GenericProvider> State<P::PodState> for ImagePull<P> {
         self: Box<Self>,
         provider_state: SharedState<P::ProviderState>,
         pod_state: &mut P::PodState,
-        mut pod: Receiver<Pod>,
+        pod: Manifest<Pod>,
     ) -> Transition<P::PodState> {
-        let pod = match pod.recv().await {
-            Some(pod) => pod,
-            None => return Transition::Complete(Err(anyhow::anyhow!("Manifest sender dropped."))),
-        };
+        let pod = pod.latest();
 
         let (client, store) = {
             // Minimise the amount of time we hold any locks

--- a/crates/kubelet/src/state/common/image_pull_backoff.rs
+++ b/crates/kubelet/src/state/common/image_pull_backoff.rs
@@ -29,7 +29,7 @@ impl<P: GenericProvider> State<P::PodState> for ImagePullBackoff<P> {
         self: Box<Self>,
         _provider_state: SharedState<P::ProviderState>,
         pod_state: &mut P::PodState,
-        _pod: &Pod,
+        _pod: Receiver<Pod>,
     ) -> Transition<P::PodState> {
         pod_state.backoff(BackoffSequence::ImagePull).await;
         Transition::next(self, ImagePull::<P>::default())

--- a/crates/kubelet/src/state/common/image_pull_backoff.rs
+++ b/crates/kubelet/src/state/common/image_pull_backoff.rs
@@ -29,7 +29,7 @@ impl<P: GenericProvider> State<P::PodState> for ImagePullBackoff<P> {
         self: Box<Self>,
         _provider_state: SharedState<P::ProviderState>,
         pod_state: &mut P::PodState,
-        _pod: Receiver<Pod>,
+        _pod: Manifest<Pod>,
     ) -> Transition<P::PodState> {
         pod_state.backoff(BackoffSequence::ImagePull).await;
         Transition::next(self, ImagePull::<P>::default())

--- a/crates/kubelet/src/state/common/registered.rs
+++ b/crates/kubelet/src/state/common/registered.rs
@@ -32,12 +32,9 @@ impl<P: GenericProvider> State<P::PodState> for Registered<P> {
         self: Box<Self>,
         _provider_state: SharedState<P::ProviderState>,
         _pod_state: &mut P::PodState,
-        mut pod: Receiver<Pod>,
+        pod: Manifest<Pod>,
     ) -> Transition<P::PodState> {
-        let pod = match pod.recv().await {
-            Some(pod) => pod,
-            None => return Transition::Complete(Err(anyhow::anyhow!("Manifest sender dropped."))),
-        };
+        let pod = pod.latest();
 
         debug!("Preparing to register pod: {}", pod.name());
         match P::validate_pod_and_containers_runnable(&pod) {

--- a/crates/kubelet/src/state/common/terminated.rs
+++ b/crates/kubelet/src/state/common/terminated.rs
@@ -28,12 +28,9 @@ impl<P: GenericProvider> State<P::PodState> for Terminated<P> {
         self: Box<Self>,
         provider_state: SharedState<P::ProviderState>,
         _pod_state: &mut P::PodState,
-        mut pod: Receiver<Pod>,
+        pod: Manifest<Pod>,
     ) -> Transition<P::PodState> {
-        let pod = match pod.recv().await {
-            Some(pod) => pod,
-            None => return Transition::Complete(Err(anyhow::anyhow!("Manifest sender dropped."))),
-        };
+        let pod = pod.latest();
 
         let state_reader = provider_state.read().await;
         // TODO: In original code, pod key was stored in state rather than

--- a/crates/kubelet/src/state/common/terminated.rs
+++ b/crates/kubelet/src/state/common/terminated.rs
@@ -28,13 +28,18 @@ impl<P: GenericProvider> State<P::PodState> for Terminated<P> {
         self: Box<Self>,
         provider_state: SharedState<P::ProviderState>,
         _pod_state: &mut P::PodState,
-        pod: &Pod,
+        mut pod: Receiver<Pod>,
     ) -> Transition<P::PodState> {
+        let pod = match pod.recv().await {
+            Some(pod) => pod,
+            None => return Transition::Complete(Err(anyhow::anyhow!("Manifest sender dropped."))),
+        };
+
         let state_reader = provider_state.read().await;
         // TODO: In original code, pod key was stored in state rather than
         // re-derived.  Is this important e.g. could pod mutate in ways
         // that invalidate the key assigned on startup?
-        let stop_result = state_reader.stop(pod).await;
+        let stop_result = state_reader.stop(&pod).await;
         Transition::Complete(stop_result)
     }
 

--- a/crates/kubelet/src/state/common/volume_mount.rs
+++ b/crates/kubelet/src/state/common/volume_mount.rs
@@ -32,12 +32,9 @@ impl<P: GenericProvider> State<P::PodState> for VolumeMount<P> {
         self: Box<Self>,
         provider_state: SharedState<P::ProviderState>,
         pod_state: &mut P::PodState,
-        mut pod: Receiver<Pod>,
+        pod: Manifest<Pod>,
     ) -> Transition<P::PodState> {
-        let pod = match pod.recv().await {
-            Some(pod) => pod,
-            None => return Transition::Complete(Err(anyhow::anyhow!("Manifest sender dropped."))),
-        };
+        let pod = pod.latest();
 
         let (client, volume_path) = {
             let state_reader = provider_state.read().await;

--- a/crates/wascc-provider/src/states/container/running.rs
+++ b/crates/wascc-provider/src/states/container/running.rs
@@ -14,7 +14,7 @@ impl State<ContainerState> for Running {
         mut self: Box<Self>,
         _shared_state: SharedState<ProviderState>,
         _state: &mut ContainerState,
-        _container: &Container,
+        _container: Receiver<Container>,
     ) -> Transition<ContainerState> {
         loop {
             tokio::time::delay_for(std::time::Duration::from_secs(10)).await;

--- a/crates/wascc-provider/src/states/container/running.rs
+++ b/crates/wascc-provider/src/states/container/running.rs
@@ -14,7 +14,7 @@ impl State<ContainerState> for Running {
         mut self: Box<Self>,
         _shared_state: SharedState<ProviderState>,
         _state: &mut ContainerState,
-        _container: Receiver<Container>,
+        _container: Manifest<Container>,
     ) -> Transition<ContainerState> {
         loop {
             tokio::time::delay_for(std::time::Duration::from_secs(10)).await;

--- a/crates/wascc-provider/src/states/container/terminated.rs
+++ b/crates/wascc-provider/src/states/container/terminated.rs
@@ -26,8 +26,13 @@ impl State<ContainerState> for Terminated {
         self: Box<Self>,
         _shared_state: SharedState<ProviderState>,
         state: &mut ContainerState,
-        container: &Container,
+        mut container: Receiver<Container>,
     ) -> Transition<ContainerState> {
+        let container = match container.recv().await {
+            Some(container) => container,
+            None => return Transition::Complete(Err(anyhow::anyhow!("Manifest sender dropped."))),
+        };
+
         if self.failed {
             error!(
                 "Pod {} container {} exited with error: {}",

--- a/crates/wascc-provider/src/states/container/terminated.rs
+++ b/crates/wascc-provider/src/states/container/terminated.rs
@@ -26,12 +26,9 @@ impl State<ContainerState> for Terminated {
         self: Box<Self>,
         _shared_state: SharedState<ProviderState>,
         state: &mut ContainerState,
-        mut container: Receiver<Container>,
+        container: Manifest<Container>,
     ) -> Transition<ContainerState> {
-        let container = match container.recv().await {
-            Some(container) => container,
-            None => return Transition::Complete(Err(anyhow::anyhow!("Manifest sender dropped."))),
-        };
+        let container = container.latest();
 
         if self.failed {
             error!(

--- a/crates/wascc-provider/src/states/container/waiting.rs
+++ b/crates/wascc-provider/src/states/container/waiting.rs
@@ -94,12 +94,9 @@ impl State<ContainerState> for Waiting {
         self: Box<Self>,
         shared: SharedState<ProviderState>,
         state: &mut ContainerState,
-        mut container: Receiver<Container>,
+        container: Manifest<Container>,
     ) -> Transition<ContainerState> {
-        let container = match container.recv().await {
-            Some(container) => container,
-            None => return Transition::Complete(Err(anyhow::anyhow!("Manifest sender dropped."))),
-        };
+        let container = container.latest();
 
         info!(
             "Starting container {} for pod {}",

--- a/crates/wascc-provider/src/states/container/waiting.rs
+++ b/crates/wascc-provider/src/states/container/waiting.rs
@@ -94,8 +94,13 @@ impl State<ContainerState> for Waiting {
         self: Box<Self>,
         shared: SharedState<ProviderState>,
         state: &mut ContainerState,
-        container: &Container,
+        mut container: Receiver<Container>,
     ) -> Transition<ContainerState> {
+        let container = match container.recv().await {
+            Some(container) => container,
+            None => return Transition::Complete(Err(anyhow::anyhow!("Manifest sender dropped."))),
+        };
+
         info!(
             "Starting container {} for pod {}",
             container.name(),

--- a/crates/wascc-provider/src/states/pod/running.rs
+++ b/crates/wascc-provider/src/states/pod/running.rs
@@ -1,4 +1,4 @@
-use tokio::sync::mpsc::Receiver as MpscReceiver;
+use tokio::sync::mpsc::Receiver;
 
 use kubelet::pod::state::prelude::*;
 use kubelet::state::common::error::Error;
@@ -10,11 +10,11 @@ use crate::{fail_fatal, PodState, ProviderState};
 #[derive(Debug, TransitionTo)]
 #[transition_to()]
 pub struct Running {
-    rx: MpscReceiver<anyhow::Result<()>>,
+    rx: Receiver<anyhow::Result<()>>,
 }
 
 impl Running {
-    pub fn new(rx: MpscReceiver<anyhow::Result<()>>) -> Self {
+    pub fn new(rx: Receiver<anyhow::Result<()>>) -> Self {
         Running { rx }
     }
 }
@@ -25,12 +25,9 @@ impl State<PodState> for Running {
         mut self: Box<Self>,
         provider_state: SharedState<ProviderState>,
         _pod_state: &mut PodState,
-        mut pod: Receiver<Pod>,
+        pod: Manifest<Pod>,
     ) -> Transition<PodState> {
-        let pod = match pod.recv().await {
-            Some(pod) => pod,
-            None => return Transition::Complete(Err(anyhow::anyhow!("Manifest sender dropped."))),
-        };
+        let pod = pod.latest();
 
         // This collects errors from registering the actor.
         if let Some(result) = self.rx.recv().await {

--- a/crates/wascc-provider/src/states/pod/starting.rs
+++ b/crates/wascc-provider/src/states/pod/starting.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use log::info;
-use tokio::sync::RwLock;
 
 use kubelet::container::{state::run_to_completion, ContainerKey};
 use kubelet::pod::state::prelude::*;
@@ -25,11 +24,15 @@ impl State<PodState> for Starting {
         self: Box<Self>,
         provider_state: SharedState<ProviderState>,
         pod_state: &mut PodState,
-        pod: &Pod,
+        mut pod: Receiver<Pod>,
     ) -> Transition<PodState> {
-        info!("Starting containers for pod {:?}", pod.name());
+        let pod_rx = pod.clone();
+        let pod = match pod.recv().await {
+            Some(pod) => pod,
+            None => return Transition::Complete(Err(anyhow::anyhow!("Manifest sender dropped."))),
+        };
 
-        let arc_pod = Arc::new(RwLock::new(pod.clone()));
+        info!("Starting containers for pod {:?}", pod.name());
 
         let containers = pod.containers();
         let (tx, rx) = tokio::sync::mpsc::channel(containers.len());
@@ -42,7 +45,7 @@ impl State<PodState> for Starting {
                 Arc::clone(&pod_state.run_context),
             );
             let task_provider = Arc::clone(&provider_state);
-            let task_pod = Arc::clone(&arc_pod);
+            let task_pod = pod_rx.clone();
             let mut task_tx = tx.clone();
             tokio::task::spawn(async move {
                 let client = {

--- a/crates/wascc-provider/src/states/pod/starting.rs
+++ b/crates/wascc-provider/src/states/pod/starting.rs
@@ -24,13 +24,10 @@ impl State<PodState> for Starting {
         self: Box<Self>,
         provider_state: SharedState<ProviderState>,
         pod_state: &mut PodState,
-        mut pod: Receiver<Pod>,
+        pod: Manifest<Pod>,
     ) -> Transition<PodState> {
         let pod_rx = pod.clone();
-        let pod = match pod.recv().await {
-            Some(pod) => pod,
-            None => return Transition::Complete(Err(anyhow::anyhow!("Manifest sender dropped."))),
-        };
+        let pod = pod.latest();
 
         info!("Starting containers for pod {:?}", pod.name());
 

--- a/crates/wasi-provider/src/states/container/running.rs
+++ b/crates/wasi-provider/src/states/container/running.rs
@@ -3,6 +3,7 @@ use super::ContainerState;
 use crate::ProviderState;
 use kubelet::container::state::prelude::*;
 use tokio::sync::mpsc::Receiver;
+use tokio::sync::watch::Receiver as WatchReceiver;
 
 /// The container is starting.
 #[derive(Debug, TransitionTo)]
@@ -23,7 +24,7 @@ impl State<ContainerState> for Running {
         mut self: Box<Self>,
         _shared_state: SharedState<ProviderState>,
         _state: &mut ContainerState,
-        _container: &Container,
+        _container: WatchReceiver<Container>,
     ) -> Transition<ContainerState> {
         while let Some(status) = self.rx.recv().await {
             if let Status::Terminated {

--- a/crates/wasi-provider/src/states/container/running.rs
+++ b/crates/wasi-provider/src/states/container/running.rs
@@ -3,7 +3,6 @@ use super::ContainerState;
 use crate::ProviderState;
 use kubelet::container::state::prelude::*;
 use tokio::sync::mpsc::Receiver;
-use tokio::sync::watch::Receiver as WatchReceiver;
 
 /// The container is starting.
 #[derive(Debug, TransitionTo)]
@@ -24,7 +23,7 @@ impl State<ContainerState> for Running {
         mut self: Box<Self>,
         _shared_state: SharedState<ProviderState>,
         _state: &mut ContainerState,
-        _container: WatchReceiver<Container>,
+        _container: Manifest<Container>,
     ) -> Transition<ContainerState> {
         while let Some(status) = self.rx.recv().await {
             if let Status::Terminated {

--- a/crates/wasi-provider/src/states/container/terminated.rs
+++ b/crates/wasi-provider/src/states/container/terminated.rs
@@ -1,6 +1,5 @@
 use kubelet::container::state::prelude::*;
 use log::error;
-use tokio::sync::watch::Receiver;
 
 use crate::ProviderState;
 
@@ -26,12 +25,9 @@ impl State<ContainerState> for Terminated {
         self: Box<Self>,
         _shared_state: SharedState<ProviderState>,
         state: &mut ContainerState,
-        mut container: Receiver<Container>,
+        container: Manifest<Container>,
     ) -> Transition<ContainerState> {
-        let container = match container.recv().await {
-            Some(container) => container,
-            None => return Transition::Complete(Err(anyhow::anyhow!("Manifest sender dropped."))),
-        };
+        let container = container.latest();
 
         if self.failed {
             error!(

--- a/crates/wasi-provider/src/states/container/waiting.rs
+++ b/crates/wasi-provider/src/states/container/waiting.rs
@@ -59,12 +59,9 @@ impl State<ContainerState> for Waiting {
         self: Box<Self>,
         shared: SharedState<ProviderState>,
         state: &mut ContainerState,
-        mut container: Receiver<Container>,
+        container: Manifest<Container>,
     ) -> Transition<ContainerState> {
-        let container = match container.recv().await {
-            Some(container) => container,
-            None => return Transition::Complete(Err(anyhow::anyhow!("Manifest sender dropped."))),
-        };
+        let container = container.latest();
 
         info!(
             "Starting container {} for pod {}",

--- a/crates/wasi-provider/src/states/pod/completed.rs
+++ b/crates/wasi-provider/src/states/pod/completed.rs
@@ -11,7 +11,7 @@ impl State<PodState> for Completed {
         self: Box<Self>,
         _provider_state: SharedState<ProviderState>,
         _pod_state: &mut PodState,
-        _pod: Receiver<Pod>,
+        _pod: Manifest<Pod>,
     ) -> Transition<PodState> {
         Transition::Complete(Ok(()))
     }

--- a/crates/wasi-provider/src/states/pod/completed.rs
+++ b/crates/wasi-provider/src/states/pod/completed.rs
@@ -11,7 +11,7 @@ impl State<PodState> for Completed {
         self: Box<Self>,
         _provider_state: SharedState<ProviderState>,
         _pod_state: &mut PodState,
-        _pod: &Pod,
+        _pod: Receiver<Pod>,
     ) -> Transition<PodState> {
         Transition::Complete(Ok(()))
     }

--- a/crates/wasi-provider/src/states/pod/initializing.rs
+++ b/crates/wasi-provider/src/states/pod/initializing.rs
@@ -25,13 +25,10 @@ impl State<PodState> for Initializing {
         self: Box<Self>,
         provider_state: SharedState<ProviderState>,
         pod_state: &mut PodState,
-        mut pod: Receiver<Pod>,
+        pod: Manifest<Pod>,
     ) -> Transition<PodState> {
         let pod_rx = pod.clone();
-        let pod = match pod.recv().await {
-            Some(pod) => pod,
-            None => return Transition::Complete(Err(anyhow::anyhow!("Manifest sender dropped."))),
-        };
+        let pod = pod.latest();
 
         let client = {
             let provider_state = provider_state.read().await;

--- a/crates/wasi-provider/src/states/pod/initializing.rs
+++ b/crates/wasi-provider/src/states/pod/initializing.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use log::{error, info};
-use tokio::sync::RwLock;
 
 use kubelet::backoff::BackoffStrategy;
 use kubelet::container::state::run_to_completion;
@@ -26,8 +25,14 @@ impl State<PodState> for Initializing {
         self: Box<Self>,
         provider_state: SharedState<ProviderState>,
         pod_state: &mut PodState,
-        pod: &Pod,
+        mut pod: Receiver<Pod>,
     ) -> Transition<PodState> {
+        let pod_rx = pod.clone();
+        let pod = match pod.recv().await {
+            Some(pod) => pod,
+            None => return Transition::Complete(Err(anyhow::anyhow!("Manifest sender dropped."))),
+        };
+
         let client = {
             let provider_state = provider_state.read().await;
             provider_state.client()
@@ -58,7 +63,7 @@ impl State<PodState> for Initializing {
                 // TODO: I think everything should be a SharedState to the same pod in the reflector.
                 Arc::clone(&provider_state),
                 container_state,
-                Arc::new(RwLock::new(pod.clone())),
+                pod_rx.clone(),
                 container_key,
             )
             .await

--- a/crates/wasi-provider/src/states/pod/running.rs
+++ b/crates/wasi-provider/src/states/pod/running.rs
@@ -1,4 +1,4 @@
-use tokio::sync::mpsc::Receiver as MpscReceiver;
+use tokio::sync::mpsc::Receiver;
 
 use kubelet::pod::state::prelude::*;
 use kubelet::state::common::error::Error;
@@ -12,11 +12,11 @@ use crate::{PodState, ProviderState};
 #[derive(Debug, TransitionTo)]
 #[transition_to(Completed)]
 pub struct Running {
-    rx: MpscReceiver<anyhow::Result<()>>,
+    rx: Receiver<anyhow::Result<()>>,
 }
 
 impl Running {
-    pub fn new(rx: MpscReceiver<anyhow::Result<()>>) -> Self {
+    pub fn new(rx: Receiver<anyhow::Result<()>>) -> Self {
         Running { rx }
     }
 }
@@ -27,12 +27,9 @@ impl State<PodState> for Running {
         mut self: Box<Self>,
         provider_state: SharedState<ProviderState>,
         _pod_state: &mut PodState,
-        mut pod: Receiver<Pod>,
+        pod: Manifest<Pod>,
     ) -> Transition<PodState> {
-        let pod = match pod.recv().await {
-            Some(pod) => pod,
-            None => return Transition::Complete(Err(anyhow::anyhow!("Manifest sender dropped."))),
-        };
+        let pod = pod.latest();
 
         let mut completed = 0;
         let total_containers = pod.containers().len();

--- a/crates/wasi-provider/src/states/pod/starting.rs
+++ b/crates/wasi-provider/src/states/pod/starting.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use log::info;
-use tokio::sync::RwLock;
 
 use kubelet::container::state::run_to_completion;
 use kubelet::container::ContainerKey;
@@ -25,10 +24,15 @@ impl State<PodState> for Starting {
         self: Box<Self>,
         provider_state: SharedState<ProviderState>,
         pod_state: &mut PodState,
-        pod: &Pod,
+        mut pod: Receiver<Pod>,
     ) -> Transition<PodState> {
+        let pod_rx = pod.clone();
+        let pod = match pod.recv().await {
+            Some(pod) => pod,
+            None => return Transition::Complete(Err(anyhow::anyhow!("Manifest sender dropped."))),
+        };
+
         info!("Starting containers for pod {:?}.", pod.name());
-        let arc_pod = Arc::new(RwLock::new(pod.clone()));
         let containers = pod.containers();
         let (tx, rx) = tokio::sync::mpsc::channel(containers.len());
         for container in containers {
@@ -40,8 +44,8 @@ impl State<PodState> for Starting {
                 Arc::clone(&pod_state.run_context),
             );
             let task_provider = Arc::clone(&provider_state);
-            let task_pod = Arc::clone(&arc_pod);
             let mut task_tx = tx.clone();
+            let task_pod = pod_rx.clone();
             tokio::task::spawn(async move {
                 let client = {
                     let provider_state = task_provider.read().await;

--- a/crates/wasi-provider/src/states/pod/starting.rs
+++ b/crates/wasi-provider/src/states/pod/starting.rs
@@ -24,13 +24,10 @@ impl State<PodState> for Starting {
         self: Box<Self>,
         provider_state: SharedState<ProviderState>,
         pod_state: &mut PodState,
-        mut pod: Receiver<Pod>,
+        pod: Manifest<Pod>,
     ) -> Transition<PodState> {
         let pod_rx = pod.clone();
-        let pod = match pod.recv().await {
-            Some(pod) => pod,
-            None => return Transition::Complete(Err(anyhow::anyhow!("Manifest sender dropped."))),
-        };
+        let pod = pod.latest();
 
         info!("Starting containers for pod {:?}.", pod.name());
         let containers = pod.containers();

--- a/docs/howto/krustlet-on-microk8s.md
+++ b/docs/howto/krustlet-on-microk8s.md
@@ -64,10 +64,8 @@ $ ./KUBECONFIG=${PWD}/krustlet-config \
 it is a good idea to override the default value here using `KUBECONFIG`. For bootstrapping,
 `KUBECONFIG` must point to a non-existent file (!). Bootstrapping will write a new
 configuration file to this location for you.
-
 > **NOTE**: If you receive an error that the CSR already exists, you may safely delete
 the existing CSR (`kubectl delete csr <hostname>-tls`) and try again.
-
 
 ### Step 2a: Approving the serving CSR
 

--- a/tests/ui/state/next_must_be_state.rs
+++ b/tests/ui/state/next_must_be_state.rs
@@ -31,7 +31,7 @@ impl State<PodState> for TestState {
         self: Box<Self>,
         _provider_state: SharedState<ProviderState>,
         _state: &mut PodState,
-        _pod: &Pod,
+        _pod: Receiver<Pod>,
     ) -> Transition<PodState> {
         // This fails because NotState is not State
         Transition::next(self, NotState)

--- a/tests/ui/state/next_must_be_state.rs
+++ b/tests/ui/state/next_must_be_state.rs
@@ -31,7 +31,7 @@ impl State<PodState> for TestState {
         self: Box<Self>,
         _provider_state: SharedState<ProviderState>,
         _state: &mut PodState,
-        _pod: Receiver<Pod>,
+        _pod: Manifest<Pod>,
     ) -> Transition<PodState> {
         // This fails because NotState is not State
         Transition::next(self, NotState)

--- a/tests/ui/state/require_same_object_state.rs
+++ b/tests/ui/state/require_same_object_state.rs
@@ -41,7 +41,7 @@ impl State<PodState> for TestState {
         self: Box<Self>,
         _provider_state: SharedState<ProviderState>,
         _state: &mut PodState,
-        _pod: Receiver<Pod>,
+        _pod: Manifest<Pod>,
     ) -> Transition<PodState> {
         // This fails because `OtherState` is `State<OtherPodState, PodStatus>`
         Transition::next(self, OtherState)
@@ -62,7 +62,7 @@ impl State<OtherPodState> for OtherState {
         self: Box<Self>,
         _provider_state: SharedState<ProviderState>,
         _state: &mut OtherPodState,
-        _pod: Receiver<Pod>,
+        _pod: Manifest<Pod>,
     ) -> Transition<OtherPodState> {
         Transition::Complete(Ok(()))
     }

--- a/tests/ui/state/require_same_object_state.rs
+++ b/tests/ui/state/require_same_object_state.rs
@@ -41,7 +41,7 @@ impl State<PodState> for TestState {
         self: Box<Self>,
         _provider_state: SharedState<ProviderState>,
         _state: &mut PodState,
-        _pod: &Pod,
+        _pod: Receiver<Pod>,
     ) -> Transition<PodState> {
         // This fails because `OtherState` is `State<OtherPodState, PodStatus>`
         Transition::next(self, OtherState)
@@ -62,7 +62,7 @@ impl State<OtherPodState> for OtherState {
         self: Box<Self>,
         _provider_state: SharedState<ProviderState>,
         _state: &mut OtherPodState,
-        _pod: &Pod,
+        _pod: Receiver<Pod>,
     ) -> Transition<OtherPodState> {
         Transition::Complete(Ok(()))
     }

--- a/tests/ui/state/require_transition_to.rs
+++ b/tests/ui/state/require_transition_to.rs
@@ -30,7 +30,7 @@ impl State<PodState> for TestState {
         self: Box<Self>,
         _provider_state: SharedState<ProviderState>,
         _state: &mut PodState,
-        _pod: &Pod,
+        _pod: Receiver<Pod>,
     ) -> Transition<PodState> {
         // This fails because TestState is not TransitionTo<TestState>
         Transition::next(self, TestState)

--- a/tests/ui/state/require_transition_to.rs
+++ b/tests/ui/state/require_transition_to.rs
@@ -30,7 +30,7 @@ impl State<PodState> for TestState {
         self: Box<Self>,
         _provider_state: SharedState<ProviderState>,
         _state: &mut PodState,
-        _pod: Receiver<Pod>,
+        _pod: Manifest<Pod>,
     ) -> Transition<PodState> {
         // This fails because TestState is not TransitionTo<TestState>
         Transition::next(self, TestState)


### PR DESCRIPTION
First attempt at handling modified events for Krator. I replaced most references to the object manifest with a `tokio::sync::watch::Receiver<Manifest>`. This should allow you to fetch the latest manifest, and optionally await updates to that manifest. The current issue I'm facing is that once `recv` is called, subsequent calls will await new updates, even for clones of the receiver. This means that most of the uses here will block on their first use until the Pod is updated. We may have to implement a custom alternative without this behavior. 

cc @soenkeliebau
closes #481 