### PR TITLE
Updated default aks version to 1.20.7

### DIFF
--- a/contrib/azure/azuredeploy.parameters.json
+++ b/contrib/azure/azuredeploy.parameters.json
@@ -18,7 +18,7 @@
 			"value": null
 		},
 		"kubernetesVersion": {
-			"value": "1.18.10"
+			"value": "1.20.7"
 		},
 		"krustletURL": {
 			"value": "https://krustlet.blob.core.windows.net/releases/krustlet-v0.6.0-linux-amd64.tar.gz"


### PR DESCRIPTION
1.18.10 is deprecated, so the demo fails by default right now.