### PR TITLE
Krator support for Admission Webhook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,6 +1481,7 @@ dependencies = [
  "chrono",
  "env_logger 0.8.2",
  "futures",
+ "json-patch",
  "k8s-openapi",
  "krator-derive",
  "kube",
@@ -1491,6 +1492,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "warp",
 ]
 
 [[package]]

--- a/crates/krator/Cargo.toml
+++ b/crates/krator/Cargo.toml
@@ -30,6 +30,7 @@ default = ["kube-native-tls"]
 kube-native-tls = ["kube/native-tls", "kube-runtime/native-tls"]
 rustls-tls = ["kube/rustls-tls", "kube-runtime/rustls-tls"]
 derive = ["krator-derive"]
+admission-webhook = ["warp", "json-patch"]
 
 [dependencies]
 async-trait = "0.1"
@@ -43,6 +44,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 futures = { version = "0.3", default-features = false }
 krator-derive = { version = "0.1", path = "../krator-derive", optional = true }
+warp = { version = "0.2", optional = true, features = ["tls"] }
+json-patch = { version = "0.2", optional = true }
 
 [dev-dependencies]
 kube-derive = "0.42"

--- a/crates/krator/examples/assets/deploy.sh
+++ b/crates/krator/examples/assets/deploy.sh
@@ -30,6 +30,4 @@ cat webhook.yaml | envsubst | kubectl apply -f -
 rm server.req
 rm ca.srl
 rm ca.key
-#rm server.crt
-#rm server.key
 rm ca.crt

--- a/crates/krator/examples/assets/deploy.sh
+++ b/crates/krator/examples/assets/deploy.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Create CA Key
+openssl genrsa -out ca.key 2048
+
+# Create CA Cert
+openssl req -new -key ca.key -x509 -out ca.crt -days 3650 -subj "/CN=ca"
+
+# Create Server Key and Signing Request
+openssl req -new -nodes -newkey rsa:2048 -keyout server.key -out server.req -batch -subj "/CN=moose-admission-webhook.default.svc" 
+
+# Create Signed Server Cert
+openssl x509 -req -in server.req -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt -days 3650 -sha256
+
+case `uname` in
+        Darwin)
+            b64_opts='-b=0'
+            export ENDPOINT=$(ipconfig getifaddr en0)
+            ;;
+        *)
+            b64_opts='--wrap=0'
+            export ENDPOINT="172.17.0.1"
+esac
+
+export CA_BUNDLE=$(cat ca.crt | base64 ${b64_opts})
+
+# Configure Admission Webhook
+cat webhook.yaml | envsubst | kubectl apply -f -
+
+rm server.req
+rm ca.srl
+rm ca.key
+#rm server.crt
+#rm server.key
+rm ca.crt

--- a/crates/krator/examples/assets/invalid_moose.yaml
+++ b/crates/krator/examples/assets/invalid_moose.yaml
@@ -1,0 +1,10 @@
+apiVersion: animals.com/v1
+kind: Moose
+metadata:
+  name: george
+  labels:
+    nps.gov/park: glacier
+spec:
+  height: 2.1
+  weight: 680
+  antlers: true

--- a/crates/krator/examples/assets/webhook.yaml
+++ b/crates/krator/examples/assets/webhook.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: moose-admission-webhook
+spec:
+  ports:
+    - protocol: TCP
+      port: 443
+      targetPort: 8443
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: moose-admission-webhook
+subsets:
+  - addresses:
+      - ip: ${ENDPOINT}
+    ports:
+      - port: 8443
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: "moose-admission-webhook"
+webhooks:
+- name: "mooses.animals.com"
+  rules:
+  - apiGroups:   ["animals.com"]
+    apiVersions: ["v1"]
+    operations:  ["CREATE"]
+    resources:   ["mooses"]
+    scope:       "Namespaced"
+  clientConfig:
+    caBundle: ${CA_BUNDLE}
+    service:
+      namespace: "default"
+      name: "moose-admission-webhook"  
+      path: /
+  admissionReviewVersions: ["v1", "v1beta1"]
+  sideEffects: None
+  timeoutSeconds: 10

