### PR TITLE
Use WatchStream for Manifest.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3534,6 +3534,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite 0.2.4",
  "tokio 1.2.0",
+ "tokio-util",
 ]
 
 [[package]]

--- a/crates/krator/Cargo.toml
+++ b/crates/krator/Cargo.toml
@@ -36,7 +36,7 @@ admission-webhook = ["warp", "json-patch"]
 async-trait = "0.1"
 anyhow = "1.0"
 tokio  = { version = "1.0", features = ["fs", "macros", "signal"] }
-tokio-stream = "0.1"
+tokio-stream = { version = "0.1", features = ['sync'] }
 k8s-openapi = { version = "0.11", default-features = false, features = ["v1_18"] }
 kube = { version = "0.48", default-features = false }
 kube-runtime = { version= "0.48", default-features = false }

--- a/crates/krator/src/manifest.rs
+++ b/crates/krator/src/manifest.rs
@@ -1,20 +1,30 @@
 use core::pin::Pin;
 use core::task::{Context, Poll};
 use tokio::sync::watch::{channel, Receiver, Sender};
-use tokio_stream::Stream;
+use tokio_stream::{wrappers::WatchStream, Stream};
 
 /// Wrapper for `ObjectState::Manifest` type which reflects
 /// the latest version of the object's manifest.
-#[derive(Clone)]
-pub struct Manifest<T: Clone> {
+pub struct Manifest<T: Clone + Sync + Send + std::marker::Unpin + 'static> {
     rx: Receiver<T>,
+    stream: WatchStream<T>,
 }
 
-impl<T: Clone> Manifest<T> {
+impl<T: Clone + Sync + Send + std::marker::Unpin + 'static> Clone for Manifest<T> {
+    fn clone(self: &Manifest<T>) -> Manifest<T> {
+        Manifest {
+            rx: self.rx.clone(),
+            stream: WatchStream::new(self.rx.clone()),
+        }
+    }
+}
+
+impl<T: Clone + Sync + Send + std::marker::Unpin + 'static> Manifest<T> {
     /// Create a new Manifest wrapper from the initial object manifest.
     pub fn new(inner: T) -> (Sender<T>, Self) {
         let (tx, rx) = channel(inner);
-        (tx, Manifest { rx })
+        let stream = WatchStream::new(rx.clone());
+        (tx, Manifest { rx, stream })
     }
 
     /// Obtain a clone of the latest object manifest.
@@ -23,21 +33,44 @@ impl<T: Clone> Manifest<T> {
     }
 }
 
-impl<T: Clone> Stream for Manifest<T> {
+impl<T: Clone + Sync + Send + std::marker::Unpin + 'static + std::fmt::Debug> Stream
+    for Manifest<T>
+{
     type Item = T;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
-        use futures::Future;
-        let pending = {
-            let mut fut = Box::pin(self.rx.changed());
-            Pin::new(&mut fut).poll(cx)
-        };
-        match pending {
-            Poll::Pending => Poll::Pending,
-            Poll::Ready(result) => match result {
-                Ok(()) => Poll::Ready(Some(self.rx.borrow().clone())),
-                Err(_) => Poll::Ready(None),
-            },
+        Pin::new(&mut self.stream).poll_next(cx)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use tokio_stream::StreamExt;
+
+    async fn watch_manifest(name: &str, mut m: Manifest<usize>) {
+        while let Some(num) = m.next().await {
+            println!("{} got update: {}", name, num);
         }
+        println!("{} manifest closed.", name);
+    }
+
+    #[tokio::test]
+    async fn test() {
+        let (tx, manifest_1) = Manifest::new(0);
+        let manifest_2 = manifest_1.clone();
+        let manifest_3 = manifest_1.clone();
+
+        let handle_1 = tokio::spawn(watch_manifest("manifest_1", manifest_1));
+        let handle_2 = tokio::spawn(watch_manifest("manifest_2", manifest_2));
+        let handle_3 = tokio::spawn(watch_manifest("manifest_3", manifest_3));
+        for i in 1..5 {
+            tx.send(i).unwrap();
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        }
+        drop(tx);
+        handle_1.await.ok();
+        handle_2.await.ok();
+        handle_3.await.ok();
     }
 }

--- a/crates/krator/src/object.rs
+++ b/crates/krator/src/object.rs
@@ -33,7 +33,7 @@ pub trait ObjectState: 'static + Sync + Send {
     /// This does not need to implement `Resource` or `Meta`, but if it does
     /// not then you will not be able to use it with `Operator` and will have
     /// to write your own `state::run_to_completion` method.
-    type Manifest: Clone;
+    type Manifest: Clone + Sync + Send + std::marker::Unpin + 'static;
     /// The status type of the state machine.
     type Status;
     /// A type representing data shared between all state machines.

--- a/crates/krator/src/operator.rs
+++ b/crates/krator/src/operator.rs
@@ -21,7 +21,8 @@ pub trait Operator: 'static + Sync + Send {
         + 'static
         + Debug
         + Sync
-        + Default;
+        + Default
+        + std::marker::Unpin;
 
     /// Type describing the status of the object.
     type Status: ObjectStatus + Send;

--- a/crates/krator/src/runtime.rs
+++ b/crates/krator/src/runtime.rs
@@ -155,8 +155,8 @@ impl<O: Operator> OperatorRuntime<O> {
                         }
                         match manifest_tx.send(manifest) {
                             Ok(()) => (),
-                            Err(e) => {
-                                warn!("Unable to broadcast manifest update: {:?}", e);
+                            Err(_) => {
+                                debug!("Manifest receiver hung up, exiting.");
                                 return;
                             }
                         }
@@ -174,8 +174,8 @@ impl<O: Operator> OperatorRuntime<O> {
                         reflector_deleted.notify_one();
                         match manifest_tx.send(manifest) {
                             Ok(()) => (),
-                            Err(e) => {
-                                warn!("Unable to broadcast manifest update: {:?}", e);
+                            Err(_) => {
+                                debug!("Manifest receiver hung up, exiting.");
                                 return;
                             }
                         }

--- a/crates/kubelet/src/container/state.rs
+++ b/crates/kubelet/src/container/state.rs
@@ -60,8 +60,8 @@ pub async fn run_to_completion<S: ObjectState<Manifest = Container, Status = Sta
 
             match container_tx.send(latest_container) {
                 Ok(()) => (),
-                Err(e) => {
-                    warn!("Unable to broadcast container update: {:?}", e);
+                Err(_) => {
+                    debug!("Container update receiver hung up, exiting.");
                     return;
                 }
             }


### PR DESCRIPTION
Closes #536 

@thomastaylor312 I know you didn't want to add all of these trait constraints, but this feels like the most stable solution given the trouble we've had with this (presumably `WatchStream` will be kept up to date and reliable by the Tokio team). In practice, this only adds one new trait to `Operator::Manifest`: `Unpin`, and required no changes outside of Krator. 

