### PR TITLE
[wip] Adjust code to changed kube_derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2066,9 +2066,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.13.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91cea1dfd50064e52db033179952d18c770cbc5dfefc8eba45d619357ba3914"
+checksum = "514d24875c140ed269eecc2d1b56d7b71b573716922a763c317fb1b1b4b58f15"
 dependencies = [
  "async-trait",
  "futures",
@@ -2082,9 +2082,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-jaeger"
-version = "0.12.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd4984441954f9ebbe3eebdfc6fd4fa95be6400d403171228779b949f3cd918"
+checksum = "a5677b3a361784aff6e2b1b30dbdb5f85f4ec57ff2ced41d9a481ad70a9d0b57"
 dependencies = [
  "async-trait",
  "lazy_static",
@@ -3604,9 +3604,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.12.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99003208b647dae59dcefc49c98aecaa3512fbc29351685d4b9ef23a9218458e"
+checksum = "cccdf13c28f1654fe806838f28c5b9cb23ca4c0eae71450daa489f50e523ceb1"
 dependencies = [
  "opentelemetry",
  "tracing",

--- a/crates/krator/Cargo.toml
+++ b/crates/krator/Cargo.toml
@@ -57,8 +57,8 @@ chrono = "0.4"
 rand = "0.8"
 tracing-subscriber = "0.2"
 tokio  = { version = "1.0", features = ["fs", "macros", "signal", "rt-multi-thread"] }
-opentelemetry-jaeger = "0.12"
-tracing-opentelemetry = "0.12"
+opentelemetry-jaeger = "0.11"
+tracing-opentelemetry = "0.11"
 structopt="0.3"
 
 [[example]]

--- a/crates/krator/examples/moose.rs
+++ b/crates/krator/examples/moose.rs
@@ -1,8 +1,8 @@
-use k8s_openapi::Metadata;
 use krator::{
     Manifest, ObjectState, ObjectStatus, Operator, OperatorRuntime, State, Transition, TransitionTo,
 };
 use kube::api::ListParams;
+use kube::Resource;
 use kube_derive::CustomResource;
 use rand::seq::IteratorRandom;
 use rand::Rng;
@@ -301,7 +301,7 @@ impl Operator for MooseTracker {
         &self,
         manifest: &Self::Manifest,
     ) -> anyhow::Result<Self::ObjectState> {
-        let name = manifest.metadata().name.clone().unwrap();
+        let name = manifest.meta().name.clone().unwrap();
         Ok(MooseState {
             name,
             food: manifest.spec.weight / 10.0,
@@ -319,7 +319,7 @@ impl Operator for MooseTracker {
     ) -> krator::admission::AdmissionResult<Self::Manifest> {
         use k8s_openapi::apimachinery::pkg::apis::meta::v1::Status;
         // All moose names start with "M"
-        let name = manifest.metadata().name.clone().unwrap();
+        let name = manifest.meta().name.clone().unwrap();
         info!("Processing admission hook for moose named {}", name);
         match name.chars().next() {
             Some('m') | Some('M') => krator::admission::AdmissionResult::Allow(manifest),

--- a/crates/krator/src/admission.rs
+++ b/crates/krator/src/admission.rs
@@ -1,7 +1,7 @@
 //! Basic implementation of Kubernetes Admission API
 use crate::Operator;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::Status;
-use kube::api::Meta;
+use kube::Resource;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::{info, trace, warn};
@@ -62,7 +62,7 @@ struct AdmissionRequest<T> {
     operation: AdmissionRequestOperation<T>,
 }
 
-impl<T: Meta> AdmissionRequest<T> {
+impl<T: Resource> AdmissionRequest<T> {
     fn name(&self) -> String {
         match &self.operation {
             AdmissionRequestOperation::Create { object, .. } => object.name(),

--- a/crates/krator/src/object.rs
+++ b/crates/krator/src/object.rs
@@ -7,6 +7,13 @@ pub struct ObjectKey {
 }
 
 impl ObjectKey {
+    pub fn new(name: &str, namespace: &Option<String>) -> Self {
+        ObjectKey {
+            name: name.to_string(),
+            namespace: namespace.clone(),
+        }
+    }
+
     pub fn name(&self) -> &str {
         &self.name
     }

--- a/crates/krator/src/operator.rs
+++ b/crates/krator/src/operator.rs
@@ -1,9 +1,7 @@
+use kube::Resource;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::fmt::Debug;
-
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-use k8s_openapi::Metadata;
 
 use crate::object::{ObjectState, ObjectStatus};
 use crate::state::{SharedState, State};
@@ -13,7 +11,7 @@ use crate::Manifest;
 /// Interface for creating an operator.
 pub trait Operator: 'static + Sync + Send {
     /// Type representing the specification of the object in the Kubernetes API.
-    type Manifest: Metadata<Ty = ObjectMeta>
+    type Manifest: Resource<DynamicType = ()>
         + Clone
         + DeserializeOwned
         + Serialize

--- a/crates/krator/src/runtime.rs
+++ b/crates/krator/src/runtime.rs
@@ -9,7 +9,6 @@ use tokio::sync::Notify;
 use tracing::{debug, error, info, trace, warn};
 
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-use k8s_openapi::Metadata;
 use kube::{
     api::{Api, ListParams, Resource},
     Client,

--- a/crates/krator/src/state.rs
+++ b/crates/krator/src/state.rs
@@ -83,7 +83,7 @@ pub async fn run_to_completion<S: ResourceState>(
     object_state: &mut S,
     manifest: Manifest<S::Manifest>,
 ) where
-    S::Manifest: k8s_openapi::Resource + Resource + DeserializeOwned,
+    S::Manifest: Resource + DeserializeOwned,
     <S::Manifest as kube::Resource>::DynamicType: std::default::Default,
     S::Status: ObjectStatus,
 {
@@ -130,7 +130,7 @@ async fn execute_object_state<S: ResourceState>(
     manifest: &Manifest<S::Manifest>,
 ) -> Option<Box<dyn State<S>>>
 where
-    S::Manifest: k8s_openapi::Resource + Resource + DeserializeOwned,
+    S::Manifest: Resource + DeserializeOwned,
     S::Status: ObjectStatus,
 {
     let latest_manifest = manifest.latest();
@@ -179,7 +179,7 @@ where
 
 /// Patch object status with Kubernetes API.
 #[tracing::instrument(level = "trace", skip(api, name, status))]
-pub async fn patch_status<R: k8s_openapi::Resource + Clone + DeserializeOwned, S: ObjectStatus>(
+pub async fn patch_status<R: Resource + Clone + DeserializeOwned, S: ObjectStatus>(
     api: &Api<R>,
     name: &str,
     status: S,

--- a/justfile
+++ b/justfile
@@ -7,6 +7,7 @@ run-wasi: run
 
 build +FLAGS='':
     cargo build {{FLAGS}}
+    cd crates/krator && cargo build {{FLAGS}} --example=moose --features=admission-webhook,derive
 
 lint-docs:
     markdownlint '**/*.md' -c .markdownlint.json


### PR DESCRIPTION
This tries to fix deislabs/krustlet#573

The kube-derive macro now implements `kube::Resource` instead of
`k8s_openapi::Resource` and and `k8s_openapi::Metadata`.

I think these adjustments should be ok, `however: kube::Resource` does not
have the method `metadata_mut()` and I couldn't fix the `resync` method
@kflansburg

I added the compilation of the example app to the github actions
workflow so this kind of error get get caught early