### PR TITLE
fix(derive): Fixes circular dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2044,7 +2044,6 @@ dependencies = [
 name = "krator-derive"
 version = "0.1.0"
 dependencies = [
- "krator",
  "quote 1.0.7",
  "syn 1.0.42",
 ]

--- a/crates/krator-derive/Cargo.toml
+++ b/crates/krator-derive/Cargo.toml
@@ -30,10 +30,6 @@ proc-macro = true
 syn = "1.0"
 quote = "1.0"
 
-[dev-dependencies]
-# For docs builds
-krator = { path = "../krator", version = "0.1", default-features = false }
-
 [package.metadata.docs.rs]
 features = ["docs"]
 rustdoc-args = ["--cfg", "feature=\"docs\""]

--- a/crates/krator-derive/src/lib.rs
+++ b/crates/krator-derive/src/lib.rs
@@ -1,19 +1,7 @@
 //! A crate for deriving state machine traits in Kubelet. Right now this crate only consists of a
 //! derive macro for the `TransitionTo` trait. In addition to the `derive` attribute, this macro
 //! also requires the use of a custom attribute called `transition_to` that specifies the types that
-//! can be transitioned to. Not specifying this attribute will result in a compile time error. A
-//! simple example of this is below:
-//!
-//! ```rust,no_run
-//! use krator_derive::TransitionTo;
-//!
-//! pub struct VolumeMount;
-//! pub struct ImagePullBackoff;
-//!
-//! #[derive(Default, Debug, TransitionTo)]
-//! #[transition_to(VolumeMount, ImagePullBackoff)]
-//! pub struct ImagePull;
-//!```
+//! can be transitioned to. Not specifying this attribute will result in a compile time error.
 
 extern crate proc_macro;
 
@@ -28,7 +16,6 @@ use syn::{
 
 const ATTRIBUTE_NAME: &str = "transition_to";
 
-#[derive(Debug)]
 struct Transitions {
     all: Vec<Path>,
 }


### PR DESCRIPTION
The dev dependency on krator led to a circular dependency issue that prevented
publishing of the crate. These changes were actually published with krator 0.1
so we could unblock things.