### PR TITLE
Bump to Warp 0.3

### DIFF
--- a/crates/krator/Cargo.toml
+++ b/crates/krator/Cargo.toml
@@ -45,7 +45,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 futures = { version = "0.3", default-features = false }
 krator-derive = { version = "0.1", path = "../krator-derive", optional = true }
-warp = { version = "0.2", optional = true, features = ["tls"] }
+warp = { version = "0.3", optional = true, features = ["tls"] }
 json-patch = { version = "0.2", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Missed this in the Tokio update since its an optional dependency. 