### PR TITLE
ref(volume): Streamlines how volumes are mounted and unmounted

### DIFF
--- a/crates/kubelet/src/pod/mod.rs
+++ b/crates/kubelet/src/pod/mod.rs
@@ -2,9 +2,8 @@
 mod handle;
 pub mod state;
 mod status;
-// Ignore deprecated here as this is just a reexport
-#[allow(deprecated)]
-pub use handle::{key_from_pod, pod_key, Handle};
+
+pub use handle::Handle;
 pub(crate) use status::initialize_pod_container_statuses;
 pub use status::{
     make_registered_status, make_status, make_status_with_containers, patch_status, Phase, Status,

--- a/crates/kubelet/src/state/common/mod.rs
+++ b/crates/kubelet/src/state/common/mod.rs
@@ -63,7 +63,7 @@ pub trait GenericPodState: ObjectState<Manifest = Pod, Status = PodStatus> {
     /// Stores the pod volume references for future mounting into
     /// the provider's execution environment. Typically your
     /// implementation can just move the volumes map into a member field.
-    async fn set_volumes(&mut self, volumes: HashMap<String, crate::volume::Ref>);
+    async fn set_volumes(&mut self, volumes: HashMap<String, crate::volume::VolumeRef>);
     /// Backs off (waits) after an error of the specified kind.
     async fn backoff(&mut self, sequence: BackoffSequence);
     /// Resets the backoff time for the specified kind of error.

--- a/crates/kubelet/src/volume/hostpath.rs
+++ b/crates/kubelet/src/volume/hostpath.rs
@@ -1,32 +1,33 @@
-use k8s_openapi::api::core::v1::HostPathVolumeSource;
+use k8s_openapi::api::core::v1::Volume as KubeVolume;
 
 use super::*;
 
+/// A type that can manage a HostPath volume with mounting and unmounting support
 pub struct HostPathVolume {
     host_path: PathBuf,
 }
 
 impl HostPathVolume {
-    pub fn new(source: &HostPathVolumeSource) -> Self {
-        HostPathVolume {
+    /// Creates a new HostPath volume from a Kubernetes volume object. Passing a non-HostPath volume
+    /// type will result in an error
+    pub fn new(vol: &KubeVolume) -> anyhow::Result<Self> {
+        let source = vol.host_path.as_ref().ok_or_else(|| {
+            anyhow::anyhow!("Called a HostPath volume constructor with a non-HostPath volume")
+        })?;
+        Ok(HostPathVolume {
             host_path: PathBuf::from(&source.path),
-        }
-    }
-}
-
-#[async_trait::async_trait]
-impl Mountable for HostPathVolume {
-    async fn mount(&mut self, _base_path: &Path) -> anyhow::Result<Ref> {
-        // Check the the directory exists on the host
-        tokio::fs::metadata(&self.host_path).await?;
-        Ok(Ref {
-            host_path: self.host_path.clone(),
-            volume_type: VolumeType::HostPath,
         })
     }
 
-    async fn unmount(&mut self, _base_path: &Path) -> anyhow::Result<()> {
-        // Not needed here as it is a host path
+    /// Returns the hostpath specified by the volume config
+    pub fn get_path(&self) -> Option<&Path> {
+        Some(self.host_path.as_path())
+    }
+
+    /// Mounts the configured host path volume. This just checks that the directory exists
+    pub async fn mount(&mut self) -> anyhow::Result<()> {
+        // Check the the directory exists on the host
+        tokio::fs::metadata(&self.host_path).await?;
         Ok(())
     }
 }

--- a/crates/kubelet/src/volume/mod.rs
+++ b/crates/kubelet/src/volume/mod.rs
@@ -2,14 +2,13 @@
 //! mandatory to create a Provider, but it does provide common implementation
 //! logic for supported volume providers.
 use std::collections::HashMap;
-use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use k8s_openapi::api::core::v1::KeyToPath;
 use k8s_openapi::api::core::v1::{PersistentVolumeClaim, Secret, Volume as KubeVolume};
 use kube::api::Api;
-use tracing::{debug, error};
+use tracing::error;
 
 use crate::plugin_watcher::PluginRegistry;
 use crate::pod::Pod;
@@ -18,6 +17,11 @@ mod configmap;
 mod hostpath;
 mod persistentvolumeclaim;
 mod secret;
+
+pub use configmap::ConfigMapVolume;
+pub use hostpath::HostPathVolume;
+pub use persistentvolumeclaim::PvcVolume;
+pub use secret::SecretVolume;
 
 /// type of volume
 #[derive(Debug)]
@@ -32,110 +36,73 @@ pub enum VolumeType {
     HostPath,
 }
 
-/// A trait that can be implemented for something that can be mounted as a volume inside of a Pod
-#[async_trait::async_trait]
-pub trait Mountable {
-    /// Mounts the object inside of the given base_path directory. Generally it will be mounted at a
-    /// directory that is the base_path + the name of the volume
-    async fn mount(&mut self, base_path: &Path) -> anyhow::Result<Ref>;
-
-    // TODO(thomastaylor312): I don't like having to pass the path again, but that is how the
-    // current system works. Perhaps we should keep the `Mountable` part in memory instead of a Ref,
-    // but that is a separate refactor
-    /// Unmounts the object from the given base_path
-    async fn unmount(&mut self, base_path: &Path) -> anyhow::Result<()>;
+/// A reference to a volume that can be mounted and unmounted. A `VolumeRef` should be stored
+/// alongside a pod handle as a way to manage the lifecycle of a Pod's volume. Each embedded type
+/// can be used separately as well
+pub enum VolumeRef {
+    /// configmap volume
+    ConfigMap(ConfigMapVolume),
+    /// secret volume
+    Secret(SecretVolume),
+    /// PVC volume
+    PersistentVolumeClaim(PvcVolume),
+    /// hostpath volume
+    HostPath(HostPathVolume),
 }
 
-/// A smart wrapper around the location of a volume on the host system. If this
-/// is a ConfigMap or Secret volume, dropping this reference will clean up the
-/// temporary volume. [AsRef] and [std::ops::Deref] are implemented for this
-/// type so you can still use it like a normal PathBuf
-#[derive(Debug)]
-pub struct Ref {
-    host_path: PathBuf,
-    volume_type: VolumeType,
-}
-
-impl Ref {
-    /// Resolves the volumes for a pod, including preparing temporary
-    /// directories containing the contents of secrets and configmaps. Returns a
-    /// HashMap of volume names to a PathBuf for the directory where the volume
-    /// is mounted
+impl VolumeRef {
+    /// Resolves the volumes for a pod.
     pub async fn volumes_from_pod(
-        volume_dir: &Path,
         pod: &Pod,
         client: &kube::Client,
         plugin_registry: Option<Arc<PluginRegistry>>,
     ) -> anyhow::Result<HashMap<String, Self>> {
-        let base_path = volume_dir.join(pod_dir_name(pod));
-        let path: &Path = base_path.as_ref();
-        tokio::fs::create_dir_all(&base_path).await?;
-        let volumes = get_mountable_pod_volumes(pod, client, plugin_registry)
-            .await?
-            .into_iter()
-            .map(|(k, mut m)| async move { Ok((k, m.mount(path).await?)) });
-        futures::future::join_all(volumes)
-            .await
-            .into_iter()
-            .collect::<anyhow::Result<_>>()
-    }
-
-    /// Unmounts any volumes mounted to the pod. Usually called when dropping
-    /// the pod out of scope.
-    pub async fn unmount_volumes_from_pod(
-        volume_dir: &Path,
-        pod: &Pod,
-        client: &kube::Client,
-        plugin_registry: Option<Arc<PluginRegistry>>,
-    ) -> anyhow::Result<()> {
-        let base_path = volume_dir.join(pod_dir_name(pod));
-        let path: &Path = base_path.as_ref();
-        let volumes = get_mountable_pod_volumes(pod, client, plugin_registry)
-            .await?
-            .into_iter()
-            .map(|(_, mut m)| async move { m.unmount(path).await });
-        futures::future::join_all(volumes)
-            .await
-            .into_iter()
-            .collect::<anyhow::Result<_>>()
-    }
-}
-
-impl AsRef<PathBuf> for Ref {
-    fn as_ref(&self) -> &PathBuf {
-        &self.host_path
-    }
-}
-
-impl Deref for Ref {
-    type Target = PathBuf;
-
-    fn deref(&self) -> &Self::Target {
-        &self.host_path
-    }
-}
-
-impl Drop for Ref {
-    fn drop(&mut self) {
-        if matches!(self.volume_type, VolumeType::ConfigMap | VolumeType::Secret) {
-            // TODO: Currently there is no way to do this async (though there is
-            // an async destructors proposal)
-            debug!(
-                "deleting {:?} directory {:?}",
-                self.volume_type, self.host_path
-            );
-            std::fs::remove_dir_all(&self.host_path).unwrap_or_else(|e| {
-                error!(
-                    "unable to delete directory {:?} on volume cleanup: {:?}",
-                    self.host_path, e
-                )
+        let zero_vec = Vec::with_capacity(0);
+        let vols = pod
+            .volumes()
+            .unwrap_or(&zero_vec)
+            .iter()
+            .map(|v| (v, plugin_registry.clone()))
+            .map(|(vol, pr)| async move {
+                Ok((
+                    vol.name.clone(),
+                    to_volume_ref(vol, pod.namespace(), client, pr).await?,
+                ))
             });
+        futures::future::join_all(vols).await.into_iter().collect()
+    }
+
+    /// A convenience wrapper that calls the correct get_path method for the variant. Returns the
+    /// path the volume is mounted at on the host, `None` if the volume hasn't been mounted
+    pub fn get_path(&self) -> Option<&Path> {
+        match self {
+            VolumeRef::ConfigMap(cm) => cm.get_path(),
+            VolumeRef::Secret(sec) => sec.get_path(),
+            VolumeRef::PersistentVolumeClaim(pv) => pv.get_path(),
+            VolumeRef::HostPath(host) => host.get_path(),
         }
     }
-}
 
-fn pod_dir_name(pod: &Pod) -> String {
-    format!("{}-{}", pod.name(), pod.namespace())
+    /// A convenience wrapper that calls the correct mount function for the variant
+    pub async fn mount(&mut self, path: impl AsRef<Path>) -> anyhow::Result<()> {
+        match self {
+            VolumeRef::ConfigMap(cm) => cm.mount(path).await,
+            VolumeRef::Secret(sec) => sec.mount(path).await,
+            VolumeRef::PersistentVolumeClaim(pv) => pv.mount(path).await,
+            VolumeRef::HostPath(host) => host.mount().await,
+        }
+    }
+
+    /// A convenience wrapper that calls the correct unmount function for the variant
+    pub async fn unmount(&mut self) -> anyhow::Result<()> {
+        match self {
+            VolumeRef::ConfigMap(cm) => cm.unmount().await,
+            VolumeRef::Secret(sec) => sec.unmount().await,
+            VolumeRef::PersistentVolumeClaim(pv) => pv.unmount().await,
+            // Doesn't need any unmounting steps
+            VolumeRef::HostPath(_) => Ok(()),
+        }
+    }
 }
 
 fn mount_setting_for(key: &str, items_to_mount: &Option<Vec<KeyToPath>>) -> ItemMount {
@@ -164,73 +131,30 @@ impl From<Option<String>> for ItemMount {
     }
 }
 
-/// Converts a Vec of KubeVolumes into a Vec of Mountable Volumes
-async fn get_mountable_pod_volumes(
-    pod: &Pod,
-    client: &kube::Client,
-    plugin_registry: Option<Arc<PluginRegistry>>,
-) -> anyhow::Result<Vec<(String, Box<dyn Mountable + Send>)>> {
-    let zero_vec = Vec::with_capacity(0);
-    let mountables = pod
-        .volumes()
-        .unwrap_or(&zero_vec)
-        .iter()
-        .map(|v| (v, plugin_registry.clone()))
-        .map(|(vol, pr)| async move {
-            Ok((
-                vol.name.clone(),
-                to_mountable(vol, pod.namespace(), client, pr).await?,
-            ))
-        });
-    futures::future::join_all(mountables)
-        .await
-        .into_iter()
-        .collect()
-}
-
-async fn to_mountable(
+async fn to_volume_ref(
     vol: &KubeVolume,
     namespace: &str,
     client: &kube::Client,
     plugin_registry: Option<Arc<PluginRegistry>>,
-) -> anyhow::Result<Box<dyn Mountable + Send>> {
-    if let Some(cm) = &vol.config_map {
-        let name = &cm
-            .name
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("no configmap name was given"))?;
-        Ok(Box::new(configmap::ConfigMapVolume::new(
-            &vol.name,
-            name,
+) -> anyhow::Result<VolumeRef> {
+    if vol.config_map.is_some() {
+        Ok(VolumeRef::ConfigMap(ConfigMapVolume::new(
+            vol,
             namespace,
             client.clone(),
-            cm.items.clone(),
-        )))
-    } else if let Some(s) = &vol.secret {
-        let name = &s
-            .secret_name
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("no secret name was given"))?;
-        Ok(Box::new(secret::SecretVolume::new(
-            &vol.name,
-            name,
+        )?))
+    } else if vol.secret.is_some() {
+        Ok(VolumeRef::Secret(SecretVolume::new(
+            vol,
             namespace,
             client.clone(),
-            s.items.clone(),
-        )))
-    } else if let Some(pvc_source) = &vol.persistent_volume_claim {
-        Ok(Box::new(
-            persistentvolumeclaim::PvcVolume::new(
-                pvc_source,
-                client.clone(),
-                &vol.name,
-                namespace,
-                plugin_registry,
-            )
-            .await?,
+        )?))
+    } else if vol.persistent_volume_claim.is_some() {
+        Ok(VolumeRef::PersistentVolumeClaim(
+            PvcVolume::new(vol, namespace, client.clone(), plugin_registry).await?,
         ))
-    } else if let Some(hp) = &vol.host_path {
-        Ok(Box::new(hostpath::HostPathVolume::new(hp)))
+    } else if vol.host_path.is_some() {
+        Ok(VolumeRef::HostPath(hostpath::HostPathVolume::new(vol)?))
     } else {
         Err(anyhow::anyhow!(
             "Unsupported volume type. Currently supported types: ConfigMap, Secret, PersistentVolumeClaim, and HostPath"

--- a/crates/kubelet/src/volume/secret.rs
+++ b/crates/kubelet/src/volume/secret.rs
@@ -1,39 +1,50 @@
 use std::path::Path;
 
-use k8s_openapi::api::core::v1::{KeyToPath, Secret};
+use k8s_openapi::api::core::v1::{KeyToPath, Secret, Volume as KubeVolume};
 use k8s_openapi::ByteString;
+use tracing::warn;
 
 use super::*;
 
+/// A type that can manage a Secret volume with mounting and unmounting support
 pub struct SecretVolume {
     vol_name: String,
     sec_name: String,
     client: kube::Api<Secret>,
     items: Option<Vec<KeyToPath>>,
+    mounted_path: Option<PathBuf>,
 }
 
 impl SecretVolume {
-    pub fn new(
-        vol_name: &str,
-        sec_name: &str,
-        namespace: &str,
-        client: kube::Client,
-        items: Option<Vec<KeyToPath>>,
-    ) -> Self {
-        SecretVolume {
-            vol_name: vol_name.to_owned(),
-            sec_name: sec_name.to_owned(),
+    /// Creates a new Secret volume from a Kubernetes volume object. Passing a non-Secret volume
+    /// type will result in an error
+    pub fn new(vol: &KubeVolume, namespace: &str, client: kube::Client) -> anyhow::Result<Self> {
+        let sec_source = vol.secret.as_ref().ok_or_else(|| {
+            anyhow::anyhow!("Called a Secret volume constructor with a non-Secret volume")
+        })?;
+        Ok(SecretVolume {
+            vol_name: vol.name.clone(),
+            sec_name: sec_source
+                .secret_name
+                .clone()
+                .ok_or_else(|| anyhow::anyhow!("Secret volume does not have a name"))?,
             client: Api::namespaced(client, namespace),
-            items,
-        }
+            items: sec_source.items.clone(),
+            mounted_path: None,
+        })
     }
-}
 
-#[async_trait::async_trait]
-impl Mountable for SecretVolume {
-    async fn mount(&mut self, base_path: &Path) -> anyhow::Result<Ref> {
+    /// Returns the path where the volume is mounted on the host. Will return `None` if the volume
+    /// hasn't been mounted yet
+    pub fn get_path(&self) -> Option<&Path> {
+        self.mounted_path.as_deref()
+    }
+
+    /// Mounts the Secret volume in the given directory. The actual path will be
+    /// $BASE_PATH/$VOLUME_NAME
+    pub async fn mount(&mut self, base_path: impl AsRef<Path>) -> anyhow::Result<()> {
         let secret = self.client.get(&self.sec_name).await?;
-        let path = base_path.join(&self.vol_name);
+        let path = base_path.as_ref().join(&self.vol_name);
         tokio::fs::create_dir_all(&path).await?;
         let data = secret.data.unwrap_or_default();
         // We could probably just move the data out of the option, but I don't know what the correct
@@ -52,14 +63,22 @@ impl Mountable for SecretVolume {
             .into_iter()
             .collect::<tokio::io::Result<_>>()?;
 
-        Ok(Ref {
-            host_path: path,
-            volume_type: VolumeType::Secret,
-        })
+        self.mounted_path = Some(path);
+
+        Ok(())
     }
 
-    async fn unmount(&mut self, _base_path: &Path) -> anyhow::Result<()> {
-        // Unmounting handled by external Ref type
+    /// Unmounts the directory, which removes all files. Calling `unmount` on a directory that
+    /// hasn't been mounted will log a warning, but otherwise not error
+    pub async fn unmount(&mut self) -> anyhow::Result<()> {
+        match self.mounted_path.take() {
+            Some(p) => {
+                tokio::fs::remove_dir_all(p).await?;
+            }
+            None => {
+                warn!("Attempted to unmount ConfigMap directory that wasn't mounted, this generally shouldn't happen");
+            }
+        }
         Ok(())
     }
 }

--- a/crates/wasi-provider/src/lib.rs
+++ b/crates/wasi-provider/src/lib.rs
@@ -49,7 +49,7 @@ use kubelet::state::common::registered::Registered;
 use kubelet::state::common::terminated::Terminated;
 use kubelet::state::common::{GenericProvider, GenericProviderState};
 use kubelet::store::Store;
-use kubelet::volume::Ref;
+use kubelet::volume::VolumeRef;
 use tokio::sync::RwLock;
 use wasi_runtime::Runtime;
 
@@ -134,7 +134,7 @@ impl WasiProvider {
 
 struct ModuleRunContext {
     modules: HashMap<String, Vec<u8>>,
-    volumes: HashMap<String, Ref>,
+    volumes: HashMap<String, VolumeRef>,
 }
 
 #[async_trait::async_trait]

--- a/crates/wasi-provider/src/states/container/waiting.rs
+++ b/crates/wasi-provider/src/states/container/waiting.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::ops::Deref;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -9,7 +8,7 @@ use tracing::{debug, info};
 use kubelet::container::state::prelude::*;
 use kubelet::pod::{Handle as PodHandle, PodKey};
 use kubelet::state::common::GenericProviderState;
-use kubelet::volume::Ref;
+use kubelet::volume::VolumeRef;
 
 use crate::wasi_runtime::WasiRuntime;
 use crate::ProviderState;
@@ -20,7 +19,7 @@ use super::ContainerState;
 
 fn volume_path_map(
     container: &Container,
-    volumes: &HashMap<String, Ref>,
+    volumes: &HashMap<String, VolumeRef>,
 ) -> anyhow::Result<HashMap<PathBuf, Option<PathBuf>>> {
     if let Some(volume_mounts) = container.volume_mounts().as_ref() {
         volume_mounts
@@ -34,13 +33,16 @@ fn volume_path_map(
                         container.name()
                     )
                 })?;
+                let host_path = vol.get_path().map(|p| p.to_owned()).ok_or_else(|| {
+                    anyhow::anyhow!("Volume {} has not been mounted yet", vm.name)
+                })?;
                 let mut guest_path = PathBuf::from(&vm.mount_path);
                 if let Some(sub_path) = &vm.sub_path {
                     guest_path.push(sub_path);
                 }
                 // We can safely assume that this should be valid UTF-8 because it would have
                 // been validated by the k8s API
-                Ok((vol.deref().clone(), Some(guest_path)))
+                Ok((host_path, Some(guest_path)))
             })
             .collect::<anyhow::Result<HashMap<PathBuf, Option<PathBuf>>>>()
     } else {
@@ -174,9 +176,9 @@ impl State<ContainerState> for Waiting {
         {
             let provider_state = shared.write().await;
             let mut handles_writer = provider_state.handles.write().await;
-            let pod_handle = handles_writer.entry(pod_key).or_insert_with(|| {
-                Arc::new(PodHandle::new(HashMap::new(), state.pod.clone(), None))
-            });
+            let pod_handle = handles_writer
+                .entry(pod_key)
+                .or_insert_with(|| Arc::new(PodHandle::new(HashMap::new(), state.pod.clone())));
             pod_handle
                 .insert_container_handle(state.container_key.clone(), container_handle)
                 .await;


### PR DESCRIPTION
This builds on #584 (well actually tears down the original idea, but
you get it) and makes volume management all handled by the same object.
This is a breaking change that removes the `Ref` type and replaces it
with a fully managed `VolumeRef` type. I am not entirely happy with having
the unmounting being handled in the async_drop stage, but it is good enough
for now. It wouldn't be a breaking change to make it a new state down the line
if we want to move it.

Closes #585