### PR TITLE
Replaces the dependency on tempdir with tempfile (RUSTSEC-2018-0017)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,12 +923,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1699,7 +1693,6 @@ dependencies = [
  "serde_yaml",
  "slab",
  "structopt",
- "tempdir",
  "tempfile",
  "thiserror",
  "tokio 0.2.25",
@@ -2426,19 +2419,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -2481,21 +2461,6 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.6.2",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -2568,15 +2533,6 @@ dependencies = [
  "pem",
  "ring",
  "yasna",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3270,16 +3226,6 @@ name = "target-lexicon"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "422045212ea98508ae3d28025bc5aaa2bd4a9cdaecd442a08da2ee620ee9ea95"
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
-]
 
 [[package]]
 name = "tempfile"

--- a/crates/kubelet/Cargo.toml
+++ b/crates/kubelet/Cargo.toml
@@ -64,7 +64,7 @@ rcgen = "0.8"
 uuid = { version = "0.8.1", features = ["v4"] }
 krator = { path = "../krator", version = "0.2", default-features = false }
 json-patch = "0.2"
-tempdir = "0.3"
+tempfile = "3.2"
 tonic = "0.4"
 # prost is needed for the files built by the protobuf
 prost = "0.7"

--- a/crates/kubelet/src/mio_uds_windows/stdnet/ext.rs
+++ b/crates/kubelet/src/mio_uds_windows/stdnet/ext.rs
@@ -685,16 +685,14 @@ impl WsaExtension {
 
 #[cfg(test)]
 mod tests {
-    extern crate tempdir;
-
     use std::io;
     use std::io::prelude::*;
     use std::os::windows::io::{FromRawSocket, IntoRawSocket};
     use std::path::PathBuf;
     use std::thread;
 
-    use self::tempdir::TempDir;
     use miow::{iocp::CompletionPort, Overlapped};
+    use tempfile::{Builder, TempDir};
 
     use crate::mio_uds_windows::net::{self, AcceptAddrsBuf, UnixListenerExt, UnixStreamExt};
     use crate::mio_uds_windows::stdnet::Socket;
@@ -709,7 +707,7 @@ mod tests {
     }
 
     fn tmpdir() -> Result<(TempDir, PathBuf), io::Error> {
-        let dir = TempDir::new("mio-uds-windows")?;
+        let dir = Builder::new().prefix("mio-uds-windows").tempdir()?;
         let path = dir.path().join("sock");
         Ok((dir, path))
     }

--- a/crates/kubelet/src/mio_uds_windows/stdnet/net.rs
+++ b/crates/kubelet/src/mio_uds_windows/stdnet/net.rs
@@ -277,13 +277,11 @@ impl<'a> Iterator for Incoming<'a> {
 
 #[cfg(test)]
 mod test {
-    extern crate tempdir;
-
     use std::io::{self, Read, Write};
     use std::path::PathBuf;
     use std::thread;
 
-    use self::tempdir::TempDir;
+    use tempfile::{Builder, TempDir};
 
     use super::*;
 
@@ -297,7 +295,7 @@ mod test {
     }
 
     fn tmpdir() -> Result<(TempDir, PathBuf), io::Error> {
-        let dir = TempDir::new("mio-uds-windows")?;
+        let dir = Builder::new().prefix("mio-uds-windows").tempdir()?;
         let path = dir.path().join("sock");
         Ok((dir, path))
     }
@@ -384,7 +382,7 @@ mod test {
 
     #[test]
     fn long_path() {
-        let dir = or_panic!(TempDir::new("mio-uds-windows"));
+        let dir = or_panic!(Builder::new().prefix("mio-uds-windows").tempdir());
         let socket_path = dir.path().join(
             "asdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfa\
                                     sasdfasdfasdasdfasdfasdfadfasdfasdfasdfasdfasdf",

--- a/crates/kubelet/src/mio_uds_windows/test/test_close_on_drop.rs
+++ b/crates/kubelet/src/mio_uds_windows/test/test_close_on_drop.rs
@@ -1,7 +1,7 @@
 use crate::mio_uds_windows::{UnixListener, UnixStream};
 use bytes::ByteBuf;
 use mio::{Events, Poll, PollOpt, Ready, Token};
-use tempdir::TempDir;
+use tempfile::Builder;
 use TryRead;
 
 use self::TestState::{AfterRead, Initial};
@@ -84,7 +84,7 @@ pub fn test_close_on_drop() {
     let _ = ::env_logger::init();
     debug!("Starting TEST_CLOSE_ON_DROP");
     let mut poll = Poll::new().unwrap();
-    let dir = TempDir::new("uds").unwrap();
+    let dir = Builder::new().prefix("uds").tempdir().unwrap();
 
     // == Create & setup server socket
     let srv = UnixListener::bind(dir.path().join("foo")).unwrap();

--- a/crates/kubelet/src/mio_uds_windows/test/test_double_register.rs
+++ b/crates/kubelet/src/mio_uds_windows/test/test_double_register.rs
@@ -5,10 +5,10 @@
 pub fn test_double_register() {
     use crate::mio_uds_windows::UnixListener;
     use mio::*;
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     let poll = Poll::new().unwrap();
-    let dir = TempDir::new("uds").unwrap();
+    let dir = Builder::new().prefix("uds").tempdir().unwrap();
 
     // Create the listener
     let l = UnixListener::bind(dir.path().join("foo")).unwrap();

--- a/crates/kubelet/src/mio_uds_windows/test/test_echo_server.rs
+++ b/crates/kubelet/src/mio_uds_windows/test/test_echo_server.rs
@@ -3,7 +3,7 @@ use bytes::{Buf, ByteBuf, MutByteBuf, SliceBuf};
 use mio::{Events, Poll, PollOpt, Ready, Token};
 use slab::Slab;
 use std::io;
-use tempdir::TempDir;
+use tempfile::Builder;
 use {TryRead, TryWrite};
 
 const SERVER: Token = Token(10_000_000);
@@ -293,7 +293,7 @@ impl Echo {
 pub fn test_echo_server() {
     debug!("Starting TEST_ECHO_SERVER");
     let mut poll = Poll::new().unwrap();
-    let dir = TempDir::new("uds").unwrap();
+    let dir = Builder::new().prefix("uds").tempdir().unwrap();
 
     let srv = UnixListener::bind(dir.path().join("foo")).unwrap();
     let addr = srv.local_addr().unwrap();

--- a/crates/kubelet/src/mio_uds_windows/test/test_local_addr_ready.rs
+++ b/crates/kubelet/src/mio_uds_windows/test/test_local_addr_ready.rs
@@ -1,6 +1,6 @@
 use crate::mio_uds_windows::{UnixListener, UnixStream};
 use mio::{Events, Poll, PollOpt, Ready, Token};
-use tempdir::TempDir;
+use tempfile::Builder;
 use TryWrite;
 
 const LISTEN: Token = Token(0);
@@ -16,7 +16,7 @@ struct MyHandler {
 
 #[test]
 fn local_addr_ready() {
-    let dir = TempDir::new("uds").unwrap();
+    let dir = Builder::new().prefix("uds").tempdir().unwrap();
 
     let server = UnixListener::bind(dir.path().join("foo")).unwrap();
     let addr = server.local_addr().unwrap();

--- a/crates/kubelet/src/mio_uds_windows/test/test_oneshot.rs
+++ b/crates/kubelet/src/mio_uds_windows/test/test_oneshot.rs
@@ -2,7 +2,8 @@ use crate::mio_uds_windows::{UnixListener, UnixStream};
 use mio::*;
 use std::io::*;
 use std::time::Duration;
-use tempdir::TempDir;
+use tempfile::Builder;
+use tempfile::
 
 const MS: u64 = 1_000;
 
@@ -12,7 +13,7 @@ pub fn test_uds_edge_oneshot() {
 
     let mut poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(1024);
-    let dir = TempDir::new("uds").unwrap();
+    let dir = Builder::new().prefix("uds").tempdir().unwrap();
 
     // Create the listener
     let l = UnixListener::bind(dir.path().join("foo")).unwrap();

--- a/crates/kubelet/src/mio_uds_windows/test/test_register_deregister.rs
+++ b/crates/kubelet/src/mio_uds_windows/test/test_register_deregister.rs
@@ -1,10 +1,10 @@
 use crate::mio_uds_windows::{UnixListener, UnixStream};
 use bytes::SliceBuf;
-use tracing::trace;
 use mio::event::Event;
 use mio::{Events, Poll, PollOpt, Ready, Token};
 use std::time::Duration;
-use tempdir::TempDir;
+use tempfile::Builder;
+use tracing::trace;
 use {expect_events, TryWrite};
 
 const SERVER: Token = Token(0);
@@ -63,7 +63,7 @@ pub fn test_register_deregister() {
     debug!("Starting TEST_REGISTER_DEREGISTER");
     let mut poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(1024);
-    let dir = TempDir::new("uds").unwrap();
+    let dir = Builder::new().prefix("uds").tempdir().unwrap();
 
     let server = UnixListener::bind(dir.path().join("foo")).unwrap();
     let addr = server.local_addr().unwrap();
@@ -104,7 +104,7 @@ pub fn test_register_deregister() {
 pub fn test_register_empty_interest() {
     let poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(1024);
-    let dir = TempDir::new("uds").unwrap();
+    let dir = Builder::new().prefix("uds").tempdir().unwrap();
 
     let sock = UnixListener::bind(dir.path().join("foo")).unwrap();
     let addr = sock.local_addr().unwrap();

--- a/crates/kubelet/src/mio_uds_windows/test/test_register_multiple_event_loops.rs
+++ b/crates/kubelet/src/mio_uds_windows/test/test_register_multiple_event_loops.rs
@@ -1,11 +1,11 @@
 use crate::mio_uds_windows::{UnixListener, UnixStream};
 use mio::*;
 use std::io::ErrorKind;
-use tempdir::TempDir;
+use tempfile::Builder;
 
 #[test]
 fn test_uds_register_multiple_event_loops() {
-    let dir = TempDir::new("uds").unwrap();
+    let dir = Builder::new().prefix("uds").tempdir().unwrap();
     let listener = UnixListener::bind(dir.path().join("foo")).unwrap();
     let addr = listener.local_addr().unwrap();
 

--- a/crates/kubelet/src/mio_uds_windows/test/test_reregister_without_poll.rs
+++ b/crates/kubelet/src/mio_uds_windows/test/test_reregister_without_poll.rs
@@ -2,7 +2,7 @@ use crate::mio_uds_windows::{UnixListener, UnixStream};
 use mio::*;
 use sleep_ms;
 use std::time::Duration;
-use tempdir::TempDir;
+use tempfile::Builder;
 
 const MS: u64 = 1_000;
 
@@ -10,7 +10,7 @@ const MS: u64 = 1_000;
 pub fn test_reregister_different_without_poll() {
     let mut events = Events::with_capacity(1024);
     let poll = Poll::new().unwrap();
-    let dir = TempDir::new("uds").unwrap();
+    let dir = Builder::new().prefix("uds").tempdir().unwrap();
 
     // Create the listener
     let l = UnixListener::bind(dir.path().join("foo")).unwrap();

--- a/crates/kubelet/src/mio_uds_windows/test/test_smoke.rs
+++ b/crates/kubelet/src/mio_uds_windows/test/test_smoke.rs
@@ -3,7 +3,7 @@ extern crate mio;
 use crate::mio_uds_windows::UnixListener;
 use mio::{Events, Poll, PollOpt, Ready, Token};
 use std::time::Duration;
-use tempdir::TempDir;
+use tempfile::Builder;
 
 #[test]
 fn run_once_with_nothing() {
@@ -16,7 +16,7 @@ fn run_once_with_nothing() {
 #[test]
 fn add_then_drop() {
     let mut events = Events::with_capacity(1024);
-    let dir = TempDir::new("uds").unwrap();
+    let dir = Builder::new().prefix("uds").tempdir().unwrap();
     let l = UnixListener::bind(dir.path().join("foo")).unwrap();
     let poll = Poll::new().unwrap();
     poll.register(

--- a/crates/kubelet/src/mio_uds_windows/test/test_uds.rs
+++ b/crates/kubelet/src/mio_uds_windows/test/test_uds.rs
@@ -4,7 +4,7 @@ use std::io::prelude::*;
 use std::sync::mpsc::channel;
 use std::thread;
 use std::time::Duration;
-use tempdir::TempDir;
+use tempfile::Builder;
 
 use crate::mio_uds_windows::{net, UnixListener, UnixStream};
 use iovec::IoVec;
@@ -18,7 +18,7 @@ fn accept() {
         listener: UnixListener,
         shutdown: bool,
     }
-    let dir = TempDir::new("uds").unwrap();
+    let dir = Builder::new().prefix("uds").tempdir().unwrap();
 
     let l = UnixListener::bind(dir.path().join("foo")).unwrap();
     let addr = l.local_addr().unwrap();
@@ -61,7 +61,7 @@ fn connect() {
         hit: u32,
         shutdown: bool,
     }
-    let dir = TempDir::new("uds").unwrap();
+    let dir = Builder::new().prefix("uds").tempdir().unwrap();
 
     let l = net::UnixListener::bind(dir.path().join("foo")).unwrap();
     let addr = l.local_addr().unwrap();
@@ -136,7 +136,7 @@ fn read() {
         socket: UnixStream,
         shutdown: bool,
     }
-    let dir = TempDir::new("uds").unwrap();
+    let dir = Builder::new().prefix("uds").tempdir().unwrap();
 
     let l = net::UnixListener::bind(dir.path().join("foo")).unwrap();
     let addr = l.local_addr().unwrap();
@@ -188,7 +188,7 @@ fn read() {
 #[test]
 fn read_bufs() {
     const N: usize = 16 * 1024 * 1024;
-    let dir = TempDir::new("uds").unwrap();
+    let dir = Builder::new().prefix("uds").tempdir().unwrap();
 
     let l = net::UnixListener::bind(dir.path().join("foo")).unwrap();
     let addr = l.local_addr().unwrap();
@@ -261,7 +261,7 @@ fn write() {
         socket: UnixStream,
         shutdown: bool,
     }
-    let dir = TempDir::new("uds").unwrap();
+    let dir = Builder::new().prefix("uds").tempdir().unwrap();
 
     let l = net::UnixListener::bind(dir.path().join("foo")).unwrap();
     let addr = l.local_addr().unwrap();
@@ -313,7 +313,7 @@ fn write() {
 #[test]
 fn write_bufs() {
     const N: usize = 16 * 1024 * 1024;
-    let dir = TempDir::new("uds").unwrap();
+    let dir = Builder::new().prefix("uds").tempdir().unwrap();
 
     let l = net::UnixListener::bind(dir.path().join("foo")).unwrap();
     let addr = l.local_addr().unwrap();
@@ -366,7 +366,7 @@ fn connect_then_close() {
         listener: UnixListener,
         shutdown: bool,
     }
-    let dir = TempDir::new("uds").unwrap();
+    let dir = Builder::new().prefix("uds").tempdir().unwrap();
 
     let poll = Poll::new().unwrap();
     let l = UnixListener::bind(dir.path().join("foo")).unwrap();
@@ -408,7 +408,7 @@ fn connect_then_close() {
 #[test]
 fn listen_then_close() {
     let poll = Poll::new().unwrap();
-    let dir = TempDir::new("uds").unwrap();
+    let dir = Builder::new().prefix("uds").tempdir().unwrap();
     let l = UnixListener::bind(dir.path().join("foo")).unwrap();
 
     poll.register(&l, Token(1), Ready::readable(), PollOpt::edge())
@@ -441,7 +441,7 @@ fn test_uds_sockets_are_send() {
 
 #[test]
 fn bind_twice_bad() {
-    let dir = TempDir::new("uds").unwrap();
+    let dir = Builder::new().prefix("uds").tempdir().unwrap();
     let l1 = UnixListener::bind(dir.path().join("foo")).unwrap();
     let addr = l1.local_addr().unwrap();
     assert!(UnixListener::bind(&addr.as_pathname().unwrap()).is_err());
@@ -450,7 +450,7 @@ fn bind_twice_bad() {
 #[test]
 fn multiple_writes_immediate_success() {
     const N: usize = 16;
-    let dir = TempDir::new("uds").unwrap();
+    let dir = Builder::new().prefix("uds").tempdir().unwrap();
     let l = net::UnixListener::bind(dir.path().join("foo")).unwrap();
     let addr = l.local_addr().unwrap();
 
@@ -498,7 +498,7 @@ fn connection_reset_by_peer() {
     let poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(16);
     let mut buf = [0u8; 16];
-    let dir = TempDir::new("uds").unwrap();
+    let dir = Builder::new().prefix("uds").tempdir().unwrap();
 
     // Create listener
     let l = UnixListener::bind(dir.path().join("foo")).unwrap();
@@ -574,7 +574,7 @@ fn connection_reset_by_peer() {
 #[test]
 fn connect_error() {
     let poll = Poll::new().unwrap();
-    let dir = TempDir::new("uds").unwrap();
+    let dir = Builder::new().prefix("uds").tempdir().unwrap();
 
     // This test is structured differently from the test
     // 'test_tcp::connect_error' in the mio codebase because
@@ -594,7 +594,7 @@ fn write_error() {
     let poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(16);
     let (tx, rx) = channel();
-    let dir = TempDir::new("uds").unwrap();
+    let dir = Builder::new().prefix("uds").tempdir().unwrap();
 
     let listener = net::UnixListener::bind(dir.path().join("foo")).unwrap();
     let addr = listener.local_addr().unwrap();

--- a/crates/kubelet/src/mio_uds_windows/test/test_uds_level.rs
+++ b/crates/kubelet/src/mio_uds_windows/test/test_uds_level.rs
@@ -3,7 +3,7 @@ use mio::event::Event;
 use mio::{Events, Poll, PollOpt, Ready, Token};
 use std::io::Write;
 use std::time::Duration;
-use tempdir::TempDir;
+use tempfile::Builder;
 use {expect_events, sleep_ms, TryRead};
 
 const MS: u64 = 1_000;
@@ -12,7 +12,7 @@ const MS: u64 = 1_000;
 pub fn test_uds_listener_level_triggered() {
     let poll = Poll::new().unwrap();
     let mut pevents = Events::with_capacity(1024);
-    let dir = TempDir::new("uds").unwrap();
+    let dir = Builder::new().prefix("uds").tempdir().unwrap();
 
     // Create the listener
     let l = UnixListener::bind(dir.path().join("foo")).unwrap();
@@ -75,7 +75,7 @@ pub fn test_uds_stream_level_triggered() {
     drop(::env_logger::init());
     let poll = Poll::new().unwrap();
     let mut pevents = Events::with_capacity(1024);
-    let dir = TempDir::new("uds").unwrap();
+    let dir = Builder::new().prefix("uds").tempdir().unwrap();
 
     // Create the listener
     let l = UnixListener::bind(dir.path().join("foo")).unwrap();

--- a/crates/kubelet/src/mio_uds_windows/test/test_write_then_drop.rs
+++ b/crates/kubelet/src/mio_uds_windows/test/test_write_then_drop.rs
@@ -3,12 +3,12 @@ use std::io::{Read, Write};
 use crate::mio_uds_windows::{UnixListener, UnixStream};
 use mio::event::Evented;
 use mio::{Events, Poll, PollOpt, Ready, Token};
-use tempdir::TempDir;
+use tempfile::Builder;
 
 #[test]
 fn write_then_drop() {
     drop(::env_logger::init());
-    let dir = TempDir::new("uds").unwrap();
+    let dir = Builder::new().prefix("uds").tempdir().unwrap();
 
     let a = UnixListener::bind(dir.path().join("foo")).unwrap();
     let addr = a.local_addr().unwrap();
@@ -60,7 +60,7 @@ fn write_then_drop() {
 #[test]
 fn write_then_deregister() {
     drop(::env_logger::init());
-    let dir = TempDir::new("uds").unwrap();
+    let dir = Builder::new().prefix("uds").tempdir().unwrap();
 
     let a = UnixListener::bind(dir.path().join("foo")).unwrap();
     let addr = a.local_addr().unwrap();

--- a/crates/kubelet/src/volume/persistentvolumeclaim.rs
+++ b/crates/kubelet/src/volume/persistentvolumeclaim.rs
@@ -210,7 +210,7 @@ pub(crate) async fn populate(
     // TODO(bacongobbler): implement node_unstage_volume(). We'll need to
     // persist the staging_path somewhere so we can recall that information
     // during unpopulate()
-    let staging_path = Builder::new().prefix("&csi.volume_handle").tempdir()?;
+    let staging_path = Builder::new().prefix(&csi.volume_handle).tempdir()?;
     if stage_unstage_volume {
         stage_volume(&mut csi_client, &csi, staging_path.path()).await?;
     }

--- a/crates/kubelet/src/volume/persistentvolumeclaim.rs
+++ b/crates/kubelet/src/volume/persistentvolumeclaim.rs
@@ -19,7 +19,7 @@ use k8s_openapi::api::core::v1::{
 use k8s_openapi::api::storage::v1::StorageClass;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector;
 
-use tempdir::TempDir;
+use tempfile::Builder;
 use thiserror::Error;
 
 use crate::grpc_sock;
@@ -210,7 +210,7 @@ pub(crate) async fn populate(
     // TODO(bacongobbler): implement node_unstage_volume(). We'll need to
     // persist the staging_path somewhere so we can recall that information
     // during unpopulate()
-    let staging_path = TempDir::new(&csi.volume_handle)?;
+    let staging_path = Builder::new().prefix("&csi.volume_handle").tempdir()?;
     if stage_unstage_volume {
         stage_volume(&mut csi_client, &csi, staging_path.path()).await?;
     }


### PR DESCRIPTION
Removes the dependency on tempdir which has been flagged as unmaintained in RUSTSEC-2018-0017.

Uses the tempfile crate instead, which has been in the dependency tree anyway, as warp depends on it.

Calls to TempDir were replaced with their equivalent from the tempfile crate.

The [documentation](https://docs.rs/tempfile/3.2.0/tempfile/#resource-leaking) for tempfile states the following: 

> tempfile will (almost) never fail to cleanup temporary resources, but TempDir and NamedTempFile will if their destructors don't run. This is because tempfile relies on the OS to cleanup the underlying file, while TempDir and NamedTempFile rely on their destructors to do so.

Which to me sounds like calling .tempfile() should be the preferred way. However as far as I can tell this does not offer creating temporary directories with a prefix. For this first iteration I kept the code functionally as is. 

I'll leave it to someone with more background knowledge of why the prefixes were chosen to evaluate whether these are actually needed?

Most occurrences of this seem to be in Windows specific code, so I was not really able to test this, `cargo check` runs fine for now.. I'll create this PR and see what CI has to say about it :)

fixes #567 
