### PR TITLE
Remove Krator::state re-export

### DIFF
--- a/crates/krator/src/lib.rs
+++ b/crates/krator/src/lib.rs
@@ -13,7 +13,7 @@ pub use manifest::Manifest;
 pub use object::{ObjectState, ObjectStatus};
 pub use operator::Operator;
 pub use runtime::OperatorRuntime;
-pub use state::{State, Transition, TransitionTo};
+pub use state::{SharedState, State, Transition, TransitionTo};
 
 #[cfg(feature = "derive")]
 #[allow(unused_imports)]

--- a/crates/kubelet/src/container/state.rs
+++ b/crates/kubelet/src/container/state.rs
@@ -2,23 +2,21 @@
 use crate::container::{patch_container_status, Status};
 use crate::container::{Container, ContainerKey};
 use crate::pod::Pod;
-use crate::state::{ResourceState, SharedState, State, Transition};
 use chrono::Utc;
 use futures::StreamExt;
 use k8s_openapi::api::core::v1::Pod as KubePod;
-use krator::Manifest;
+use krator::{Manifest, ObjectState, SharedState, State, Transition};
 use kube::api::Api;
 use log::{debug, error, warn};
 
 /// Prelude for Pod state machines.
 pub mod prelude {
     pub use crate::container::{Container, Handle, Status};
-    pub use crate::state::{ResourceState, SharedState, State, Transition, TransitionTo};
-    pub use krator::Manifest;
+    pub use krator::{Manifest, ObjectState, SharedState, State, Transition, TransitionTo};
 }
 
 /// Iteratively evaluate state machine until it returns Complete.
