### PR TITLE
Update dirs dependency to use dirs-next instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,15 +705,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,7 +1561,7 @@ version = "0.7.0"
 dependencies = [
  "anyhow",
  "compiletest_rs",
- "dirs 3.0.1",
+ "dirs-next",
  "env_logger 0.7.1",
  "futures",
  "hostname",
@@ -1670,7 +1661,7 @@ dependencies = [
  "base64 0.13.0",
  "bytes 0.3.0",
  "chrono",
- "dirs 3.0.1",
+ "dirs-next",
  "env_logger 0.4.3",
  "futures",
  "hostname",
@@ -3301,7 +3292,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5"
 dependencies = [
- "dirs 2.0.2",
+ "dirs",
  "winapi 0.3.9",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ krator = { path = "./crates/krator", version = "0.2", default-features = false }
 kubelet = { path = "./crates/kubelet", version = "0.7", default-features = false, features = ["cli"] }
 wasi-provider = { path = "./crates/wasi-provider", version = "0.7", default-features = false }
 oci-distribution = { path = "./crates/oci-distribution", version = "0.6", default-features = false }
-dirs = "3.0"
+dirs = { package = "dirs-next", version = "2.0.0" }
 hostname = "0.3"
 regex = "1.3"
 env_logger = "0.7"

--- a/crates/kubelet/Cargo.toml
+++ b/crates/kubelet/Cargo.toml
@@ -37,7 +37,7 @@ derive = ["krator/derive"]
 [dependencies]
 async-trait = "0.1"
 base64 = "0.13"
-dirs = "3.0"
+dirs = { package = "dirs-next", version = "2.0.0" }
 anyhow = "1.0"
 futures = { version = "0.3", default-features = false }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Dirs dependencd has been flagged as unmaintained in https://rustsec.org/advisories/RUSTSEC-2020-0053

Fixes #565