### PR TITLE
chore(*): Updates the kubelet crate to use tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,20 +736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "atty",
- "humantime 1.3.0",
- "log 0.4.14",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
-dependencies = [
- "atty",
- "humantime 2.1.0",
+ "humantime",
  "log 0.4.14",
  "regex",
  "termcolor",
@@ -1191,12 +1178,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "hyper"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1526,7 +1507,6 @@ dependencies = [
  "anyhow",
  "compiletest_rs",
  "dirs-next",
- "env_logger 0.8.3",
  "futures",
  "hostname",
  "k8s-openapi",
@@ -1542,6 +1522,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio 1.2.0",
+ "tracing-subscriber",
  "wasi-provider",
 ]
 
@@ -1664,6 +1645,7 @@ dependencies = [
  "tonic-build",
  "tower",
  "tracing",
+ "tracing-futures",
  "url 2.2.1",
  "uuid",
  "version-sync",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ oci-distribution = { path = "./crates/oci-distribution", version = "0.6", defaul
 dirs = { package = "dirs-next", version = "2.0.0" }
 hostname = "0.3"
 regex = "1.3"
-env_logger = "0.8"
+tracing-subscriber = "0.2"
 
 [dev-dependencies]
 serde_derive = "1.0"

--- a/crates/kubelet/Cargo.toml
+++ b/crates/kubelet/Cargo.toml
@@ -72,7 +72,8 @@ prost-types = "0.7"
 notify = "5.0.0-pre.3"
 async-stream = "0.3"
 tower = { version = "0.4.2", features = ["util"] }
-tracing = { version = "0.1", features = ['log'] }
+tracing = { version = "0.1", features = ["log"] }
+tracing-futures = "0.2"
 
 [target.'cfg(target_family = "windows")'.dependencies]
 mio = "0.6"

--- a/crates/kubelet/src/container/state.rs
+++ b/crates/kubelet/src/container/state.rs
@@ -7,7 +7,8 @@ use futures::StreamExt;
 use k8s_openapi::api::core::v1::Pod as KubePod;
 use krator::{Manifest, ObjectState, SharedState, State, Transition};
 use kube::api::Api;
-use tracing::{debug, error, warn};
+use tracing::{debug, error, warn, instrument};
+use tracing_futures::Instrument;
 
 /// Prelude for Pod state machines.
 pub mod prelude {
@@ -16,6 +17,22 @@ pub mod prelude {
 }
 
 /// Iteratively evaluate state machine until it returns Complete.
+#[instrument(
+    level = "info", 
+    skip(
+        client,
+        initial_state,
+        shared,
+        container_state,
+        pod,
+        container_name
+    ), 
+    fields(
+        pod_name,
+        namespace,
+        container = %container_name
+    )
+)]
 pub async fn run_to_completion<S: ObjectState<Manifest = Container, Status = Status>>(
     client: &kube::Client,
     initial_state: impl State<S>,
@@ -44,35 +61,33 @@ pub async fn run_to_completion<S: ObjectState<Manifest = Container, Status = Sta
     let (container_tx, container_rx) = Manifest::new(initial_container);
     let mut task_pod = pod.clone();
     let task_container_name = container_name.clone();
-    tokio::spawn(async move {
-        while let Some(latest_pod) = task_pod.next().await {
-            let latest_container = match latest_pod.find_container(&task_container_name) {
-                Some(container) => container,
-                None => {
-                    error!(
-                        "Unable to locate container {} in pod {} manifest.",
-                        &task_container_name,
-                        latest_pod.name()
-                    );
-                    continue;
-                }
-            };
+    tokio::spawn(
+        async move {
+            while let Some(latest_pod) = task_pod.next().await {
+                let latest_container = match latest_pod.find_container(&task_container_name) {
+                    Some(container) => container,
+                    None => {
+                        error!("Unable to locate container in pod manifest");
+                        continue;
+                    }
+                };
 
-            match container_tx.send(latest_container) {
-                Ok(()) => (),
-                Err(_) => {
-                    debug!("Container update receiver hung up, exiting.");
-                    return;
+                match container_tx.send(latest_container) {
+                    Ok(()) => (),
+                    Err(_) => {
+                        debug!("Container update receiver hung up, exiting");
+                        return;
+                    }
                 }
             }
         }
-    });
+        .instrument(
+            tracing::trace_span!("manifest_updater", %pod_name, %namespace, %container_name),
+        ),
+    );
 
     loop {
-        debug!(
-            "Pod {} container {} entering state {:?}",
-            &pod_name, container_name, state
-        );
+        debug!(?state, "Pod container entering state");
 
         let latest_pod = pod.latest();
         let latest_container = latest_pod.find_container(&container_name).unwrap();
@@ -83,23 +98,23 @@ pub async fn run_to_completion<S: ObjectState<Manifest = Container, Status = Sta
                     Ok(_) => (),
                     Err(e) => {
                         warn!(
-                            "Pod {} container {} status patch request returned error: {:?}",
-                            &pod_name, container_name, e
+                            error = %e,
+                            "Pod containerstatus patch request returned error"
                         );
                     }
                 }
             }
             Err(e) => {
                 warn!(
-                    "Pod {} container {} status patch returned error: {:?}",
-                    &pod_name, container_name, e
+                    error = %e,
+                    "Pod container status patch returned error"
                 );
             }
         }
 
         debug!(
-            "Pod {} container {} executing state handler {:?}",
-            &pod_name, container_name, state
+            ?state,
+            "Pod container executing state handler"
         );
         let transition = {
             state
@@ -110,24 +125,18 @@ pub async fn run_to_completion<S: ObjectState<Manifest = Container, Status = Sta
         state = match transition {
             Transition::Next(s) => {
                 let state = s.into();
-                debug!(
-                    "Pod {} container {} transitioning to {:?}.",
-                    &pod_name, container_name, state
-                );
+                debug!(?state, "Pod container transitioning to state");
                 state
             }
             Transition::Complete(result) => match result {
                 Ok(()) => {
-                    debug!(
-                        "Pod {} container {} state machine exited without error",
-                        &pod_name, container_name
-                    );
+                    debug!("Pod container state machine exited without error");
                     break result;
                 }
                 Err(ref e) => {
                     error!(
-                        "Pod {} container {} state machine exited with error: {:?}",
-                        &pod_name, container_name, e
+                        error = %e,
+                        "Pod container state machine exited with error"
                     );
                     let status = Status::Terminated {
                         timestamp: Utc::now(),

--- a/crates/kubelet/src/fs_watch/mod.rs
+++ b/crates/kubelet/src/fs_watch/mod.rs
@@ -38,7 +38,7 @@ impl FileSystemWatcher {
         let (stream_tx, stream_rx) = unbounded_channel::<NotifyResult<Event>>();
         let mut watcher: RecommendedWatcher = Watcher::new_immediate(move |res| {
             if let Err(e) = stream_tx.send(res) {
-                error!("Unable to send inotify event into stream: {:?}", e)
+                error!(error = %e, "Unable to send inotify event into stream")
             }
         })?;
         watcher.configure(Config::PreciseEvents(true))?;
@@ -83,9 +83,9 @@ mod mac {
                 Ok(set) => set,
                 Err(e) => {
                     error!(
-                        "Unable to refresh directory {}, will attempt again: {:?}",
-                        path.display(),
-                        e
+                        error = %e,
+                        path = %path.display(),
+                        "Unable to refresh directory, will attempt again"
                     );
                     HashSet::new()
                 }
@@ -96,12 +96,12 @@ mod mac {
                     Ok(set) => set,
                     Err(e) => {
                         error!(
-                            "Unable to refresh directory {}, will attempt again: {:?}",
-                            path.display(),
-                            e
+                            error = %e,
+                            path = %path.display(),
+                            "Unable to refresh directory, will attempt again"
                         );
                         if let Err(e) = tx.send(Err(NotifyError::io(e))) {
-                            error!("Unable to send error {:?} due to channel being closed", e.0);
+                            error!(result = ?e.0, "Unable to send error due to channel being closed");
                         }
                         continue;
                     }
@@ -172,8 +172,8 @@ mod mac {
             // At this point there isn't much we can do as the channel is closed. So just log an
             // error
             error!(
-                "Unable to send event {:?} due to the channel being closed",
-                e.0
+                result = ?e.0,
+                "Unable to send event due to the channel being closed"
             );
         }
     }

--- a/crates/kubelet/src/kubelet.rs
+++ b/crates/kubelet/src/kubelet.rs
@@ -85,14 +85,14 @@ impl<P: Provider> Kubelet<P> {
         let services = Box::pin(async {
             tokio::select! {
                 res = signal_task => if let Err(e) = res {
-                    error!("Signal task completed with error {:?}", &e);
+                    error!(error = %e, "Signal task completed with error");
                 },
-                res = webserver => error!("Webserver task completed with result {:?}", &res),
+                res = webserver => error!(result = ?res, "Webserver task completed with result"),
                 res = node_updater => if let Err(e) = res {
-                    error!("Node updater task completed with error {:?}", &e);
+                    error!(error = %e, "Node updater task completed with error");
                 },
                 res = plugin_registrar => if let Err(e) = res {
-                    error!("Plugin registrar task completed with error {:?}", &e);
+                    error!(error = %e, "Plugin registrar task completed with error");
                 }
             };
             // Use relaxed ordering because we just need other tasks to eventually catch the signal.
@@ -117,7 +117,7 @@ impl<P: Provider> Kubelet<P> {
                 res = signal_handler => match res {
                     Ok(()) => self.provider.shutdown(&self.config.node_name).await,
                     Err(e) => {
-                        error!("Signal handler task joined with error {:?}", &e);
+                        error!(error = %e, "Signal handler task joined with error");
                         Err(e)
                     }
                 },
@@ -187,7 +187,7 @@ async fn start_signal_handler(signal: Arc<AtomicBool>) -> anyhow::Result<()> {
     let duration = std::time::Duration::from_millis(100);
     loop {
         if signal.load(Ordering::Relaxed) {
-            info!("Signal caught.");
+            info!("Signal caught");
             // When the signal was caught we simply exit the loop here,
             // handling is done outside of this task to avoid having to
             // pass a reference to the provider here

--- a/crates/kubelet/src/log/mod.rs
+++ b/crates/kubelet/src/log/mod.rs
@@ -75,10 +75,10 @@ impl Sender {
         let b: hyper::body::Bytes = data.into();
         self.sender.send_data(b).await.map_err(|e| {
             if e.is_closed() {
-                debug!("channel closed.");
+                debug!("channel closed");
                 SendError::ChannelClosed
             } else {
-                error!("channel error: {}", e);
+                error!(error = %e, "channel error");
                 SendError::Abnormal(anyhow::Error::new(e))
             }
         })
@@ -96,9 +96,10 @@ async fn tail<R: AsyncRead + std::marker::Unpin>(
     while let Some(line) = match lines.next_line().await {
         Ok(line) => line,
         Err(e) => {
-            let err = format!("Error reading from log: {:?}", e);
-            error!("{}", &err);
-            sender.send(err).await?;
+            error!(error = %e, "Error reading from log");
+            sender
+                .send(format!("Error reading from log: {:?}", e))
+                .await?;
             return Err(e.into());
         }
     } {
@@ -123,9 +124,10 @@ async fn stream_to_end<R: AsyncRead + std::marker::Unpin>(
     while let Some(mut line) = match lines.next_line().await {
         Ok(line) => line,
         Err(e) => {
-            let err = format!("Error reading from log: {:?}", e);
-            error!("{}", &err);
-            sender.send(err).await?;
+            error!(error = %e, "Error reading from log");
+            sender
+                .send(format!("Error reading from log: {:?}", e))
+                .await?;
             return Err(e.into());
         }
     } {

--- a/crates/kubelet/src/pod/handle.rs
+++ b/crates/kubelet/src/pod/handle.rs
@@ -66,13 +66,15 @@ impl<H: StopHandler, F> Handle<H, F> {
         {
             let mut handles = self.container_handles.write().await;
             for (key, handle) in handles.iter_mut() {
-                info!("Stopping container: {}", key);
+                info!(container_name = %key, "Stopping container");
                 match handle.stop().await {
-                    Ok(_) => debug!("Successfully stopped container {}", key),
+                    Ok(_) => debug!(container_name = %key, "Successfully stopped container"),
                     // NOTE: I am not sure what recovery or retry steps should be
                     // done here, but we should definitely continue and try to stop
                     // the other containers
-                    Err(e) => error!("Error while trying to stop pod {}: {:?}", key, e),
+                    Err(e) => {
+                        error!(container_name = %key, error = %e, "Error while trying to stop pod")
+                    }
                 }
             }
         }

--- a/crates/kubelet/src/provider/mod.rs
+++ b/crates/kubelet/src/provider/mod.rs
@@ -6,7 +6,7 @@ use k8s_openapi::api::core::v1::{ConfigMap, EnvVarSource, Secret};
 use kube::api::Api;
 use std::sync::Arc;
 use thiserror::Error;
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 use crate::container::Container;
 use crate::log::Sender;
@@ -125,7 +125,7 @@ pub trait Provider: Sized + Send + Sync + 'static {
     /// * `node_name` - The name of the node object that was created by this Kubelet instance
     ///
     async fn shutdown(&self, node_name: &str) -> anyhow::Result<()> {
-        info!("Shutdown triggered for node {}, since no custom shutdown behavior was implemented Kubelet will simply shut down now.", node_name);
+        info!(node_name, "Shutdown triggered for node, since no custom shutdown behavior was implemented Kubelet will simply shut down now");
         Ok(())
     }
 
@@ -260,7 +260,7 @@ async fn on_missing_env_value(
                     .unwrap_or_default();
             }
             Err(e) => {
-                error!("Error fetching config map {}: {}", name, e);
+                error!(error = %e, name, "Error fetching config map");
                 return "".to_string();
             }
         }
@@ -284,7 +284,7 @@ async fn on_missing_env_value(
                     .unwrap_or_default();
             }
             Err(e) => {
-                error!("Error fetching secret {}: {}", name, e);
+                error!(error = %e, name, "Error fetching secret");
                 return String::new();
             }
         }
@@ -319,7 +319,7 @@ fn field_map(pod: &Pod) -> HashMap<String, String> {
         pod.pod_ip().unwrap_or_default().to_owned(),
     );
     pod.labels().iter().for_each(|(k, v)| {
-        info!("adding {} to labels", k);
+        debug!(item = %k, "adding to labels");
         map.insert(format!("metadata.labels.{}", k), v.clone());
     });
     pod.annotations().iter().for_each(|(k, v)| {

--- a/crates/kubelet/src/store/oci/file.rs
+++ b/crates/kubelet/src/store/oci/file.rs
@@ -70,7 +70,7 @@ impl Storer for FileStorer {
             ));
         }
 
-        debug!("Fetching image ref '{:?}' from disk", image_ref);
+        debug!(?image_ref, "Fetching image ref from disk");
         Ok(tokio::fs::read(path).await?)
     }
     async fn store(&mut self, image_ref: &Reference, image_data: ImageData) -> anyhow::Result<()> {

--- a/crates/wasi-provider/src/states.rs
+++ b/crates/wasi-provider/src/states.rs
@@ -7,7 +7,7 @@ pub(crate) mod pod;
 macro_rules! transition_to_error {
     ($slf:ident, $err:ident) => {{
         let aerr = anyhow::Error::from($err);
-        tracing::error!("{:?}", aerr);
+        tracing::error!(error = %aerr);
         let error_state =
             kubelet::state::common::error::Error::<crate::WasiProvider>::new(aerr.to_string());
         return Transition::next($slf, error_state);
@@ -20,7 +20,7 @@ macro_rules! transition_to_error {
 macro_rules! fail_fatal {
     ($err:ident) => {{
         let aerr = anyhow::Error::from($err);
-        tracing::error!("{:?}", aerr);
+        tracing::error!(error = %aerr);
         return Transition::Complete(Err(aerr));
     }};
 }

--- a/crates/wasi-provider/src/states/pod.rs
+++ b/crates/wasi-provider/src/states/pod.rs
@@ -41,7 +41,7 @@ impl ObjectState for PodState {
                 let unmounts = context.volumes.iter_mut().map(|(k, vol)| async move {
                     if let Err(e) = vol.unmount().await {
                         // Just log the error, as there isn't much we can do here
-                        error!("Unable to unmount volume {}: {}", k, e);
+                        error!(error = %e, volume_name = %k, "Unable to unmount volume");
                     }
                 });
                 futures::future::join_all(unmounts).await;

--- a/src/krustlet-wasi.rs
+++ b/src/krustlet-wasi.rs
@@ -13,7 +13,7 @@ async fn main() -> anyhow::Result<()> {
     let config = Config::new_from_file_and_flags(env!("CARGO_PKG_VERSION"), None);
 
     // Initialize the logger
-    env_logger::init();
+    tracing_subscriber::fmt::init();
 
     let kubeconfig = kubelet::bootstrap(&config, &config.bootstrap_file, notify_bootstrap).await?;
 


### PR DESCRIPTION
We had already dropped in the tracing crate, but were not using structured
fields. This adds structured fields to all log messages and switches from
the `env_logger` crate to the fmt subscriber.

Closes #583