--- a/crates/krator/examples/moose.rs
+++ b/crates/krator/examples/moose.rs
@@ -309,6 +309,26 @@ impl Operator for MooseTracker {
     async fn shared_state(&self) -> Arc<RwLock<SharedMooseState>> {
         Arc::clone(&self.shared)
     }
+
+    #[cfg(feature = "admission-webhook")]
+    async fn admission_hook(
+        &self,
+        manifest: Self::Manifest,
+    ) -> krator::admission::AdmissionResult<Self::Manifest> {
+        use k8s_openapi::apimachinery::pkg::apis::meta::v1::Status;
+        // All moose names start with "M"
+        let name = manifest.metadata().name.clone().unwrap();
+        info!("Processing admission hook for moose named {}", name);
+        match name.chars().next() {
+            Some('m') | Some('M') => krator::admission::AdmissionResult::Allow(manifest),
+            _ => krator::admission::AdmissionResult::Deny(Status {
+                code: Some(400),
+                message: Some("Mooses may only have names starting with 'M'.".to_string()),
+                status: Some("Failure".to_string()),
+                ..Default::default()
+            }),
+        }
+    }
 }
 
 #[tokio::main]

--- a/crates/krator/src/admission.rs
+++ b/crates/krator/src/admission.rs
@@ -97,13 +97,11 @@ pub(crate) async fn endpoint<O: Operator>(operator: Arc<O>) {
                         patch_type: None,
                     },
                 };
-                Ok::<warp::reply::Json, std::convert::Infallible>(warp::reply::json(
-                    &AdmissionReviewResponse {
-                        api_version: request.api_version,
-                        kind: request.kind,
-                        response,
-                    },
-                ))
+                Ok::<_, std::convert::Infallible>(warp::reply::json(&AdmissionReviewResponse {
+                    api_version: request.api_version,
+                    kind: request.kind,
+                    response,
+                }))
             }
         });
     warp::serve(routes)

