### PR TITLE
feat(tests): Adds e2e tests for CSI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,8 @@ jobs:
           pathInArchive: just
       - name: Get NODE_IP
         run: echo "KRUSTLET_NODE_IP=$(ip addr ls eth0 | awk '/inet / {split($2, ary, /\//); print ary[1]}')" >> $GITHUB_ENV
+      - name: Apply RBAC rules for CSI tests
+        run: kubectl apply -f tests/csi/rbac.yaml
       - name: Run e2e tests (full)
         if: ${{ github.event_name == 'push' }}
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules/
 krustlet-wasi-e2e.stdout.txt
 krustlet-wasi-e2e.stderr.txt
 oneclick-logs
+csi-test-binaries

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1572,10 +1572,12 @@ name = "krustlet"
 version = "0.7.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "compiletest_rs",
  "dirs-next",
  "futures",
  "hostname",
+ "k8s-csi",
  "k8s-openapi",
  "krator",
  "kube",
@@ -1589,6 +1591,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio 1.2.0",
+ "tonic",
  "tracing-subscriber",
  "wasi-provider",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,15 +57,19 @@ dirs = { package = "dirs-next", version = "2.0.0" }
 hostname = "0.3"
 regex = "1.3"
 tracing-subscriber = "0.2"
+serde = "1.0"
 
 [dev-dependencies]
 serde_derive = "1.0"
 serde_json = "1.0"
-serde = "1.0"
 reqwest = { version = "0.11", default-features = false }
-tempfile = "3.1"
 kube-runtime = { version = "0.55", default-features = false }
 compiletest_rs = "0.6"
