### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# This file is described here:  https://help.github.com/en/articles/about-code-owners
+
+# Global Owners: These members are Core Maintainers of Krustlet
+* @thomastaylor312 @bacongobbler @kflansburg @technosophos


### PR DESCRIPTION
This PR adds a CODEOWNERS file to this repo, according to https://help.github.com/en/articles/about-code-owners.