### PR TITLE
Use LC_ALL to set all locale categories

### DIFF
--- a/docs/howto/assets/bootstrap.sh
+++ b/docs/howto/assets/bootstrap.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export LC_CTYPE=C
+export LC_ALL=C
 
 token_id="$(</dev/urandom tr -dc a-z0-9 | head -c "${1:-6}";echo;)"
 token_secret="$(< /dev/urandom tr -dc a-z0-9 | head -c "${1:-16}";echo;)"


### PR DESCRIPTION
On macOS 11.2, `LC_CTYPE=C` was not sufficient:
```
tr: Illegal byte sequence
tr: Illegal byte sequence
error: error validating "STDIN": error validating data: [unknown object type "nil" in Secret.stringData.token-id, unknown object type "nil" in Secret.stringData.token-secret]; if you choose to ignore these errors, turn validation off with --validate=false
```
I needed to set `LC_ALL=C`.