+tempfile = "3.2"
+k8s-csi = "0.3"
+tonic = "0.4"
+async-trait = "0.1"
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "time", "process"] }
 
 [workspace]
 members = [

--- a/crates/wasi-provider/src/wasi_runtime.rs
+++ b/crates/wasi-provider/src/wasi_runtime.rs
@@ -156,7 +156,7 @@ impl WasiRuntime {
 
         let name = self.name.clone();
         let handle = tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
-            let span = tracing::trace_span!("wasmtime_module_run", %name);
+            let span = tracing::info_span!("wasmtime_module_run", %name);
             let _enter = span.enter();
             // Log this info here so it isn't on _every_ log line
             trace!(env = ?data.env, args = ?data.args, dirs = ?data.dirs, "Starting setup of wasmtime module");

--- a/src/krustlet-wasi.rs
+++ b/src/krustlet-wasi.rs
@@ -15,6 +15,7 @@ async fn main() -> anyhow::Result<()> {
     // Initialize the logger
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();
 
     let kubeconfig = kubelet::bootstrap(&config, &config.bootstrap_file, notify_bootstrap).await?;

--- a/tests/csi/README.md
+++ b/tests/csi/README.md
@@ -1,0 +1,18 @@
+# CSI Test directory
+
+This directory contains the config for CSI RBAC (necessary if you are using
+KinD). Required binaries for the test are downloaded automatically when you use
+the `justfile`. Right now we only run these things on Linux because the
+Registrar is still missing [MacOS
+support](https://github.com/kubernetes-csi/node-driver-registrar/pull/133) and
+the mock driver would need to handle Windows, which would reuse our ugly code.
+It may be worth making some sort of more fully featured and separate mock driver
+in the future
+
+## Why not use the Docker images for these?
+
+Those would work here for our e2e tests since we are running a KinD node. However, we want these
+tests to reflect more real world usage and there is no guarantee that a Krustlet node will have a
+container runtime (nor do we want to require one). There is also the additional benefit of having
+this be some simple instructions of how you can build some of the key components to get CSI running
+for a Real World™ cluster.

--- a/tests/csi/mod.rs
+++ b/tests/csi/mod.rs
@@ -1,0 +1,370 @@
+pub mod setup;
+pub mod socket_server;
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use k8s_csi::v1_3_0::*;
+use k8s_csi::v1_3_0::{
+    controller_server::Controller,
+    controller_service_capability::rpc::Type as RpcType,
+    controller_service_capability::{Rpc, Type},
+    identity_server::Identity,
+    list_volumes_response::{Entry, VolumeStatus},
+    node_server::Node,
+    plugin_capability::service::Type as PluginRpcType,
+    plugin_capability::{Service, Type as PluginType},
+    validate_volume_capabilities_response::Confirmed,
+};
+use tokio::sync::RwLock;
+
+pub const DRIVER_NAME: &str = "mock.csi.krustlet.dev";
+
+#[derive(Clone)]
+pub struct MockCsiPlugin {
+    volumes: Arc<RwLock<HashSet<String>>>,
+    node_name: String,
+    pub node_publish_called: Arc<RwLock<bool>>,
+    pub node_unpublish_called: Arc<RwLock<bool>>,
+}
+
+impl MockCsiPlugin {
+    pub fn new(node_name: &str) -> Self {
+        MockCsiPlugin {
+            volumes: Arc::new(RwLock::new(HashSet::new())),
+            node_name: node_name.to_owned(),
+            node_publish_called: Default::default(),
+            node_unpublish_called: Default::default(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Controller for MockCsiPlugin {
+    /// Does nothing except keep track of the volume name. The module should
+    /// just use the empty directory created by krustlet
+    async fn create_volume(
+        &self,
+        request: tonic::Request<CreateVolumeRequest>,
+    ) -> Result<tonic::Response<CreateVolumeResponse>, tonic::Status> {
+        let req = request.into_inner();
+        let mut vols = self.volumes.write().await;
+        vols.insert(req.name.clone());
+        Ok(tonic::Response::new(CreateVolumeResponse {
+            volume: Some(Volume {
+                volume_id: req.name,
+                capacity_bytes: 0,
+                ..Default::default()
+            }),
+        }))
+    }
+
+    /// Removes the volume name from tracking
+    async fn delete_volume(
+        &self,
+        request: tonic::Request<DeleteVolumeRequest>,
+    ) -> Result<tonic::Response<DeleteVolumeResponse>, tonic::Status> {
+        let req = request.into_inner();
+        let mut vols = self.volumes.write().await;
+        vols.remove(&req.volume_id);
+        Ok(tonic::Response::new(DeleteVolumeResponse {}))
+    }
+
+    async fn controller_publish_volume(
+        &self,
+        _request: tonic::Request<ControllerPublishVolumeRequest>,
+    ) -> Result<tonic::Response<ControllerPublishVolumeResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(
+            "controller publish volume not implemented",
+        ))
+    }
+
+    async fn controller_unpublish_volume(
+        &self,
+        _request: tonic::Request<ControllerUnpublishVolumeRequest>,
+    ) -> Result<tonic::Response<ControllerUnpublishVolumeResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(
+            "controller unpublish volume not implemented",
+        ))
+    }
+
+    async fn validate_volume_capabilities(
+        &self,
+        request: tonic::Request<ValidateVolumeCapabilitiesRequest>,
+    ) -> Result<tonic::Response<ValidateVolumeCapabilitiesResponse>, tonic::Status> {
+        let req = request.into_inner();
+        // Super basic validation to emulate things somewhat
+        let vols = self.volumes.read().await;
+        if !vols.contains(&req.volume_id) {
+            return Err(tonic::Status::not_found("volume not found"));
+        }
+
+        for cap in req.volume_capabilities.iter() {
+            if cap.access_type.is_none() {
+                return Err(tonic::Status::invalid_argument(
+                    "An access type must be specified",
+                ));
+            }
+        }
+        Ok(tonic::Response::new(ValidateVolumeCapabilitiesResponse {
+            confirmed: Some(Confirmed {
+                volume_context: req.volume_context,
+                volume_capabilities: req.volume_capabilities,
+                parameters: req.parameters,
+            }),
+            message: String::new(),
+        }))
+    }
+
+    async fn list_volumes(
+        &self,
+        _request: tonic::Request<ListVolumesRequest>,
+    ) -> Result<tonic::Response<ListVolumesResponse>, tonic::Status> {
+        let vols = self.volumes.read().await;
+        // We are ignoring pagination here
+        Ok(tonic::Response::new(ListVolumesResponse {
+            next_token: String::new(),
+            entries: vols
+                .iter()
+                .cloned()
+                .map(|volume_id| Entry {
+                    volume: Some(Volume {
+                        volume_id,
+                        capacity_bytes: 0,
+                        ..Default::default()
+                    }),
+                    status: Some(VolumeStatus {
+                        published_node_ids: vec![self.node_name.clone()],
+                        volume_condition: Some(VolumeCondition {
+                            abnormal: false,
+                            message: String::from("Volume is a-ok"),
+                        }),
+                    }),
+                })
+                .collect(),
+        }))
+    }
+
+    async fn get_capacity(
+        &self,
+        _request: tonic::Request<GetCapacityRequest>,
+    ) -> Result<tonic::Response<GetCapacityResponse>, tonic::Status> {
+        Ok(tonic::Response::new(GetCapacityResponse {
+            available_capacity: 104857600, // 100 GB
+        }))
+    }
+
+    async fn controller_get_capabilities(
+        &self,
+        _request: tonic::Request<ControllerGetCapabilitiesRequest>,
+    ) -> Result<tonic::Response<ControllerGetCapabilitiesResponse>, tonic::Status> {
+        Ok(tonic::Response::new(ControllerGetCapabilitiesResponse {
+            capabilities: vec![
+                ControllerServiceCapability {
+                    r#type: Some(Type::Rpc(Rpc {
+                        r#type: RpcType::CreateDeleteVolume as i32,
+                    })),
+                },
+                ControllerServiceCapability {
+                    r#type: Some(Type::Rpc(Rpc {
+                        r#type: RpcType::GetVolume as i32,
+                    })),
+                },
+                ControllerServiceCapability {
+                    r#type: Some(Type::Rpc(Rpc {
+                        r#type: RpcType::GetCapacity as i32,
+                    })),
+                },
+                ControllerServiceCapability {
+                    r#type: Some(Type::Rpc(Rpc {
+                        r#type: RpcType::ListVolumes as i32,
+                    })),
+                },
+                ControllerServiceCapability {
+                    r#type: Some(Type::Rpc(Rpc {
+                        r#type: RpcType::VolumeCondition as i32,
+                    })),
+                },
+            ],
+        }))
+    }
+
+    async fn create_snapshot(
+        &self,
+        _request: tonic::Request<CreateSnapshotRequest>,
+    ) -> Result<tonic::Response<CreateSnapshotResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented("snapshots not implemented"))
+    }
+
+    async fn delete_snapshot(
+        &self,
+        _request: tonic::Request<DeleteSnapshotRequest>,
+    ) -> Result<tonic::Response<DeleteSnapshotResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented("snapshots not implemented"))
+    }
+
+    async fn list_snapshots(
+        &self,
+        _request: tonic::Request<ListSnapshotsRequest>,
+    ) -> Result<tonic::Response<ListSnapshotsResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented("snapshots not implemented"))
+    }
+
+    async fn controller_expand_volume(
+        &self,
+        _request: tonic::Request<ControllerExpandVolumeRequest>,
+    ) -> Result<tonic::Response<ControllerExpandVolumeResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(
+            "expand volume not implemented",
+        ))
+    }
+
+    async fn controller_get_volume(
+        &self,
+        request: tonic::Request<ControllerGetVolumeRequest>,
+    ) -> Result<tonic::Response<ControllerGetVolumeResponse>, tonic::Status> {
+        let req = request.into_inner();
+        self.volumes
+            .read()
+            .await
+            .contains(&req.volume_id)
+            .then(|| {
+                tonic::Response::new(ControllerGetVolumeResponse {
+                    volume: Some(Volume {
+                        volume_id: req.volume_id,
+                        capacity_bytes: 0,
+                        ..Default::default()
+                    }),
+                    status: Some(controller_get_volume_response::VolumeStatus {
+                        published_node_ids: vec![self.node_name.clone()],
+                        volume_condition: Some(VolumeCondition {
+                            abnormal: false,
+                            message: String::from("Volume is a-ok"),
+                        }),
+                    }),
+                })
+            })
+            .ok_or_else(|| tonic::Status::not_found("Volume not found"))
+    }
+}
+
+#[async_trait::async_trait]
+impl Node for MockCsiPlugin {
+    /// Our "publish" volume does nothing except check that the volume exists
+    /// and mark that the function was called
+    async fn node_publish_volume(
+        &self,
+        request: tonic::Request<NodePublishVolumeRequest>,
+    ) -> Result<tonic::Response<NodePublishVolumeResponse>, tonic::Status> {
+        let req = request.into_inner();
+        if !self.volumes.read().await.contains(&req.volume_id) {
+            return Err(tonic::Status::not_found("volume not found"));
+        }
+        let mut called = self.node_publish_called.write().await;
+        *called = true;
+        Ok(tonic::Response::new(NodePublishVolumeResponse {}))
+    }
+
+    async fn node_stage_volume(
+        &self,
+        _request: tonic::Request<NodeStageVolumeRequest>,
+    ) -> Result<tonic::Response<NodeStageVolumeResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented("stage/unstage not supported"))
+    }
+
+    async fn node_unstage_volume(
+        &self,
+        _request: tonic::Request<NodeUnstageVolumeRequest>,
+    ) -> Result<tonic::Response<NodeUnstageVolumeResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented("stage/unstage not supported"))
+    }
+
+    /// Our "unpublish" volume does nothing except check that the volume exists
+    /// and mark that the function was called
+    async fn node_unpublish_volume(
+        &self,
+        request: tonic::Request<NodeUnpublishVolumeRequest>,
+    ) -> Result<tonic::Response<NodeUnpublishVolumeResponse>, tonic::Status> {
+        let req = request.into_inner();
+        if !self.volumes.read().await.contains(&req.volume_id) {
+            return Err(tonic::Status::not_found("volume not found"));
+        }
+        let mut called = self.node_unpublish_called.write().await;
+        *called = true;
+        Ok(tonic::Response::new(NodeUnpublishVolumeResponse {}))
+    }
+
+    async fn node_get_volume_stats(
+        &self,
+        _request: tonic::Request<NodeGetVolumeStatsRequest>,
+    ) -> Result<tonic::Response<NodeGetVolumeStatsResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented("volume stats not supported"))
+    }
+
+    async fn node_expand_volume(
+        &self,
+        _request: tonic::Request<NodeExpandVolumeRequest>,
+    ) -> Result<tonic::Response<NodeExpandVolumeResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented("expand volume not supported"))
+    }
+
+    async fn node_get_capabilities(
+        &self,
+        _request: tonic::Request<NodeGetCapabilitiesRequest>,
+    ) -> Result<tonic::Response<NodeGetCapabilitiesResponse>, tonic::Status> {
+        Ok(tonic::Response::new(NodeGetCapabilitiesResponse {
+            // We don't support any of the extras here
+            capabilities: Vec::with_capacity(0),
+        }))
+    }
+
+    async fn node_get_info(
+        &self,
+        _request: tonic::Request<NodeGetInfoRequest>,
+    ) -> Result<tonic::Response<NodeGetInfoResponse>, tonic::Status> {
+        let mut segments = std::collections::BTreeMap::new();
+        segments.insert(
+            "topology.hostpath.csi/node".to_owned(),
+            self.node_name.clone(),
+        );
+        Ok(tonic::Response::new(NodeGetInfoResponse {
+            node_id: self.node_name.clone(),
+            max_volumes_per_node: 20,
+            accessible_topology: Some(Topology { segments }),
+        }))
+    }
+}
+
+#[async_trait::async_trait]
+impl Identity for MockCsiPlugin {
+    async fn get_plugin_info(
+        &self,
+        _request: tonic::Request<GetPluginInfoRequest>,
+    ) -> Result<tonic::Response<GetPluginInfoResponse>, tonic::Status> {
+        Ok(tonic::Response::new(GetPluginInfoResponse {
+            name: DRIVER_NAME.to_owned(),
+            vendor_version: String::from("v1.0.0"),
+            ..Default::default()
+        }))
+    }
+
+    async fn get_plugin_capabilities(
+        &self,
+        _request: tonic::Request<GetPluginCapabilitiesRequest>,
+    ) -> Result<tonic::Response<GetPluginCapabilitiesResponse>, tonic::Status> {
+        Ok(tonic::Response::new(GetPluginCapabilitiesResponse {
+            capabilities: vec![PluginCapability {
+                r#type: Some(PluginType::Service(Service {
+                    r#type: PluginRpcType::ControllerService as i32,
+                })),
+            }],
+        }))
+    }
+
+    async fn probe(
+        &self,
+        _request: tonic::Request<ProbeRequest>,
+    ) -> Result<tonic::Response<ProbeResponse>, tonic::Status> {
+        Ok(tonic::Response::new(ProbeResponse { ready: Some(true) }))
+    }
+}

