### PR TITLE
Wasmerciser: allow writing files or EVs out directly

### DIFF
--- a/demos/wasi/wasmerciser/src/syntax.rs
+++ b/demos/wasi/wasmerciser/src/syntax.rs
@@ -84,7 +84,7 @@ impl Command {
                     Value::parse(value.to_string())?,
                 ))
             }
-            _ => Err(anyhow::anyhow!("unexpected read command syntax")),
+            _ => Err(anyhow::anyhow!("unexpected assert_value command syntax")),
         }
     }
 
@@ -110,7 +110,7 @@ impl Command {
                     DataDestination::parse(destination.to_string())?,
                 ))
             }
-            _ => Err(anyhow::anyhow!("unexpected read command syntax")),
+            _ => Err(anyhow::anyhow!("unexpected write command syntax")),
         }
     }
 }

--- a/demos/wasi/wasmerciser/src/syntax.rs
+++ b/demos/wasi/wasmerciser/src/syntax.rs
@@ -68,10 +68,12 @@ impl Command {
 
     fn parse_assert_not_exists(tokens: &[CommandToken]) -> anyhow::Result<Self> {
         match &tokens[..] {
-            [_, CommandToken::Bracketed(source)] => {
-                Ok(Self::AssertNotExists(DataSource::parse(source.to_string())?))
-            }
-            _ => Err(anyhow::anyhow!("unexpected assert_not_exists command syntax")),
+            [_, CommandToken::Bracketed(source)] => Ok(Self::AssertNotExists(DataSource::parse(
+                source.to_string(),
+            )?)),
+            _ => Err(anyhow::anyhow!(
+                "unexpected assert_not_exists command syntax"
+            )),
         }
     }
 
@@ -121,7 +123,10 @@ impl DataSource {
         match bits[..] {
             ["file", f] => Ok(DataSource::File(f.to_string())),
             ["env", e] => Ok(DataSource::Env(e.to_string())),
-            _ => Err(anyhow::anyhow!("invalid data source: {} (must be file/env)", &text)),
+            _ => Err(anyhow::anyhow!(
+                "invalid data source: {} (must be file/env)",
+                &text
+            )),
         }
     }
 }
@@ -133,7 +138,10 @@ impl DataDestination {
             ["file", f] => Ok(DataDestination::File(f.to_string())),
             ["stm", "stdout"] => Ok(DataDestination::StdOut),
             ["stm", "stderr"] => Ok(DataDestination::StdErr),
-            _ => Err(anyhow::anyhow!("invalid write destination: {} (must be file/stm)", &text)),
+            _ => Err(anyhow::anyhow!(
+                "invalid write destination: {} (must be file/stm)",
+                &text
+            )),
         }
     }
 }
@@ -143,7 +151,10 @@ impl Variable {
         let bits: Vec<&str> = text.split(':').collect();
         match bits[..] {
             ["var", v] => Ok(Variable::Variable(v.to_string())),
-            _ => Err(anyhow::anyhow!("invalid variable reference: {} (must be var)", &text)),
+            _ => Err(anyhow::anyhow!(
+                "invalid variable reference: {} (must be var)",
+                &text
+            )),
         }
     }
 }
@@ -154,7 +165,10 @@ impl Value {
         match bits[..] {
             ["var", v] => Ok(Self::Variable(v.to_string())),
             ["lit", t] => Ok(Self::Literal(t.to_string())),
-            _ => Err(anyhow::anyhow!("invalid value: {} (must be var/lit)", &text)),
+            _ => Err(anyhow::anyhow!(
+                "invalid value: {} (must be var/lit)",
+                &text
+            )),
         }
     }
 }
@@ -167,7 +181,10 @@ impl ValueSource {
             ["env", e] => Ok(Self::Env(e.to_string())),
             ["var", v] => Ok(Self::Variable(v.to_string())),
             ["lit", t] => Ok(Self::Literal(t.to_string())),
-            _ => Err(anyhow::anyhow!("invalid value source: {} (must be file/env/var/lit)", &text)),
+            _ => Err(anyhow::anyhow!(
+                "invalid value source: {} (must be file/env/var/lit)",
+                &text
+            )),
         }
     }
 }

