### PR TITLE
Remove k8s-openapi version feature from kubelet

### DIFF
--- a/crates/kubelet/Cargo.toml
+++ b/crates/kubelet/Cargo.toml
@@ -49,7 +49,7 @@ http = "0.2"
 hyper = {version = "0.14", default-features = false, features = ["stream"]}
 json-patch = "0.2"
 k8s-csi = "0.4"
-k8s-openapi = {version = "0.13", default-features = false, features = ["v1_22", "api"]}
+k8s-openapi = {version = "0.13", default-features = false, features = ["api"]}
 krator = {version = "0.5", default-features = false}
 kube = {version = "0.60", default-features = false, features = ["jsonpatch"]}
 kube-runtime = {version = "0.60", default-features = false}
@@ -99,6 +99,11 @@ version-sync = "0.5"
 reqwest = {version = "0.11", default-features = false}
 tempfile = "3.1"
 tower-test = "0.4"
+
+[dev-dependencies.k8s-openapi]
+version = "0.13"
+default-features = false
+features = ["v1_22"]
 
 [build-dependencies]
 tonic-build = "0.5"


### PR DESCRIPTION
Closes #612 

I think this is all we need, `kubelet` and `wasi-provider` crates now only specify the version feature in dev-dependencies. 

Our binaries are compiled with the specific version we test (1.22 right now). 

I verified that I can create new project which imports `kubelet` crate, and specify a different version without issues. 

The only missing component is that we discussed specifying a default version, and requiring the user to turn off default features to customize their API version. `k8s-openapi` is [pretty explicit](https://arnavion.github.io/k8s-openapi/v0.13.x/k8s_openapi/index.html#crate-features) that libraries should not specify version features. Would it be worth reaching out to the author to get their opinion? @bacongobbler  