-pub async fn run_to_completion<S: ResourceState<Manifest = Container, Status = Status>>(
+pub async fn run_to_completion<S: ObjectState<Manifest = Container, Status = Status>>(
     client: &kube::Client,
     initial_state: impl State<S>,
     shared: SharedState<S::SharedState>,

--- a/crates/kubelet/src/kubelet.rs
+++ b/crates/kubelet/src/kubelet.rs
@@ -189,11 +189,11 @@ mod test {
     use super::*;
     use crate::container::Container;
     use crate::pod::{Pod, Status};
-    use crate::state::ResourceState;
     use k8s_openapi::api::core::v1::{
         Container as KubeContainer, EnvVar, EnvVarSource, ObjectFieldSelector, Pod as KubePod,
         PodSpec, PodStatus,
     };
+    use krator::ObjectState;
     use kube::api::ObjectMeta;
     use std::collections::BTreeMap;
     use tokio::sync::RwLock;
@@ -210,7 +210,7 @@ mod test {
     struct PodState;
 
     #[async_trait::async_trait]
-    impl ResourceState for PodState {
+    impl ObjectState for PodState {
         type Manifest = Pod;
         type Status = Status;
         type SharedState = ProviderState;
@@ -230,7 +230,7 @@ mod test {
             Ok(PodState)
         }
 
-        fn provider_state(&self) -> crate::state::SharedState<ProviderState> {
+        fn provider_state(&self) -> krator::SharedState<ProviderState> {
             Arc::new(RwLock::new(ProviderState {}))
         }
 

--- a/crates/kubelet/src/lib.rs
+++ b/crates/kubelet/src/lib.rs
@@ -10,7 +10,6 @@
 //! use kubelet::config::Config;
 //! use kubelet::pod::Pod;
 //! use kubelet::provider::Provider;
-//! use kubelet::state::SharedState;
 //! use std::sync::Arc;
 //! use tokio::sync::RwLock;
 //! use kubelet::pod::state::prelude::*;
@@ -25,7 +24,7 @@
 //! struct PodState;
 //!
 //! #[async_trait::async_trait]
-//! impl ResourceState for PodState {
+//! impl ObjectState for PodState {
 //!     type Manifest = Pod;
 //!     type Status = PodStatus;
 //!     type SharedState = ProviderState;

--- a/crates/kubelet/src/pod/state.rs
+++ b/crates/kubelet/src/pod/state.rs
@@ -1,7 +1,6 @@
 //! Functions for running Pod state machines.
 use crate::pod::{Pod, Status as PodStatus};
-use crate::state::{ResourceState, SharedState, State, Transition};
-use krator::Manifest;
+use krator::{Manifest, ObjectState, SharedState, State, Transition};
 
 /// Prelude for Pod state machines.
 pub mod prelude {
@@ -9,8 +8,7 @@ pub mod prelude {
         make_status, make_status_with_containers, status::StatusBuilder, Phase, Pod,
         Status as PodStatus,
     };
-    pub use crate::state::{ResourceState, SharedState, State, Transition, TransitionTo};
-    pub use krator::Manifest;
+    pub use krator::{Manifest, ObjectState, SharedState, State, Transition, TransitionTo};
 }
 
 #[derive(Default, Debug)]
@@ -18,7 +16,7 @@ pub mod prelude {
 pub struct Stub;
 
 #[async_trait::async_trait]
-impl<PodState: ResourceState<Manifest = Pod, Status = PodStatus>> State<PodState> for Stub {
+impl<PodState: ObjectState<Manifest = Pod, Status = PodStatus>> State<PodState> for Stub {
     async fn next(
         self: Box<Self>,
         _shared_state: SharedState<PodState::SharedState>,
@@ -35,8 +33,8 @@ impl<PodState: ResourceState<Manifest = Pod, Status = PodStatus>> State<PodState
 
 #[cfg(test)]
 mod test {
+    use crate::pod::state::prelude::*;
     use crate::pod::{Pod, Status as PodStatus};
-    use crate::state::{ResourceState, SharedState, State, Transition, TransitionTo};
     use krator::Manifest;
 
     #[derive(Debug)]
@@ -49,7 +47,7 @@ mod test {
     struct ValidState;
 
     #[async_trait::async_trait]
-    impl ResourceState for PodState {
+    impl ObjectState for PodState {
         type Manifest = Pod;
         type Status = PodStatus;
         type SharedState = ProviderState;

--- a/crates/kubelet/src/provider/mod.rs
+++ b/crates/kubelet/src/provider/mod.rs
@@ -12,7 +12,7 @@ use crate::log::Sender;
 use crate::node::Builder;
 use crate::pod::Pod;
 use crate::pod::Status as PodStatus;
-use crate::state::{ResourceState, State};
+use krator::{ObjectState, State};
 
 /// A back-end for a Kubelet.
 ///
@@ -32,7 +32,6 @@ use crate::state::{ResourceState, State};
 /// use async_trait::async_trait;
 /// use kubelet::pod::{Pod, Status};
 /// use kubelet::provider::Provider;
-/// use kubelet::state::SharedState;
 /// use kubelet::pod::state::Stub;
 /// use kubelet::pod::state::prelude::*;
 /// use std::sync::Arc;
@@ -44,7 +43,7 @@ use crate::state::{ResourceState, State};
 /// struct PodState;
 ///
 /// #[async_trait]
-/// impl ResourceState for PodState {
+/// impl ObjectState for PodState {
 ///     type Manifest = Pod;
 ///     type Status = Status;
 ///     type SharedState = ProviderState;
@@ -77,7 +76,7 @@ pub trait Provider: Sized + Send + Sync + 'static {
     type ProviderState: 'static + Send + Sync;
 
     /// The state that is passed between Pod state handlers.
-    type PodState: ResourceState<
+    type PodState: ObjectState<
         Manifest = Pod,
         Status = PodStatus,
         SharedState = Self::ProviderState,
@@ -93,7 +92,7 @@ pub trait Provider: Sized + Send + Sync + 'static {
     const ARCH: &'static str;
 
     /// Gets the provider state.
-    fn provider_state(&self) -> crate::state::SharedState<Self::ProviderState>;
+    fn provider_state(&self) -> krator::SharedState<Self::ProviderState>;
 
     /// Allows provider to populate node information.
     async fn node(&self, _builder: &mut Builder) -> anyhow::Result<()> {

--- a/crates/kubelet/src/state.rs
+++ b/crates/kubelet/src/state.rs
@@ -17,7 +17,7 @@
 //! struct PodState;
 //!
 //! #[async_trait::async_trait]
-//! impl ResourceState for PodState {
+//! impl ObjectState for PodState {
 //!     type Manifest = Pod;
 //!     type Status = Status;
 //!     type SharedState = ProviderState;
@@ -46,7 +46,6 @@
 //! ```
 //!
 
-pub use krator::state::*;
 pub mod common;
 
 #[cfg(feature = "derive")]

--- a/crates/kubelet/src/state/common/mod.rs
+++ b/crates/kubelet/src/state/common/mod.rs
@@ -5,8 +5,7 @@
 
 use crate::pod::state::prelude::PodStatus;
 use crate::pod::Pod;
-use crate::state::ResourceState;
-use crate::state::State;
+use krator::{ObjectState, State};
 use std::collections::HashMap;
 
 pub mod crash_loop_backoff;
@@ -52,7 +51,7 @@ pub trait GenericProviderState: 'static + Send + Sync {
 /// Exposes pod state in a way that can be consumed by
 /// the generic states.
 #[async_trait::async_trait]
-pub trait GenericPodState: ResourceState<Manifest = Pod, Status = PodStatus> {
+pub trait GenericPodState: ObjectState<Manifest = Pod, Status = PodStatus> {
     /// Stores the pod module binaries for future execution. Typically your
     /// implementation can just move the modules map into a member field.
     async fn set_modules(&mut self, modules: HashMap<String, Vec<u8>>);
@@ -75,7 +74,7 @@ pub trait GenericProvider: 'static + Send + Sync {
     /// The state of the provider itself.
     type ProviderState: GenericProviderState;
     /// The state that is passed between Pod state handlers.
-    type PodState: GenericPodState + ResourceState<SharedState = Self::ProviderState>;
+    type PodState: GenericPodState + ObjectState<SharedState = Self::ProviderState>;
     /// The state to which pods should transition after they have completed
     /// all generic states. Typically this is the state which first runs
     /// any pod binary (for example, the state which runs init containers).

--- a/crates/wascc-provider/src/states/container.rs
+++ b/crates/wascc-provider/src/states/container.rs
@@ -1,8 +1,8 @@
 use crate::ModuleRunContext;
 use crate::ProviderState;
+use krator::{ObjectState, SharedState};
 use kubelet::container::{Container, ContainerKey, Status};
 use kubelet::pod::Pod;
-use kubelet::state::{ResourceState, SharedState};
 
 pub(crate) mod running;
 pub(crate) mod terminated;
@@ -29,7 +29,7 @@ impl ContainerState {
 }
 
 #[async_trait::async_trait]
-impl ResourceState for ContainerState {
+impl ObjectState for ContainerState {
     type Manifest = Container;
     type Status = Status;
     type SharedState = ProviderState;

--- a/crates/wascc-provider/src/states/pod.rs
+++ b/crates/wascc-provider/src/states/pod.rs
@@ -4,11 +4,11 @@ use std::sync::Arc;
 use log::debug;
 use tokio::sync::RwLock;
 
+use krator::{ObjectState, SharedState};
 use kubelet::backoff::BackoffStrategy;
 use kubelet::backoff::ExponentialBackoffStrategy;
 use kubelet::pod::{Pod, PodKey, Status};
 use kubelet::state::common::{BackoffSequence, GenericPodState, ThresholdTrigger};
-use kubelet::state::{ResourceState, SharedState};
 
 use crate::ModuleRunContext;
 use crate::ProviderState;
@@ -78,7 +78,7 @@ impl GenericPodState for PodState {
 }
 
 #[async_trait::async_trait]
-impl ResourceState for PodState {
+impl ObjectState for PodState {
     type Manifest = Pod;
     type Status = Status;
     type SharedState = ProviderState;

--- a/crates/wasi-provider/src/states/container.rs
+++ b/crates/wasi-provider/src/states/container.rs
@@ -1,8 +1,8 @@
 use crate::ModuleRunContext;
 use crate::ProviderState;
+use krator::{ObjectState, SharedState};
 use kubelet::container::{Container, ContainerKey, Status};
 use kubelet::pod::Pod;
-use kubelet::state::{ResourceState, SharedState};
 
 pub(crate) mod running;
 pub(crate) mod terminated;
@@ -29,7 +29,7 @@ impl ContainerState {
 }
 
 #[async_trait::async_trait]
-impl ResourceState for ContainerState {
+impl ObjectState for ContainerState {
     type Manifest = Container;
     type Status = Status;
     type SharedState = ProviderState;

--- a/crates/wasi-provider/src/states/pod.rs
+++ b/crates/wasi-provider/src/states/pod.rs
@@ -1,13 +1,13 @@
 use crate::ModuleRunContext;
 use crate::ProviderState;
 use async_trait::async_trait;
+use krator::{ObjectState, SharedState};
 use kubelet::backoff::BackoffStrategy;
 use kubelet::backoff::ExponentialBackoffStrategy;
 use kubelet::pod::Pod;
 use kubelet::pod::PodKey;
 use kubelet::pod::Status;
 use kubelet::state::common::{BackoffSequence, GenericPodState, ThresholdTrigger};
-use kubelet::state::{ResourceState, SharedState};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -27,7 +27,7 @@ pub struct PodState {
 }
 
 #[async_trait]
-impl ResourceState for PodState {
+impl ObjectState for PodState {
     type Manifest = Pod;
     type Status = Status;
     type SharedState = ProviderState;

--- a/tests/ui/state/cannot_construct_transition_next.rs
+++ b/tests/ui/state/cannot_construct_transition_next.rs
@@ -2,15 +2,16 @@
 // edition:2018
 extern crate async_trait;
 extern crate kubelet;
+extern crate krator;
 
-use kubelet::state::{Transition, StateHolder, ResourceState};
+use krator::{Transition, state::StateHolder, ObjectState};
 use kubelet::pod::{Pod, Status, state::Stub};
 
 struct PodState;
 struct ProviderState;
 
 #[async_trait::async_trait]
-impl ResourceState for PodState {
+impl ObjectState for PodState {
     type Manifest = Pod;
     type Status = Status;
     type SharedState = ProviderState;

--- a/tests/ui/state/cannot_construct_transition_next.stderr
+++ b/tests/ui/state/cannot_construct_transition_next.stderr
@@ -1,7 +1,7 @@
 error[E0451]: field `state` of struct `StateHolder` is private
-  --> $DIR/cannot_construct_transition_next.rs:23:9
+  --> $DIR/cannot_construct_transition_next.rs:24:9
    |
-23 |         state: Box::new(Stub),
+24 |         state: Box::new(Stub),
    |         ^^^^^^^^^^^^^^^^^^^^^ private field
 
 error: aborting due to previous error

--- a/tests/ui/state/next_must_be_state.rs
+++ b/tests/ui/state/next_must_be_state.rs
@@ -16,7 +16,7 @@ struct PodState;
 struct ProviderState;
 
 #[async_trait::async_trait]
-impl ResourceState for PodState {
+impl ObjectState for PodState {
     type Manifest = Pod;
     type Status = PodStatus;
     type SharedState = ProviderState;

--- a/tests/ui/state/require_same_object_state.rs
+++ b/tests/ui/state/require_same_object_state.rs
@@ -16,7 +16,7 @@ struct PodState;
 struct ProviderState;
 
 #[async_trait::async_trait]
-impl ResourceState for PodState {
+impl ObjectState for PodState {
     type Manifest = Pod;
     type Status = PodStatus;
     type SharedState = ProviderState;
@@ -29,7 +29,7 @@ struct OtherState;
 struct OtherPodState;
 
 #[async_trait::async_trait]
-impl ResourceState for OtherPodState {
+impl ObjectState for OtherPodState {
     type Manifest = Pod;
     type Status = PodStatus;
     type SharedState = ProviderState;

--- a/tests/ui/state/require_transition_to.rs
+++ b/tests/ui/state/require_transition_to.rs
@@ -3,7 +3,7 @@
 extern crate async_trait;
 extern crate kubelet;
 extern crate anyhow;
-
+extern crate krator;
 
 use kubelet::pod::state::prelude::*;
 use kubelet::pod::Pod;
@@ -17,7 +17,7 @@ struct PodState;
 struct ProviderState;
 
 #[async_trait::async_trait]
-impl ResourceState for PodState {
+impl ObjectState for PodState {
     type Manifest = Pod;
     type Status = PodStatus;
     type SharedState = ProviderState;

--- a/tests/ui/state/require_transition_to.stderr
+++ b/tests/ui/state/require_transition_to.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `TestState: TransitionTo<_>` is not satisfied
 36 |         Transition::next(self, TestState)
    |         ^^^^^^^^^^^^^^^^ the trait `TransitionTo<_>` is not implemented for `TestState`
    |
-   = note: required by `kubelet::state::Transition::<S>::next`
+   = note: required by `krator::Transition::<S>::next`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
We were planning to deprecate, but deprecation warnings don't seem to work for `pub use`. 

Branched off of #499 so that should probably merge first. 