--- a/demos/wasi/wasmerciser/src/syntax.rs
+++ b/demos/wasi/wasmerciser/src/syntax.rs
@@ -7,6 +7,30 @@ pub enum Command {
     Write(Value, DataDestination),
 }
 
+#[derive(Debug, PartialEq)]
+pub enum DataSource {
+    File(String),
+    Env(String),
+}
+
+#[derive(Debug, PartialEq)]
+pub enum DataDestination {
+    File(String),
+    StdOut,
+    StdErr,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Variable {
+    Variable(String),
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Value {
+    Variable(String),
+    Literal(String),
+}
+
 impl Command {
     pub fn parse(text: String) -> anyhow::Result<Self> {
         let tokens = CommandToken::parse(text)?;
@@ -81,30 +105,6 @@ impl Command {
             _ => Err(anyhow::anyhow!("unexpected read command syntax")),
         }
     }
-}
-
-#[derive(Debug, PartialEq)]
-pub enum DataSource {
-    File(String),
-    Env(String),
-}
-
-#[derive(Debug, PartialEq)]
-pub enum DataDestination {
-    File(String),
-    StdOut,
-    StdErr,
-}
-
-#[derive(Debug, PartialEq)]
-pub enum Variable {
-    Variable(String),
-}
-
-#[derive(Debug, PartialEq)]
-pub enum Value {
-    Variable(String),
-    Literal(String),
 }
 
 impl DataSource {

--- a/demos/wasi/wasmerciser/src/syntax.rs
+++ b/demos/wasi/wasmerciser/src/syntax.rs
@@ -121,7 +121,7 @@ impl DataSource {
         match bits[..] {
             ["file", f] => Ok(DataSource::File(f.to_string())),
             ["env", e] => Ok(DataSource::Env(e.to_string())),
-            _ => Err(anyhow::anyhow!("invalid data source")),
+            _ => Err(anyhow::anyhow!("invalid data source: {} (must be file/env)", &text)),
         }
     }
 }
@@ -133,7 +133,7 @@ impl DataDestination {
             ["file", f] => Ok(DataDestination::File(f.to_string())),
             ["stm", "stdout"] => Ok(DataDestination::StdOut),
             ["stm", "stderr"] => Ok(DataDestination::StdErr),
-            _ => Err(anyhow::anyhow!("invalid write destination")),
+            _ => Err(anyhow::anyhow!("invalid write destination: {} (must be file/stm)", &text)),
         }
     }
 }
@@ -143,7 +143,7 @@ impl Variable {
         let bits: Vec<&str> = text.split(':').collect();
         match bits[..] {
             ["var", v] => Ok(Variable::Variable(v.to_string())),
-            _ => Err(anyhow::anyhow!("invalid variable reference")),
+            _ => Err(anyhow::anyhow!("invalid variable reference: {} (must be var)", &text)),
         }
     }
 }
@@ -154,7 +154,7 @@ impl Value {
         match bits[..] {
             ["var", v] => Ok(Self::Variable(v.to_string())),
             ["lit", t] => Ok(Self::Literal(t.to_string())),
-            _ => Err(anyhow::anyhow!("invalid value")),
+            _ => Err(anyhow::anyhow!("invalid value: {} (must be var/lit)", &text)),
         }
     }
 }
@@ -167,7 +167,7 @@ impl ValueSource {
             ["env", e] => Ok(Self::Env(e.to_string())),
             ["var", v] => Ok(Self::Variable(v.to_string())),
             ["lit", t] => Ok(Self::Literal(t.to_string())),
-            _ => Err(anyhow::anyhow!("invalid data source")),
+            _ => Err(anyhow::anyhow!("invalid value source: {} (must be file/env/var/lit)", &text)),
         }
     }
 }


### PR DESCRIPTION
At the moment, the wasmerciser `write` instruction only accepts variables or literals.  So if you want to dump a file to stdout, you have to read it into a variable first, then write the variable to stdout.  This was okay for most early use cases, but it was a non-obvious limitation - too easy to write `write(file:/test.txt)to(stm:stdout)` and get a mystifying error.

This PR does two things:

1. Enables `file` or a `env` as sources in the `write` instruction
2. Improves parse errors for all instructions, e.g. by listing permitted options

NOTE: if this PR is accepted we will need to build and push a new wasmerciser image.  This is still a manual process per the readme.