### PR TITLE
Updated|Corrected Microk8s instructions

### DIFF
--- a/docs/howto/krustlet-on-microk8s.md
+++ b/docs/howto/krustlet-on-microk8s.md
@@ -80,7 +80,7 @@ Now you can see things work! Feel free to give any of the demos a try in another
 terminal like so:
 
 ```console
-$ microk8s.kubectl apply --file=https://raw.githubusercontent.com/deislabs/krustlet/master/demos/wasi/hello-world-rust/k8s.yaml
+$ microk8s.kubectl apply --filename=https://raw.githubusercontent.com/deislabs/krustlet/master/demos/wasi/hello-world-rust/k8s.yaml
 $ microk8s.kubectl logs pod/hello-world-wasi-rust
 hello from stdout!
 hello from stderr!

--- a/docs/howto/krustlet-on-microk8s.md
+++ b/docs/howto/krustlet-on-microk8s.md
@@ -51,8 +51,7 @@ There are 2 binaries (`krustlet-wasi` and `krustlet-wascc`), let's start the
 first:
 
 ```console
-$ KUBECONFIG=~/.krustlet/config \
-./krustlet-wasi \
+$ ./krustlet-wasi \
 --node-ip=127.0.0.1 \
 --node-name=krustlet \
 --bootstrap-file=~/.krustlet/config/bootstrap.conf

--- a/docs/howto/krustlet-on-microk8s.md
+++ b/docs/howto/krustlet-on-microk8s.md
@@ -84,8 +84,16 @@ $ microk8s.kubectl apply --filename=https://raw.githubusercontent.com/deislabs/k
 $ microk8s.kubectl logs pod/hello-world-wasi-rust
 hello from stdout!
 hello from stderr!
-CONFIG_MAP_VAL=cool stuff
-FOO=bar
 POD_NAME=hello-world-wasi-rust
+FOO=bar
+CONFIG_MAP_VAL=cool stuff
 Args are: []
+
+Bacon ipsum dolor amet chuck turducken porchetta, tri-tip spare ribs t-bone ham hock. Meatloaf
+pork belly leberkas, ham beef pig corned beef boudin ground round meatball alcatra jerky.
+Pancetta brisket pastrami, flank pork chop ball tip short loin burgdoggen. Tri-tip kevin
+shoulder cow andouille. Prosciutto chislic cupim, short ribs venison jerky beef ribs ham hock
+short loin fatback. Bresaola meatloaf capicola pancetta, prosciutto chicken landjaeger andouille
+swine kielbasa drumstick cupim tenderloin chuck shank. Flank jowl leberkas turducken ham tongue
+beef ribs shankle meatloaf drumstick pork t-bone frankfurter tri-tip.
 ```

--- a/docs/howto/krustlet-on-microk8s.md
+++ b/docs/howto/krustlet-on-microk8s.md
@@ -42,6 +42,8 @@ that you generated through another process, you can proceed to the next step.
 However, the credentials Krustlet uses must be part of the `system:nodes` group
 in order for things to function properly.
 
+> **NOTE** You should now have a file `bootstrap.conf` in `${HOME}/.krustlet/config`
+
 ## Step 2: Install and configure Krustlet
 
 Install the latest release of Krustlet following [the install
@@ -51,11 +53,21 @@ There are 2 binaries (`krustlet-wasi` and `krustlet-wascc`), let's start the
 first:
 
 ```console
-$ ./krustlet-wasi \
---node-ip=127.0.0.1 \
---node-name=krustlet \
---bootstrap-file=~/.krustlet/config/bootstrap.conf
+$ ./KUBECONFIG=${PWD}/krustlet-config \
+  krustlet-wasi \
+  --node-ip=127.0.0.1 \
+  --node-name=krustlet \
+  --bootstrap-file=${HOME}/.krustlet/config/bootstrap.conf
 ```
+
+> **NOTE**: To avoid the Krustlet using your default Kubernetes credentials (`~/.kube/config`),
+it is a good idea to override the default value here using `KUBECONFIG`. For bootstrapping,
+`KUBECONFIG` must point to a non-existent file (!). Bootstrapping will write a new
+configuration file to this location for you.
+
+> **NOTE**: If you receive an error that the CSR already exists, you may safely delete
+the existing CSR (`kubectl delete csr <hostname>-tls`) and try again.
+
 
 ### Step 2a: Approving the serving CSR
 
@@ -71,7 +83,7 @@ run:
 $ microk8s.kubectl certificate approve <hostname>-tls
 ```
 
-NOTE: You will only need to do this approval step the first time Krustlet
+> **NOTE**: You will only need to do this approval step the first time Krustlet
 starts. It will generate and save all of the needed credentials to your machine
 
 ## Step 3: Test that things work


### PR DESCRIPTION
Reran this document after a hiatus.

+ II[U|R]C setting `KUBECONFIG=foo ./krustlet-... ---bootstrap-file=bar` uses `bar` to authenticate to the cluster so `foo` is redundant
+ Corrected a typo in the `Step 3: test`
+ Updated the `hello-world-wasi-rust` output to reflect current state

Now to review the GKE instructions ;-)