### PR TITLE
Introduce deregistration hook in Krator Operator

### DIFF
--- a/crates/krator/src/operator.rs
+++ b/crates/krator/src/operator.rs
@@ -58,4 +58,12 @@ pub trait Operator: 'static + Sync + Send {
         &self,
         manifest: Self::Manifest,
     ) -> crate::admission::AdmissionResult<Self::Manifest>;
+
+    /// Called before the state machine is run.
+    async fn deregistration_hook(
+        &self,
+        mut _manifest: Manifest<Self::Manifest>,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
 }

--- a/crates/kubelet/src/provider/mod.rs
+++ b/crates/kubelet/src/provider/mod.rs
@@ -127,6 +127,11 @@ pub trait Provider: Sized + Send + Sync + 'static {
         Err(NotImplementedError.into())
     }
 
+    /// Gets the path at which to construct temporary directories for volumes.
+    fn volume_path(&self) -> Option<std::path::PathBuf> {
+        None
+    }
+
     /// Fetch the CSI driver plugin registry.
     fn plugin_registry(&self) -> Option<Arc<PluginRegistry>> {
         None

--- a/crates/kubelet/src/state/common/terminated.rs
+++ b/crates/kubelet/src/state/common/terminated.rs
@@ -1,9 +1,7 @@
 //! Pod was deleted.
-use log::error;
 
 use super::{GenericProvider, GenericProviderState};
 use crate::pod::state::prelude::*;
-use crate::volume::Ref;
 
 /// Pod was deleted.
 pub struct Terminated<P: GenericProvider> {
@@ -35,24 +33,6 @@ impl<P: GenericProvider> State<P::PodState> for Terminated<P> {
         let pod = pod.latest();
 
         let state_reader = provider_state.read().await;
-        // TODO: move this out of the state machine and into krator via a
-        // deregistration hook
-        //
-        // https://github.com/deislabs/krustlet/issues/504
-        match Ref::unmount_volumes_from_pod(
-            &state_reader.volume_path(),
-            &pod,
-            &state_reader.client(),
-            state_reader.plugin_registry(),
-        )
-        .await
-        {
-            Ok(_) => {}
-            Err(e) => {
-                // report the error, but carry on. Volume unmount failures should not result in a panic()
-                error!("{:?}", e);
-            }
-        };
         // TODO: In original code, pod key was stored in state rather than
         // re-derived.  Is this important e.g. could pod mutate in ways
         // that invalidate the key assigned on startup?

--- a/crates/wasi-provider/src/lib.rs
+++ b/crates/wasi-provider/src/lib.rs
@@ -177,6 +177,10 @@ impl Provider for WasiProvider {
     fn plugin_registry(&self) -> Option<Arc<PluginRegistry>> {
         Some(self.shared.plugin_registry.clone())
     }
+
+    fn volume_path(&self) -> Option<PathBuf> {
+        Some(self.shared.volume_path())
+    }
 }
 
 impl GenericProvider for WasiProvider {


### PR DESCRIPTION
* Update Krustlet to use this hook to clean up volume mounts, rather
  than `Terminated` state.

Closes #504