### PR TITLE
oci-distribution: expose client builder

### DIFF
--- a/crates/kubelet/src/config_interpreter.rs
+++ b/crates/kubelet/src/config_interpreter.rs
@@ -10,7 +10,10 @@ impl ClientConfigSource for Config {
             None => ClientProtocol::default(),
             Some(registries) => ClientProtocol::HttpsExcept(registries.clone()),
         };
-        ClientConfig { protocol }
+        ClientConfig {
+            protocol,
+            ..Default::default()
+        }
     }
 }
 

--- a/crates/oci-distribution/src/client.rs
+++ b/crates/oci-distribution/src/client.rs
@@ -19,8 +19,9 @@ use hyperx::header::Header;
 use reqwest::header::HeaderMap;
 use sha2::Digest;
 use std::collections::HashMap;
+use std::convert::TryFrom;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
-use tracing::debug;
+use tracing::{debug, warn};
 use www_authenticate::{Challenge, ChallengeFields, RawChallenge, WwwAuthenticate};
 
 /// The data for an image or module.
@@ -114,14 +115,42 @@ pub trait ClientConfigSource {
     fn client_config(&self) -> ClientConfig;
 }
 
+impl TryFrom<ClientConfig> for Client {
+    type Error = anyhow::Error;
+
+    fn try_from(config: ClientConfig) -> Result<Self, Self::Error> {
+        let mut client_builder = reqwest::Client::builder()
+            .danger_accept_invalid_certs(config.accept_invalid_certificates)
+            .danger_accept_invalid_hostnames(config.accept_invalid_hostnames);
+
+        for c in &config.extra_root_certificates {
+            let cert = match c.encoding {
+                CertificateEncoding::Der => reqwest::Certificate::from_der(c.data.as_slice())?,
+                CertificateEncoding::Pem => reqwest::Certificate::from_pem(c.data.as_slice())?,
+            };
+            client_builder = client_builder.add_root_certificate(cert);
+        }
+
+        Ok(Self {
+            config,
+            tokens: HashMap::new(),
+            client: client_builder.build()?,
+        })
+    }
+}
+
 impl Client {
     /// Create a new client with the supplied config
     pub fn new(config: ClientConfig) -> Self {
-        Self {
-            config,
-            tokens: HashMap::new(),
-            client: reqwest::Client::new(),
-        }
+        Client::try_from(config.clone()).unwrap_or_else(|err| {
+            warn!("Cannot create OCI client from config: {:?}", err);
+            warn!("Creating client with default configuration");
+            Self {
+                config,
+                tokens: HashMap::new(),
+                client: reqwest::Client::new(),
+            }
+        })
     }
 
     /// Create a new client with the supplied config
@@ -710,11 +739,40 @@ impl Client {
     }
 }
 
+/// The encoding of the certificate
+#[derive(Debug, Clone)]
+pub enum CertificateEncoding {
+    #[allow(missing_docs)]
+    Der,
+    #[allow(missing_docs)]
+    Pem,
+}
+
+/// A x509 certificate
+#[derive(Debug, Clone)]
+pub struct Certificate {
+    /// Which encoding is used by the certificate
+    pub encoding: CertificateEncoding,
+
+    /// Actual certificate
+    pub data: Vec<u8>,
+}
+
 /// A client configuration
 #[derive(Debug, Clone, Default)]
 pub struct ClientConfig {
     /// Which protocol the client should use
     pub protocol: ClientProtocol,
+
+    /// Accept invalid hostname. Defaults to false
+    pub accept_invalid_hostnames: bool,
+
+    /// Accept invalid certificates. Defaults to false
+    pub accept_invalid_certificates: bool,
+
+    /// A list of extra root certificate to trust. This can be used to connect
+    /// to servers using self-signed certificates
+    pub extra_root_certificates: Vec<Certificate>,
 }
 
 /// The protocol that the client should use to connect