--- a/crates/krator/src/admission.rs
+++ b/crates/krator/src/admission.rs
@@ -1,0 +1,115 @@
+//! Basic implementation of Kubernetes Admission API
+use crate::Operator;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::Status;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+/// Result of admission hook.
+#[allow(clippy::large_enum_variant)]
+pub enum AdmissionResult<T> {
+    /// Permit the request. Pass the object (with possible mutations) back.
+    /// JSON Patch of any changes will automatically be created.
+    Allow(T),
+    /// Deny the request. Pass a Status object to provide information about the error.
+    Deny(Status),
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+/// AdmissionRequest describes the admission.Attributes for the admission request.
+struct AdmissionRequest<T> {
+    /// UID is an identifier for the individual request/response. It allows us to distinguish instances of requests which are
+    /// otherwise identical (parallel requests, requests when earlier requests did not modify etc)
+    /// The UID is meant to track the round trip (request/response) between the KAS and the WebHook, not the user request.
+    /// It is suitable for correlating log entries between the webhook and apiserver, for either auditing or debugging.
+    uid: Option<String>,
+    /// Object is the object from the incoming request.
+    object: T,
+}
+
+/// AdmissionResponse describes an admission response.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AdmissionResponse {
+    /// UID is an identifier for the individual request/response.
+    /// This must be copied over from the corresponding AdmissionRequest.
+    uid: Option<String>,
+    /// Allowed indicates whether or not the admission request was permitted.
+    allowed: bool,
+    /// Result contains extra details into why an admission request was denied.
+    /// This field IS NOT consulted in any way if "Allowed" is "true".
+    status: Option<Status>,
+    /// The patch body. Currently we only support "JSONPatch" which implements RFC 6902.
+    patch: Option<json_patch::Patch>,
+    /// The type of Patch. Currently we only allow "JSONPatch".
+    patch_type: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AdmissionReviewRequest<T> {
+    api_version: String,
+    kind: String,
+    request: AdmissionRequest<T>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AdmissionReviewResponse {
+    api_version: String,
+    kind: String,
+    response: AdmissionResponse,
+}
+
+pub(crate) async fn endpoint<O: Operator>(operator: Arc<O>) {
+    let cert_path = std::env::var("ADMISSION_CERT_PATH").expect("No certificate path specified.");
+    let key_path = std::env::var("ADMISSION_KEY_PATH").expect("No key path specified.");
+    use warp::Filter;
+    let routes = warp::any()
+        .and(warp::post())
+        .and(warp::body::json())
+        .and_then(move |request: AdmissionReviewRequest<O::Manifest>| {
+            let operator = Arc::clone(&operator);
+            async move {
+                let original = serde_json::to_value(&request.request.object).unwrap();
+                let response = match operator.admission_hook(request.request.object).await {
+                    AdmissionResult::Allow(manifest) => {
+                        let value = serde_json::to_value(&manifest).unwrap();
+                        let patch = json_patch::diff(&original, &value);
+                        let (patch, patch_type) = if !patch.0.is_empty() {
+                            (Some(patch), Some("JSONPatch".to_string()))
+                        } else {
+                            (None, None)
+                        };
+                        AdmissionResponse {
+                            uid: request.request.uid,
+                            allowed: true,
+                            status: None,
+                            patch,
+                            patch_type,
+                        }
+                    }
+                    AdmissionResult::Deny(status) => AdmissionResponse {
+                        uid: request.request.uid,
+                        allowed: false,
+                        status: Some(status),
+                        patch: None,
+                        patch_type: None,
+                    },
+                };
+                Ok::<warp::reply::Json, std::convert::Infallible>(warp::reply::json(
+                    &AdmissionReviewResponse {
+                        api_version: request.api_version,
+                        kind: request.kind,
+                        response,
+                    },
+                ))
+            }
+        });
+    warp::serve(routes)
+        .tls()
+        .cert_path(&cert_path)
+        .key_path(&key_path)
+        .run(([0, 0, 0, 0], 8443))
+        .await;
+}

--- a/crates/krator/src/lib.rs
+++ b/crates/krator/src/lib.rs
@@ -7,6 +7,9 @@ mod object;
 mod operator;
 mod runtime;
 
+#[cfg(feature = "admission-webhook")]
+pub mod admission;
+
 pub mod state;
 
 pub use manifest::Manifest;

--- a/crates/krator/src/operator.rs
+++ b/crates/krator/src/operator.rs
@@ -1,4 +1,5 @@
 use serde::de::DeserializeOwned;
+use serde::Serialize;
 use std::fmt::Debug;
 
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -15,6 +16,7 @@ pub trait Operator: 'static + Sync + Send {
     type Manifest: Metadata<Ty = ObjectMeta>
         + Clone
         + DeserializeOwned
+        + Serialize
         + Send
         + 'static
         + Debug
@@ -49,4 +51,11 @@ pub trait Operator: 'static + Sync + Send {
     ) -> anyhow::Result<()> {
         Ok(())
     }
+
+    #[cfg(feature = "admission-webhook")]
+    /// Invoked when object is created or modified. Can mutate the and / or deny the request.
+    async fn admission_hook(
+        &self,
+        manifest: Self::Manifest,
+    ) -> crate::admission::AdmissionResult<Self::Manifest>;
 }

--- a/crates/kubelet/src/pod/mod.rs
+++ b/crates/kubelet/src/pod/mod.rs
@@ -18,12 +18,13 @@ use k8s_openapi::api::core::v1::{
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use kube::api::Meta;
 use serde::Deserialize;
+use serde::Serialize;
 
 /// A Kubernetes Pod
 ///
 /// This is a new type around the k8s_openapi Pod definition
 /// providing convenient accessor methods
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, Deserialize, Serialize)]
 pub struct Pod {
     #[serde(flatten)]
     kube_pod: KubePod,


### PR DESCRIPTION
This allows the Operator to validate, mutate, and/or reject incoming objects. This seems to be an uncommon pattern, but it makes a lot of sense to me that an Operator gets to validate the objects that it acts on. This is completely optional behind a feature flag (disabled for Krustlet). 

I've updated the moose example for (optionally, based on feature) testing this functionality, and to demonstrate provisioning certificates for mTLS and configuring Kubernetes to use the endpoint.