--- a/tests/csi/rbac.yaml
+++ b/tests/csi/rbac.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: storageclass-reader
+rules:
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: node-storageclass-reader
+subjects:
+  - kind: Group
+    name: system:nodes
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: storageclass-reader

--- a/tests/csi/setup.rs
+++ b/tests/csi/setup.rs
@@ -1,0 +1,144 @@
+use std::ops::Deref;
+use std::path::Path;
+use tokio::process::Child;
+
+use tokio::sync::oneshot::{error::TryRecvError, Receiver};
+
+const LOG_DIR: &str = "oneclick-logs";
+const SOCKET_PATH: &str = "/tmp/csi.sock";
+
+/// A struct for keeping references to processes and tempdirs. All embedded data and processes will
+/// be cleaned up when dropped
+pub(crate) struct CsiRunner {
+    _processes: Vec<Child>,
+    _signal: Receiver<Option<String>>,
+    pub mock: super::MockCsiPlugin,
+}
+
+pub(crate) async fn launch_csi_things(node_name: &str) -> anyhow::Result<CsiRunner> {
+    let bin_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("csi-test-binaries");
+    let mut processes = Vec::with_capacity(3);
+
+    let (mut signal, mock) = driver_start(node_name).await?;
+
+    processes.push(external_provisioner_start(&bin_root)?);
+
+    processes.push(registrar_start(&bin_root)?);
+
+    // Check that something didn't crash
+    match signal.try_recv() {
+        Ok(None) => return Err(anyhow::anyhow!("Driver exited prematurely")),
+        Ok(Some(msg)) => return Err(anyhow::anyhow!("Driver exited with error: {}", msg)),
+        Err(TryRecvError::Closed) => {
+            return Err(anyhow::anyhow!(
+                "Sender was dropped, meaning the driver likely crashed"
+            ))
+        }
+        Err(TryRecvError::Empty) => (),
+    }
+
+    Ok(CsiRunner {
+        _processes: processes,
+        _signal: signal,
+        mock,
+    })
+}
+
+/// Starts the mock CSI driver with the data dir set to a temporary
+/// directory. Returns  a oneshot channel for checking if the process exited
+async fn driver_start(
+    node_name: &str,
+) -> anyhow::Result<(Receiver<Option<String>>, super::MockCsiPlugin)> {
+    // HACK: For some reason, implementing `Drop` on the socket isn't cleaning
+    // up the socket on shutdown (probably because the socket is still running
+    // when the `Drop` runs for the path), so this removes the path if it
+    // already exists
+    match tokio::fs::remove_file(SOCKET_PATH).await {
+        Ok(_) => (),
+        Err(e) if matches!(e.kind(), std::io::ErrorKind::NotFound) => (),
+        Err(e) => return Err(e.into()),
+    };
+    let socket = super::socket_server::Socket::new(SOCKET_PATH)
+        .expect("unable to setup server listening on socket");
+
+    let (tx, rx) = tokio::sync::oneshot::channel::<Option<String>>();
+
+    let plugin = super::MockCsiPlugin::new(node_name);
+
+    let owned_plugin = plugin.clone();
+    tokio::spawn(async move {
+        let serv = tonic::transport::Server::builder()
+            .add_service(k8s_csi::v1_3_0::identity_server::IdentityServer::new(
+                owned_plugin.clone(),
+            ))
+            .add_service(k8s_csi::v1_3_0::controller_server::ControllerServer::new(
+                owned_plugin.clone(),
+            ))
+            .add_service(k8s_csi::v1_3_0::node_server::NodeServer::new(owned_plugin))
+            .serve_with_incoming(socket);
+        match serv.await {
+            Ok(_) => tx.send(None),
+            Err(e) => tx.send(Some(e.to_string())),
+        }
+    });
+
+    println!("Mock CSI plugin started");
+
+    Ok((rx, plugin))
+}
+
+fn external_provisioner_start(bin_root: &Path) -> anyhow::Result<Child> {
+    let stdout = std::fs::File::create(Path::new(LOG_DIR).join("csi-provisioner.stdout"))?;
+    let stderr = std::fs::File::create(Path::new(LOG_DIR).join("csi-provisioner.stderr"))?;
+
+    let bin = bin_root.join("csi-provisioner");
+    let kubeconfig = dirs::home_dir()
+        .ok_or_else(|| anyhow::anyhow!("Unable to find homedir"))?
+        .join(".kube/config");
+
+    let process = tokio::process::Command::new(bin)
+        .args(&[
+            "--csi-address",
+            "/tmp/csi.sock",
+            "--kubeconfig",
+            kubeconfig.to_string_lossy().deref(),
+        ])
+        .stdout(stdout)
+        .stderr(stderr)
+        .kill_on_drop(true)
+        .spawn()?;
+
+    println!("CSI provisioner started");
+
+    Ok(process)
+}
+
+fn registrar_start(bin_root: &Path) -> anyhow::Result<Child> {
+    let stdout =
+        std::fs::File::create(Path::new(LOG_DIR).join("csi-node-driver-registrar.stdout"))?;
+    let stderr =
+        std::fs::File::create(Path::new(LOG_DIR).join("csi-node-driver-registrar.stderr"))?;
+
+    let bin = bin_root.join("csi-node-driver-registrar");
+    let krustlet_plugin_dir = dirs::home_dir()
+        .ok_or_else(|| anyhow::anyhow!("Unable to find homedir"))?
+        .join(".krustlet/plugins");
+
+    let process = tokio::process::Command::new(bin)
+        .args(&[
+            "--csi-address",
+            "/tmp/csi.sock",
+            "--kubelet-registration-path",
+            "/tmp/csi.sock",
+            "--plugin-registration-path",
+            krustlet_plugin_dir.to_string_lossy().deref(),
+        ])
+        .stdout(stdout)
+        .stderr(stderr)
+        .kill_on_drop(true)
+        .spawn()?;
+
+    println!("Node driver registrar started");
+
+    Ok(process)
+}

