### PR TITLE
Expose pull_manifest in public API.

### DIFF
--- a/crates/oci-distribution/src/client.rs
+++ b/crates/oci-distribution/src/client.rs
@@ -406,6 +406,9 @@ impl Client {
     ///
     /// The client will check if it's already been authenticated and if
     /// not will attempt to do.
+    ///
+    /// A Tuple is returned containing the [OciManifest](crate::manifest::OciManifest)
+    /// and the manifest content digest hash.
     pub async fn pull_manifest(
         &mut self,
         image: &Reference,
@@ -487,6 +490,10 @@ impl Client {
     ///
     /// The client will check if it's already been authenticated and if
     /// not will attempt to do.
+    ///
+    /// A Tuple is returned containing the [OciManifest](crate::manifest::OciManifest),
+    /// the manifest content digest hash and the contents of the manifests config layer
+    /// as a String.
     pub async fn pull_manifest_and_config(
         &mut self,
         image: &Reference,

--- a/crates/oci-distribution/src/client.rs
+++ b/crates/oci-distribution/src/client.rs
@@ -437,8 +437,6 @@ impl Client {
                 let digest = digest_header_value(&res)?;
                 let text = res.text().await?;
 
-                println!("Manifest Response: {}", text);
-
                 self.validate_image_manifest(&text).await?;
 
                 debug!("Parsing response as OciManifest: {}", text);

--- a/crates/oci-distribution/src/lib.rs
+++ b/crates/oci-distribution/src/lib.rs
@@ -11,7 +11,7 @@ pub mod secrets;
 #[doc(inline)]
 pub use client::Client;
 #[doc(inline)]
-pub use reference::Reference;
+pub use reference::{ParseError, Reference};
 
 #[macro_use]
 extern crate lazy_static;

--- a/crates/oci-distribution/src/reference.rs
+++ b/crates/oci-distribution/src/reference.rs
@@ -8,15 +8,24 @@ use crate::regexp;
 /// NAME_TOTAL_LENGTH_MAX is the maximum total number of characters in a repository name.
 const NAME_TOTAL_LENGTH_MAX: usize = 255;
 
+/// Reasons that parsing a string as a Reference can fail.
 #[derive(Debug, PartialEq, Eq)]
 pub enum ParseError {
+    /// Invalid checksum digest format
     DigestInvalidFormat,
+    /// Invalid checksum digest length
     DigestInvalidLength,
+    /// Unsupported digest algorithm
     DigestUnsupported,
+    /// Repository name must be lowercase
     NameContainsUppercase,
+    /// Repository name must have at least one component
     NameEmpty,
+    /// Repository name must not be more than NAME_TOTAL_LENGTH_MAX characters
     NameTooLong,
+    /// Invalid reference format
     ReferenceInvalidFormat,
+    /// Invalid tag format
     TagInvalidFormat,
 }
 


### PR DESCRIPTION
Also add a new public helper to pull OciManifest and the config JSON blob referenced by an OciManifest and expose `ParseError` so that `Reference` can be used more freely outside of `oci_distribution`.