### PR TITLE
Explicitly specify license in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ authors = [
 ]
 edition = "2018"
 default-run = "krustlet-wasi"
+license = "Apache-2.0"
 license-file = "LICENSE"
 description = "A Kubernetes kubelet implementation in Rust, used for running WebAssembly modules in Kubernetes"
 repository = "https://github.com/deislabs/krustlet"

--- a/crates/kubelet/Cargo.toml
+++ b/crates/kubelet/Cargo.toml
@@ -12,6 +12,7 @@ authors = [
     "Kevin Flansburg <kevin.flansburg@gmail.com>",
 ]
 edition = "2018"
+license = "Apache-2.0"
 license-file = "../../LICENSE"
 description = "A Kubernetes kubelet implementation in Rust"
 repository = "https://github.com/deislabs/krustlet"

--- a/crates/oci-distribution/Cargo.toml
+++ b/crates/oci-distribution/Cargo.toml
@@ -12,6 +12,7 @@ authors = [
     "Kevin Flansburg <kevin.flansburg@gmail.com>",
 ]
 edition = "2018"
+license = "Apache-2.0"
 license-file = "../../LICENSE"
 description = "An OCI implementation in Rust"
 repository = "https://github.com/deislabs/krustlet"


### PR DESCRIPTION
This will allow `cargo-deny` to run without issues.

The docs (https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields) are also not entirely clear: "If a package is using a nonstandard license, then the license-file field may be specified in lieu of the license field."

I decided to leave `license-file` in.