--- a/tests/csi/socket_server.rs
+++ b/tests/csi/socket_server.rs
@@ -1,0 +1,91 @@
+// Copied from the grpc_sock module in the Kubelet crate. The windows stuff is pretty hacky so it
+// shouldn't be exported from there. Before we make this cross platform in the future, we'll need to
+// make sure the server part works well on Windows
+
+use std::{
+    path::{Path, PathBuf},
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::Stream;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tonic::transport::server::Connected;
+
+#[derive(Debug)]
+pub struct UnixStream(tokio::net::UnixStream);
+
+/// A `PathBuf` that will get deleted on drop
+struct OwnedPathBuf {
+    inner: PathBuf,
+}
+
+impl Drop for OwnedPathBuf {
+    fn drop(&mut self) {
+        if let Err(e) = std::fs::remove_file(&self.inner) {
+            eprintln!(
+                "cleanup of file {} failed, manual cleanup needed: {}",
+                self.inner.display(),
+                e
+            );
+        }
+    }
+}
+
+pub struct Socket {
+    listener: tokio::net::UnixListener,
+    _socket_path: OwnedPathBuf,
+}
+
+impl Socket {
+    pub fn new<P: AsRef<Path> + ?Sized>(path: &P) -> anyhow::Result<Self> {
+        let listener = tokio::net::UnixListener::bind(path)?;
+        Ok(Socket {
+            listener,
+            _socket_path: OwnedPathBuf {
+                inner: path.as_ref().to_owned(),
+            },
+        })
+    }
+}
+
+impl Stream for Socket {
+    type Item = Result<UnixStream, std::io::Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match Pin::new(&mut self.listener).poll_accept(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(res) => Poll::Ready(Some(res.map(|(stream, _)| UnixStream(stream)))),
+        }
+    }
+}
+
+impl Connected for UnixStream {}
+
+impl AsyncRead for UnixStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.0).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for UnixStream {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.0).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.0).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.0).poll_shutdown(cx)
+    }
+}

