### PR TITLE
Use merge for Krator status patch.

### DIFF
--- a/crates/krator/src/state.rs
+++ b/crates/krator/src/state.rs
@@ -177,7 +177,7 @@ pub async fn patch_status<R: Resource + Clone + DeserializeOwned, S: ObjectStatu
         .patch_status(
             &name,
             &PatchParams::default(),
-            &kube::api::Patch::Strategic(patch),
+            &kube::api::Patch::Merge(patch),
         )
         .await
     {


### PR DESCRIPTION
Unfortunately I trusted [these docs](https://docs.rs/kube/0.42.0/kube/api/struct.PatchParams.html#structfield.patch_strategy) when determining which patch strategy we were using before we updated to `kube` 0.48. 

It turns out that strategic patches are not supported for Custom Resources, and [looking at the code](https://docs.rs/kube/0.42.0/src/kube/api/params.rs.html#246) it turns out that a merge patch was the default. 