### PR TITLE
Change master to main in Actions Config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build and Test
 on:
   push:
     branches:
-      - master
+      - main
   pull_request: {}
 jobs:
   ui_test:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ on:
   push:
     paths: 'docs/**'
     branches:
-      - master
+      - main
   pull_request:
     paths: 'docs/**'
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: release
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - "v*"
 jobs:
@@ -53,8 +53,8 @@ jobs:
         shell: bash
         run: echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
 
-      - name: set the release version (master)
-        if: github.ref == 'refs/heads/master'
+      - name: set the release version (main)
+        if: github.ref == 'refs/heads/main'
         shell: bash
         run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
 
@@ -113,7 +113,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         run: echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
       - name: set the release version
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
       - name: download release assets
         uses: actions/download-artifact@v1


### PR DESCRIPTION
After GitHub's automatic branch renaming, actions were not running on main. This should fix that.