--- a/tests/oneclick/src/main.rs
+++ b/tests/oneclick/src/main.rs
@@ -12,6 +12,7 @@ const EXIT_CODE_TESTS_FAILED: i32 = 1;
 const EXIT_CODE_NEED_MANUAL_CLEANUP: i32 = 2;
 const EXIT_CODE_BUILD_FAILED: i32 = 3;
 const LOG_DIR: &str = "oneclick-logs";
+const NODE_NAME: &str = "krustlet-wasi";
 
 fn main() {
     println!("Ensuring all binaries are built...");
@@ -381,7 +382,7 @@ impl OwnedChildProcess {
     fn terminate(&mut self) -> anyhow::Result<()> {
         match self.exited() {
             Ok(true) | Err(_) => {
-                eprintln!("Krutlet already exited.");
+                eprintln!("Krustlet already exited.");
                 return Ok(());
             }
             Ok(false) => (),
@@ -419,7 +420,7 @@ impl Drop for OwnedChildProcess {
 fn run_tests(readiness: BootstrapReadiness) -> anyhow::Result<()> {
     std::fs::create_dir_all(LOG_DIR)?;
     let wasi_process_result = launch_kubelet(
-        "krustlet-wasi",
+        NODE_NAME,
         "wasi",
         3001,
         matches!(readiness, BootstrapReadiness::NeedBootstrapAndApprove),
@@ -439,7 +440,7 @@ fn run_tests(readiness: BootstrapReadiness) -> anyhow::Result<()> {
     let test_result = run_test_suite(&mut wasi_process);
 
     if matches!(test_result, Err(_)) {
-        warn_if_premature_exit(&mut wasi_process, "krustlet-wasi");
+        warn_if_premature_exit(&mut wasi_process, NODE_NAME);
         // TODO: ideally we shouldn't have to wait for termination before getting logs
         match wasi_process.exited() {
             Ok(true) | Err(_) => (),

--- a/tests/pod_builder.rs
+++ b/tests/pod_builder.rs
@@ -45,6 +45,8 @@ pub enum WasmerciserVolumeSource {
     ConfigMapItems(&'static str, Vec<(&'static str, &'static str)>),
     Secret(&'static str),
     SecretItems(&'static str, Vec<(&'static str, &'static str)>),
+    #[cfg(target_os = "linux")]
+    Pvc(&'static str),
 }
 
 const DEFAULT_TEST_REGISTRY: &str = "webassembly";
@@ -133,6 +135,17 @@ fn wasmerciser_volume(
                 "secret": {
                     "secretName": name,
                     "items": items.iter().map(|(key, path)| json!({"key": key, "path": path})).collect::<Vec<_>>(),
+                }
+            }))?;
+
+            Ok((volume, None))
+        }
+        #[cfg(target_os = "linux")]
+        WasmerciserVolumeSource::Pvc(pvc_name) => {
+            let volume: Volume = serde_json::from_value(json!({
+                "name": spec.volume_name,
+                "persistentVolumeClaim": {
+                    "claimName": pvc_name
                 }
             }))?;
 


### PR DESCRIPTION
This PR adds e2e tests for the CSI code as part of our polishing for 1.0. Right now these tests only run on linux as some of the dependent components don't yet run on Mac. Also, the mock driver would need to use all of our ugly Windows socket code so we don't test it there either. Basically this is all a bit ugly, but it does exercise basic testing of the CSI components of the system. I also updated `podsmiter` to account for the new resources we are creating.

Closes #579 