@@ -882,6 +940,7 @@ mod test {
     fn manifest_url_generation_respects_http_protocol() {
         let c = Client::new(ClientConfig {
             protocol: ClientProtocol::Http,
+            ..Default::default()
         });
         let reference = Reference::try_from("webassembly.azurecr.io/hello:v1".to_owned())
             .expect("Could not parse reference");
@@ -895,6 +954,7 @@ mod test {
     fn blob_url_generation_respects_http_protocol() {
         let c = Client::new(ClientConfig {
             protocol: ClientProtocol::Http,
+            ..Default::default()
         });
         let reference = Reference::try_from("webassembly.azurecr.io/hello@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff".to_owned())
             .expect("Could not parse reference");
@@ -912,7 +972,10 @@ mod test {
     fn manifest_url_generation_uses_https_if_not_on_exception_list() {
         let insecure_registries = vec!["localhost".to_owned(), "oci.registry.local".to_owned()];
         let protocol = ClientProtocol::HttpsExcept(insecure_registries);
-        let c = Client::new(ClientConfig { protocol });
+        let c = Client::new(ClientConfig {
+            protocol,
+            ..Default::default()
+        });
         let reference = Reference::try_from("webassembly.azurecr.io/hello:v1".to_owned())
             .expect("Could not parse reference");
         assert_eq!(
@@ -925,7 +988,10 @@ mod test {
     fn manifest_url_generation_uses_http_if_on_exception_list() {
         let insecure_registries = vec!["localhost".to_owned(), "oci.registry.local".to_owned()];
         let protocol = ClientProtocol::HttpsExcept(insecure_registries);
-        let c = Client::new(ClientConfig { protocol });
+        let c = Client::new(ClientConfig {
+            protocol,
+            ..Default::default()
+        });
         let reference = Reference::try_from("oci.registry.local/hello:v1".to_owned())
             .expect("Could not parse reference");
         assert_eq!(
@@ -938,7 +1004,10 @@ mod test {
     fn blob_url_generation_uses_https_if_not_on_exception_list() {
         let insecure_registries = vec!["localhost".to_owned(), "oci.registry.local".to_owned()];
         let protocol = ClientProtocol::HttpsExcept(insecure_registries);
-        let c = Client::new(ClientConfig { protocol });
+        let c = Client::new(ClientConfig {
+            protocol,
+            ..Default::default()
+        });
         let reference = Reference::try_from("webassembly.azurecr.io/hello@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff".to_owned())
             .expect("Could not parse reference");
         assert_eq!(
@@ -955,7 +1024,10 @@ mod test {
     fn blob_url_generation_uses_http_if_on_exception_list() {
         let insecure_registries = vec!["localhost".to_owned(), "oci.registry.local".to_owned()];
         let protocol = ClientProtocol::HttpsExcept(insecure_registries);
-        let c = Client::new(ClientConfig { protocol });
+        let c = Client::new(ClientConfig {
+            protocol,
+            ..Default::default()
+        });
         let reference = Reference::try_from("oci.registry.local/hello@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff".to_owned())
             .expect("Could not parse reference");
         assert_eq!(
@@ -1193,6 +1265,7 @@ mod test {
     async fn can_push_layer() {
         let mut c = Client::new(ClientConfig {
             protocol: ClientProtocol::Http,
+            ..Default::default()
         });
         let url = "oci.registry.local/hello-wasm:v1";
         let image: Reference = url.parse().unwrap();
@@ -1234,6 +1307,7 @@ mod test {
     async fn can_push_multiple_layers() {
         let mut c = Client::new(ClientConfig {
             protocol: ClientProtocol::Http,
+            ..Default::default()
         });
         let sample_uuid = "6987887f-0196-45ee-91a1-2dfad901bea0";
         let url = "oci.registry.local/hello-wasm:v1";
@@ -1295,6 +1369,7 @@ mod test {
     async fn test_image_roundtrip() {
         let mut c = Client::new(ClientConfig {
             protocol: ClientProtocol::HttpsExcept(vec!["oci.registry.local".to_string()]),
+            ..Default::default()
         });
 
         let image: Reference = HELLO_IMAGE_TAG_AND_DIGEST.parse().unwrap();


### PR DESCRIPTION
# What this PR does

Allow users to provide a `reqwest::ClientBuilder` instance when the `oci-distribution::Client` is created.

# Why this is useful

This can be useful for users who want to fine tune the client used to access the remote registry. For example, to add a root certificate to be used when connecting to a registry secured with a self-signed certificate.

# Open questions

This is a quick prototype, what I don't like about this solution is:

  * Break the API of `oci-distrubution::Client`. The PR fixes the broken code, but what about other users of this crate?
  * Expose the `reqwest::ClientBuilder`. Disclaimer, I'm new to Rust, in Go I would propose to use instead an interface as parameter. In Rust I would say we could request a series of traits to be provided by the `ClientBuilder`, but this would require changes inside of `reqwest::ClientBuilder`.

I would be interested to know what you think about these drawbacks.