### PR TITLE
Allow providers to implement custom shutdown behavior

### DIFF
--- a/crates/kubelet/src/provider/mod.rs
+++ b/crates/kubelet/src/provider/mod.rs
@@ -124,16 +124,6 @@ pub trait Provider: Sized + Send + Sync + 'static {
     ///
     /// * `node_name` - The name of the node object that was created by this Kubelet instance
     ///
-    /// # Examples
-    /// This code has been taken from the wasi provider and evicts all currently running pods
-    /// from this node upon shutdown.
-    ///
-    /// ```no_run
-    /// async fn shutdown(&self, node_name: &str) -> anyhow::Result<()> {
-    //     node::drain(&self.shared.client, &node_name).await?;
-    //     Ok(())
-    //  }
-    /// ```
     async fn shutdown(&self, node_name: &str) -> anyhow::Result<()> {
         info!("Shutdown triggered for node {}, since no custom shutdown behavior was implemented Kubelet will simply shut down now.", node_name);
         Ok(())

--- a/crates/kubelet/src/provider/mod.rs
+++ b/crates/kubelet/src/provider/mod.rs
@@ -110,6 +110,12 @@ pub trait Provider: Sized + Send + Sync + 'static {
     // TODO: Is there a way to provide a default implementation of this if Self::PodState: Default?
     async fn initialize_pod_state(&self, pod: &Pod) -> anyhow::Result<Self::PodState>;
 
+    /// Hook to allow the provider to react to the Kubelet being shut down
+    async fn shutdown(&self, node_name: &str) -> anyhow::Result<()> {
+        info!("Shutdown triggered for node {}, since no custom shutdown behavior was implemented Kubelet will simply shut down now.", node_name);
+        Ok(())
+    }
+
     /// Given a Pod, get back the logs for the associated workload.
     async fn logs(
         &self,

--- a/crates/wasi-provider/src/lib.rs
+++ b/crates/wasi-provider/src/lib.rs
@@ -185,6 +185,7 @@ impl Provider for WasiProvider {
         Some(self.shared.volume_path())
     }
 
+    // Evict all pods upon shutdown
     async fn shutdown(&self, node_name: &str) -> anyhow::Result<()> {
         node::drain(&self.shared.client, &node_name).await?;
         Ok(())

--- a/crates/wasi-provider/src/lib.rs
+++ b/crates/wasi-provider/src/lib.rs
@@ -54,6 +54,7 @@ use tokio::sync::RwLock;
 use wasi_runtime::Runtime;
 
 mod states;
+use kubelet::node;
 use states::pod::PodState;
 
 const TARGET_WASM32_WASI: &str = "wasm32-wasi";
@@ -182,6 +183,11 @@ impl Provider for WasiProvider {
 
     fn volume_path(&self) -> Option<PathBuf> {
         Some(self.shared.volume_path())
+    }
+
+    async fn shutdown(&self, node_name: &str) -> anyhow::Result<()> {
+        node::drain(&self.shared.client, &node_name).await?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This is a very simple first attempt at allowing providers to implement custom shutdown behavior.

I tried to be as minimally invasive as possible for the time being. I pass the node name into the shutdown function because I don't think the provider ever has access to the _real_ node object in a proper fashion, but I may be mistaken.
The only way I could find was to take it from the builder in the [node()](https://github.com/deislabs/krustlet/blob/b50bc34c1eafb59b59bc3eff39f643a213bea98e/crates/kubelet/src/provider/mod.rs#L105) function, but that would mean relying on the implementation detail that the kubelet sets the name on the builder before and not after passing the builder to the provider.

We could make this much more complex if we wanted, some ideas I had along the way and just want to mention here: 
- track shutdown reason (Ctrl-C, SIGINT, SIGTERM, Host shutting down, panic) and pass this into the shutdown function (this might become extremely difficult with cross plattform compatibility)
- add a shutdownstate type to the provider trait and optionally have all pods transition to this state when shutting down 

fixes #523