### PR TITLE
ref(volume): Adds new `Mountable` trait

### DIFF
--- a/crates/kubelet/src/volume/configmap.rs
+++ b/crates/kubelet/src/volume/configmap.rs
@@ -1,42 +1,77 @@
 use std::path::Path;
 
 use k8s_openapi::api::core::v1::{ConfigMap, KeyToPath};
+use k8s_openapi::ByteString;
 
 use super::*;
 
-pub(crate) async fn populate(
-    config_map: ConfigMap,
-    path: &Path,
-    items: &Option<Vec<KeyToPath>>,
-) -> anyhow::Result<VolumeType> {
-    tokio::fs::create_dir_all(path).await?;
-    let binary_data = config_map.binary_data.unwrap_or_default();
-    let binary_data = binary_data.into_iter().map(|(key, data)| async move {
-        match mount_setting_for(&key, items) {
-            ItemMount::MountAt(mount_path) => {
-                let file_path = path.join(mount_path);
-                tokio::fs::write(file_path, &data.0).await
-            }
-            ItemMount::DoNotMount => Ok(()),
-        }
-    });
-    let binary_data = futures::future::join_all(binary_data);
-    let data = config_map.data.unwrap_or_default();
-    let data = data.into_iter().map(|(key, data)| async move {
-        match mount_setting_for(&key, items) {
-            ItemMount::MountAt(mount_path) => {
-                let file_path = path.join(mount_path);
-                tokio::fs::write(file_path, data).await
-            }
-            ItemMount::DoNotMount => Ok(()),
-        }
-    });
-    let data = futures::future::join_all(data);
-    let (binary_data, data) = futures::future::join(binary_data, data).await;
-    binary_data
-        .into_iter()
-        .chain(data)
-        .collect::<tokio::io::Result<_>>()?;
+pub struct ConfigMapVolume {
+    vol_name: String,
+    cm_name: String,
+    client: kube::Api<ConfigMap>,
+    items: Option<Vec<KeyToPath>>,
+}
 
-    Ok(VolumeType::ConfigMap)
+impl ConfigMapVolume {
+    pub fn new(
+        vol_name: &str,
+        cm_name: &str,
+        namespace: &str,
+        client: kube::Client,
+        items: Option<Vec<KeyToPath>>,
+    ) -> Self {
+        ConfigMapVolume {
+            vol_name: vol_name.to_owned(),
+            cm_name: cm_name.to_owned(),
+            client: Api::namespaced(client, namespace),
+            items,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Mountable for ConfigMapVolume {
+    async fn mount(&mut self, base_path: &Path) -> anyhow::Result<Ref> {
+        let config_map = self.client.get(&self.cm_name).await?;
+        let path = base_path.join(&self.vol_name);
+        tokio::fs::create_dir_all(&path).await?;
+
+        let binary_data = config_map.binary_data.unwrap_or_default();
+        let binary_data = binary_data
+            .into_iter()
+            .filter_map(
+                |(key, ByteString(data))| match mount_setting_for(&key, &self.items) {
+                    ItemMount::MountAt(mount_path) => Some((path.join(mount_path), data)),
+                    ItemMount::DoNotMount => None,
+                },
+            )
+            .map(|(file_path, data)| async move { tokio::fs::write(file_path, &data).await });
+        let binary_data = futures::future::join_all(binary_data);
+
+        let data = config_map.data.unwrap_or_default();
+        let data = data
+            .into_iter()
+            .filter_map(|(key, data)| match mount_setting_for(&key, &self.items) {
+                ItemMount::MountAt(mount_path) => Some((path.join(mount_path), data)),
+                ItemMount::DoNotMount => None,
+            })
+            .map(|(file_path, data)| async move { tokio::fs::write(file_path, &data).await });
+        let data = futures::future::join_all(data);
+
+        let (binary_data, data) = futures::future::join(binary_data, data).await;
+        binary_data
+            .into_iter()
+            .chain(data)
+            .collect::<tokio::io::Result<_>>()?;
+
+        Ok(Ref {
+            host_path: path,
+            volume_type: VolumeType::ConfigMap,
+        })
+    }
+
+    async fn unmount(&mut self, _base_path: &Path) -> anyhow::Result<()> {
+        // Unmounting is handled with the external ref type
+        Ok(())
+    }
 }

--- a/crates/kubelet/src/volume/hostpath.rs
+++ b/crates/kubelet/src/volume/hostpath.rs
@@ -2,8 +2,31 @@ use k8s_openapi::api::core::v1::HostPathVolumeSource;
 
 use super::*;
 
-pub(crate) async fn populate(hostpath: &HostPathVolumeSource) -> anyhow::Result<VolumeType> {
-    // Check the the directory exists on the host
-    tokio::fs::metadata(&hostpath.path).await?;
-    Ok(VolumeType::HostPath)
+pub struct HostPathVolume {
+    host_path: PathBuf,
+}
+
+impl HostPathVolume {
+    pub fn new(source: &HostPathVolumeSource) -> Self {
+        HostPathVolume {
+            host_path: PathBuf::from(&source.path),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Mountable for HostPathVolume {
+    async fn mount(&mut self, _base_path: &Path) -> anyhow::Result<Ref> {
+        // Check the the directory exists on the host
+        tokio::fs::metadata(&self.host_path).await?;
+        Ok(Ref {
+            host_path: self.host_path.clone(),
+            volume_type: VolumeType::HostPath,
+        })
+    }
+
+    async fn unmount(&mut self, _base_path: &Path) -> anyhow::Result<()> {
+        // Not needed here as it is a host path
+        Ok(())
+    }
 }

--- a/crates/kubelet/src/volume/secret.rs
+++ b/crates/kubelet/src/volume/secret.rs
@@ -5,26 +5,61 @@ use k8s_openapi::ByteString;
 
 use super::*;
 
-pub(crate) async fn populate(
-    secret: Secret,
-    path: &Path,
-    items: &Option<Vec<KeyToPath>>,
-) -> anyhow::Result<VolumeType> {
-    tokio::fs::create_dir_all(path).await?;
-    let data = secret.data.unwrap_or_default();
-    let data = data.into_iter().map(|(key, ByteString(data))| async move {
-        match mount_setting_for(&key, items) {
-            ItemMount::MountAt(mount_path) => {
-                let file_path = path.join(mount_path);
-                tokio::fs::write(file_path, &data).await
-            }
-            ItemMount::DoNotMount => Ok(()),
-        }
-    });
-    futures::future::join_all(data)
-        .await
-        .into_iter()
-        .collect::<tokio::io::Result<_>>()?;
+pub struct SecretVolume {
+    vol_name: String,
+    sec_name: String,
+    client: kube::Api<Secret>,
+    items: Option<Vec<KeyToPath>>,
+}
 
-    Ok(VolumeType::Secret)
+impl SecretVolume {
+    pub fn new(
+        vol_name: &str,
+        sec_name: &str,
+        namespace: &str,
+        client: kube::Client,
+        items: Option<Vec<KeyToPath>>,
+    ) -> Self {
+        SecretVolume {
+            vol_name: vol_name.to_owned(),
+            sec_name: sec_name.to_owned(),
+            client: Api::namespaced(client, namespace),
+            items,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Mountable for SecretVolume {
+    async fn mount(&mut self, base_path: &Path) -> anyhow::Result<Ref> {
+        let secret = self.client.get(&self.sec_name).await?;
+        let path = base_path.join(&self.vol_name);
+        tokio::fs::create_dir_all(&path).await?;
+        let data = secret.data.unwrap_or_default();
+        // We could probably just move the data out of the option, but I don't know what the correct
+        // behavior is from k8s point of view if something tries to mount a volume again
+        let data = data
+            .into_iter()
+            .filter_map(
+                |(key, ByteString(data))| match mount_setting_for(&key, &self.items) {
+                    ItemMount::MountAt(mount_path) => Some((path.join(mount_path), data)),
+                    ItemMount::DoNotMount => None,
+                },
+            )
+            .map(|(file_path, data)| async move { tokio::fs::write(file_path, &data).await });
+        futures::future::join_all(data)
+            .await
+            .into_iter()
+            .collect::<tokio::io::Result<_>>()?;
+
+        Ok(Ref {
+            host_path: path,
+            volume_type: VolumeType::Secret,
+        })
+    }
+
+    async fn unmount(&mut self, _base_path: &Path) -> anyhow::Result<()> {
+        // Unmounting handled by external Ref type
+        Ok(())
+    }
 }


### PR DESCRIPTION
This adds a new `Mountable` trait that any volume can implement. Things
are better than before but not perfect and I think further refactor of
how we store references to volumes should be done before we hit 1.0.

Closes #482