### PR TITLE
chore(*): Bumps docs and cargo for 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2051,7 +2051,7 @@ dependencies = [
 
 [[package]]
 name = "krustlet"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "compiletest_rs",
@@ -2140,7 +2140,7 @@ dependencies = [
 
 [[package]]
 name = "kubelet"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-stream 0.3.0",
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "oci-distribution"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -4848,7 +4848,7 @@ dependencies = [
 
 [[package]]
 name = "wascc-provider"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4908,7 +4908,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-provider"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krustlet"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
     "Matt Butcher <matt.butcher@microsoft.com>",
     "Matthew Fisher <matt.fisher@microsoft.com>",
@@ -63,10 +63,10 @@ k8s-openapi = { version = "0.9", default-features = false, features = ["v1_18"] 
 env_logger = "0.7"
 futures = "0.3"
 krator = { path = "./crates/krator", version = "0.1", default-features = false }
-kubelet = { path = "./crates/kubelet", version = "0.5", default-features = false, features = ["cli"] }
-wascc-provider = { path = "./crates/wascc-provider", version = "0.5", default-features = false }
-wasi-provider = { path = "./crates/wasi-provider", version = "0.5", default-features = false }
-oci-distribution = { path = "./crates/oci-distribution", version = "0.4", default-features = false }
+kubelet = { path = "./crates/kubelet", version = "0.6", default-features = false, features = ["cli"] }
+wascc-provider = { path = "./crates/wascc-provider", version = "0.6", default-features = false }
+wasi-provider = { path = "./crates/wasi-provider", version = "0.6", default-features = false }
+oci-distribution = { path = "./crates/oci-distribution", version = "0.5", default-features = false }
 dirs = "3.0"
 hostname = "0.3"
 regex = "1.3"

--- a/contrib/azure/azuredeploy.json
+++ b/contrib/azure/azuredeploy.json
@@ -52,7 +52,7 @@
 		},
 		"krustletURL": {
 			"type": "string",
-			"defaultValue": "https://krustlet.blob.core.windows.net/releases/krustlet-v0.5.0-linux-amd64.tar.gz",
+			"defaultValue": "https://krustlet.blob.core.windows.net/releases/krustlet-v0.6.0-linux-amd64.tar.gz",
 			"metadata": {
 				"description": "URL to a Krustlet release archive."
 			}

--- a/contrib/azure/azuredeploy.parameters.json
+++ b/contrib/azure/azuredeploy.parameters.json
@@ -21,7 +21,7 @@
 			"value": "1.18.10"
 		},
 		"krustletURL": {
-			"value": "https://krustlet.blob.core.windows.net/releases/krustlet-v0.5.0-linux-amd64.tar.gz"
+			"value": "https://krustlet.blob.core.windows.net/releases/krustlet-v0.6.0-linux-amd64.tar.gz"
 		},
 		"servicePrincipalClientId": {
 			"value": null

--- a/crates/kubelet/Cargo.toml
+++ b/crates/kubelet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kubelet"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
     "Matt Butcher <matt.butcher@microsoft.com>",
     "Matthew Fisher <matt.fisher@microsoft.com>",
@@ -56,7 +56,7 @@ structopt = { version = "0.3", features = ["wrap_help"], optional = true }
 hostname = "0.3"
 thiserror = "1.0"
 lazy_static = "1.4"
-oci-distribution = { path = "../oci-distribution", version = "0.4", default-features = false }
+oci-distribution = { path = "../oci-distribution", version = "0.5", default-features = false }
 url = "2.1"
 warp = { version = "0.2", features = ['tls'] }
 http = "0.2"

--- a/crates/kubelet/src/container/handle.rs
+++ b/crates/kubelet/src/container/handle.rs
@@ -8,7 +8,7 @@ use crate::log::{stream, HandleFactory, Sender};
 
 /// Represents a handle to a running "container" (whatever that might be). This
 /// can be used on its own, however, it is generally better to use it as a part
-/// of a [`pod::Handle`], which manages a group of containers in a Kubernetes
+/// of a [`crate::pod::Handle`], which manages a group of containers in a Kubernetes
 /// Pod
 pub struct Handle<H, F> {
     handle: H,

--- a/crates/kubelet/src/kubelet.rs
+++ b/crates/kubelet/src/kubelet.rs
@@ -164,9 +164,14 @@ async fn start_plugin_registry(registrar: Option<Arc<PluginRegistry>>) -> anyhow
         Some(r) => r.run().await,
         // Do nothing; just poll forever and "pretend" that a plugin watcher is running
         None => {
-            task::spawn(async { loop {} })
-                .map_err(anyhow::Error::from)
-                .await
+            task::spawn(async {
+                loop {
+                    // We run a delay here so we don't waste time on NOOP CPU cycles
+                    tokio::time::delay_for(tokio::time::Duration::from_secs(std::u64::MAX)).await;
+                }
+            })
+            .map_err(anyhow::Error::from)
+            .await
         }
     }
 }

--- a/crates/kubelet/src/lib.rs
+++ b/crates/kubelet/src/lib.rs
@@ -1,8 +1,8 @@
 //! A crate for building custom Kubernetes [kubelets](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/).
 //!
-//! The crate provides the [`Provider`] trait for declaring a Kubelet backend
-//! as well as a the [`Kubelet`] type which takes a [`Provider`] and runs
-//! a Kubelet server.
+//! The crate provides the [`Provider`](crate::provider::Provider) trait for declaring a Kubelet
+//! backend as well as a the [`Kubelet`] type which takes a [`Provider`](crate::provider::Provider)
+//! and runs a Kubelet server.
 //!
 //! # Example
 //! ```rust,no_run

--- a/crates/kubelet/src/state/common/terminated.rs
+++ b/crates/kubelet/src/state/common/terminated.rs
@@ -3,7 +3,6 @@ use log::error;
 
 use super::{GenericProvider, GenericProviderState};
 use crate::pod::state::prelude::*;
-use crate::state::common::error::Error;
 use crate::volume::Ref;
 
 /// Pod was deleted.

--- a/crates/kubelet/src/volume/mod.rs
+++ b/crates/kubelet/src/volume/mod.rs
@@ -6,8 +6,6 @@ use std::ops::Deref;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use tokio::task;
-
 use k8s_openapi::api::core::v1::KeyToPath;
 use k8s_openapi::api::core::v1::{ConfigMap, PersistentVolumeClaim, Secret, Volume as KubeVolume};
 use kube::api::Api;

--- a/crates/oci-distribution/Cargo.toml
+++ b/crates/oci-distribution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oci-distribution"
-version = "0.4.0"
+version = "0.5.0"
 authors = [
     "Matt Butcher <matt.butcher@microsoft.com>",
     "Matthew Fisher <matt.fisher@microsoft.com>",

--- a/crates/oci-distribution/src/client.rs
+++ b/crates/oci-distribution/src/client.rs
@@ -828,7 +828,7 @@ mod test {
     const HELLO_IMAGE_TAG: &str = "webassembly.azurecr.io/hello-wasm:v1";
     const HELLO_IMAGE_DIGEST: &str = "webassembly.azurecr.io/hello-wasm@sha256:51d9b231d5129e3ffc267c9d455c49d789bf3167b611a07ab6e4b3304c96b0e7";
     const HELLO_IMAGE_TAG_AND_DIGEST: &str = "webassembly.azurecr.io/hello-wasm:v1@sha256:51d9b231d5129e3ffc267c9d455c49d789bf3167b611a07ab6e4b3304c96b0e7";
-    const TEST_IMAGES: &'static [&str] = &[
+    const TEST_IMAGES: &[&str] = &[
         // TODO(jlegrone): this image cannot be pulled currently because no `latest`
         //                 tag exists on the image repository. Re-enable this image
         //                 in tests once `latest` is published.

--- a/crates/oci-distribution/src/client.rs
+++ b/crates/oci-distribution/src/client.rs
@@ -428,7 +428,7 @@ impl Client {
         Ok(())
     }
 
-    /// Pull a single layer from an OCI registy.
+    /// Pull a single layer from an OCI registry.
     ///
     /// This pulls the layer for a particular image that is identified by
     /// the given digest. The image reference is used to find the
@@ -1093,9 +1093,25 @@ mod test {
             let mut file: Vec<u8> = Vec::new();
             let layer0 = &manifest.layers[0];
 
-            c.pull_layer(&reference, &layer0.digest, &mut file)
-                .await
-                .expect("Pull layer into vec");
+            // This call likes to flake, so we try it at least 5 times
+            let mut last_error = None;
+            for i in 1..6 {
+                if let Err(e) = c.pull_layer(&reference, &layer0.digest, &mut file).await {
+                    println!(
+                        "Got error on pull_layer call attempt {}. Will retry in 1s: {:?}",
+                        i, e
+                    );
+                    last_error.replace(e);
+                    tokio::time::delay_for(tokio::time::Duration::from_secs(1)).await;
+                } else {
+                    last_error = None;
+                    break;
+                }
+            }
+
+            if let Some(e) = last_error {
+                panic!("Unable to pull layer: {:?}", e);
+            }
 
             // The manifest says how many bytes we should expect.
             assert_eq!(file.len(), layer0.size as usize);
@@ -1107,14 +1123,39 @@ mod test {
         for &image in TEST_IMAGES {
             let reference = Reference::try_from(image).expect("failed to parse reference");
 
-            let image_data = Client::default()
-                .pull(
-                    &reference,
-                    &RegistryAuth::Anonymous,
-                    vec![manifest::WASM_LAYER_MEDIA_TYPE],
-                )
-                .await
-                .expect("failed to pull manifest");
+            // This call likes to flake, so we try it at least 5 times
+            let mut last_error = None;
+            let mut image_data = ImageData {
+                layers: Vec::with_capacity(0),
+                digest: None,
+            };
+            for i in 1..6 {
+                match Client::default()
+                    .pull(
+                        &reference,
+                        &RegistryAuth::Anonymous,
+                        vec![manifest::WASM_LAYER_MEDIA_TYPE],
+                    )
+                    .await
+                {
+                    Ok(data) => {
+                        image_data = data;
+                        break;
+                    }
+                    Err(e) => {
+                        println!(
+                            "Got error on pull call attempt {}. Will retry in 1s: {:?}",
+                            i, e
+                        );
+                        last_error.replace(e);
+                        tokio::time::delay_for(tokio::time::Duration::from_secs(1)).await;
+                    }
+                }
+            }
+
+            if let Some(e) = last_error {
+                panic!("Unable to pull layer: {:?}", e);
+            }
 
             assert!(!image_data.layers.is_empty());
             assert!(image_data.digest.is_some());

--- a/crates/wascc-provider/Cargo.toml
+++ b/crates/wascc-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wascc-provider"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
     "Matt Butcher <matt.butcher@microsoft.com>",
     "Matthew Fisher <matt.fisher@microsoft.com>",
@@ -28,7 +28,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 kube = { version= "0.42", default-features = false }
-kubelet = { path = "../kubelet", version = "0.5", default-features = false, features = ["derive"] }
+kubelet = { path = "../kubelet", version = "0.6", default-features = false, features = ["derive"] }
 krator = { path = "../krator", version = "0.1", default-features = false, features = ["derive"] }
 tokio = { version = "0.2", features = ["fs", "macros"] }
 chrono = { version = "0.4", features = ["serde"] }
@@ -41,4 +41,4 @@ k8s-openapi = { version = "0.9", default-features = false, features = ["v1_18"] 
 rand = "0.7.3"
 
 [dev-dependencies]
-oci-distribution = { path = "../oci-distribution", version = "0.4" }
+oci-distribution = { path = "../oci-distribution", version = "0.5" }

--- a/crates/wascc-provider/src/lib.rs
+++ b/crates/wascc-provider/src/lib.rs
@@ -90,7 +90,7 @@ const VOLUME_DIR: &str = "volumes";
 /// Kubernetes' view of environment variables is an unordered map of string to string.
 type EnvVars = std::collections::HashMap<String, String>;
 
-/// A [kubelet::handle::Handle] implementation for a wascc actor
+/// A [kubelet::handle::StopHandler] implementation for a wascc actor
 pub struct ActorHandle {
     /// The public key of the wascc Actor that will be stopped
     pub key: String,

--- a/crates/wasi-provider/Cargo.toml
+++ b/crates/wasi-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasi-provider"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
     "Matt Butcher <matt.butcher@microsoft.com>",
     "Matthew Fisher <matt.fisher@microsoft.com>",
@@ -32,7 +32,7 @@ tempfile = "3.1"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-kubelet = { path = "../kubelet", version = "0.5", default-features = false, features = ["derive"] }
+kubelet = { path = "../kubelet", version = "0.6", default-features = false, features = ["derive"] }
 krator = { path = "../krator", version = "0.1", default-features = false, features = ["derive"] }
 wat = "1.0"
 tokio = { version = "0.2", features = ["fs", "stream", "macros", "io-util", "sync"] }
@@ -41,4 +41,4 @@ futures = "0.3"
 k8s-openapi = { version = "0.9", default-features = false, features = ["v1_18"] }
 
 [dev-dependencies]
-oci-distribution = { path = "../oci-distribution", version = "0.4" }
+oci-distribution = { path = "../oci-distribution", version = "0.5" }

--- a/docs/intro/install.md
+++ b/docs/intro/install.md
@@ -11,7 +11,7 @@ PowerShell)
 
 1. Download your desired version from [the releases
    page](https://github.com/deislabs/krustlet/releases)
-1. Unpack it (`tar -xzf krustlet-v0.4.0-linux-amd64.tar.gz`)
+1. Unpack it (`tar -xzf krustlet-v0.6.0-linux-amd64.tar.gz`)
 1. Find the desired Krustlet provider in the unpacked directory, and move it to
    its desired destination somewhere in your `$PATH` (e.g. `mv krustlet-wasi
    /usr/local/bin/` on unix-like systems or `mv krustlet-wasi.exe
@@ -24,7 +24,7 @@ environment variable is set correctly.
 ### Validating
 
 If you'd like to validate the download, checksums can be downloaded from
-<https://krustlet.blob.core.windows.net/releases/checksums-v0.4.0.txt>
+<https://krustlet.blob.core.windows.net/releases/checksums-v0.6.0.txt>
 
 ### Windows
 

--- a/tests/assert.rs
+++ b/tests/assert.rs
@@ -35,8 +35,10 @@ pub async fn pod_container_log_contains(
     container_name: &str,
     expected_log: &str,
 ) -> anyhow::Result<()> {
-    let mut log_params = LogParams::default();
-    log_params.container = Some(container_name.to_owned());
+    let log_params = LogParams {
+        container: Some(container_name.to_owned()),
+        ..Default::default()
+    };
     let logs = pods.logs(pod_name, &log_params).await?;
     assert!(
         logs.contains(expected_log),

--- a/tests/expectations.rs
+++ b/tests/expectations.rs
@@ -108,7 +108,7 @@ pub async fn assert_container_statuses(
 
     let status = pod
         .status
-        .ok_or(anyhow::anyhow!("Pod {} had no status", pod_name))?;
+        .ok_or_else(|| anyhow::anyhow!("Pod {} had no status", pod_name))?;
 
     for expectation in expectations {
         if let Err(e) = expectation.verify_against(&status) {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -39,11 +39,8 @@ async fn test_wascc_provider() -> Result<(), Box<dyn std::error::Error>> {
     let mut tries: u8 = 0;
     loop {
         // Send a request to the pod to trigger some logging
-        match reqwest::get("http://127.0.0.1:30000").await {
-            Ok(_) => {
-                break;
-            }
-            Err(e) => (),
+        if reqwest::get("http://127.0.0.1:30000").await.is_ok() {
+            break;
         }
         tries += 1;
         if tries == 10 {
@@ -64,7 +61,7 @@ async fn test_wascc_provider() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-async fn verify_wascc_node(node: Node) -> () {
+async fn verify_wascc_node(node: Node) {
     let node_status = node.status.expect("node reported no status");
     assert_eq!(
         node_status
@@ -183,7 +180,7 @@ impl Drop for WasccTestResourceCleaner {
     }
 }
 
-async fn clean_up_wascc_test_resources() -> () {
+async fn clean_up_wascc_test_resources() {
     let client = kube::Client::try_default()
         .await
         .expect("Failed to create client");
@@ -194,7 +191,7 @@ async fn clean_up_wascc_test_resources() -> () {
         .expect("Failed to delete pod");
 }
 
-async fn verify_wasi_node(node: Node) -> () {
+async fn verify_wasi_node(node: Node) {
     let node_status = node.status.expect("node reported no status");
     assert_eq!(
         node_status
@@ -559,6 +556,7 @@ async fn create_faily_pod(
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn wasmercise_wasi(
     pod_name: &str,
     client: kube::Client,

--- a/tests/pod_builder.rs
+++ b/tests/pod_builder.rs
@@ -52,7 +52,7 @@ const PRIVATE_TEST_REGISTRY: &str = "krustletintegrationtestprivate";
 
 fn wasmerciser_container(
     spec: &WasmerciserContainerSpec,
-    volumes: &Vec<WasmerciserVolumeSpec>,
+    volumes: &[WasmerciserVolumeSpec],
 ) -> anyhow::Result<Container> {
     let volume_mounts: Vec<_> = volumes
         .iter()
@@ -207,13 +207,13 @@ pub fn wasmerciser_pod(
     })
 }
 
-fn unzip<T, U: Clone>(source: &Vec<(T, U)>) -> (Vec<&T>, Vec<U>) {
+fn unzip<T, U: Clone>(source: &[(T, U)]) -> (Vec<&T>, Vec<U>) {
     let ts: Vec<_> = source.iter().map(|v| &v.0).collect();
     let us: Vec<_> = source.iter().map(|v| v.1.clone()).collect();
     (ts, us)
 }
 
-fn option_values<T: Clone>(source: &Vec<Option<T>>) -> Vec<T> {
+fn option_values<T: Clone>(source: &[Option<T>]) -> Vec<T> {
     source.iter().filter_map(|t| t.clone()).collect()
 }
 

--- a/tests/pod_setup.rs
+++ b/tests/pod_setup.rs
@@ -28,7 +28,7 @@ pub async fn wait_for_pod_ready(
                 .unwrap_or_else(Vec::new);
             let phase = o.status.unwrap().phase.unwrap();
             if (phase == "Running")
-                & (containers.len() > 0)
+                & (!containers.is_empty())
                 & containers.iter().all(|status| status.ready)
             {
                 went_ready = true;

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -1,5 +1,3 @@
-use compiletest_rs;
-
 use std::path::PathBuf;
 
 #[cfg(target_os = "macos")]
@@ -20,9 +18,11 @@ fn link_deps(config: &mut compiletest_rs::Config) {
 
 #[test]
 fn compile_test() {
-    let mut config = compiletest_rs::Config::default();
-    config.mode = compiletest_rs::common::Mode::Ui;
-    config.src_base = PathBuf::from("tests/ui");
+    let mut config = compiletest_rs::Config {
+        mode: compiletest_rs::common::Mode::Ui,
+        src_base: PathBuf::from("tests/ui"),
+        ..Default::default()
+    };
     link_deps(&mut config);
 
     config.clean_rmeta();


### PR DESCRIPTION
This also includes a bunch of fixes for clippy lints that had piled up (we had something like 15 or 20). So those are all fixed now