### PR TITLE
update k8s.gcr.io to registry.k8s.io

### DIFF
--- a/crates/wasi-provider/src/lib.rs
+++ b/crates/wasi-provider/src/lib.rs
@@ -219,7 +219,7 @@ impl GenericProvider for WasiProvider {
         container: &kubelet::container::Container,
     ) -> anyhow::Result<()> {
         if let Some(image) = container.image()? {
-            if image.whole().starts_with("k8s.gcr.io/kube-proxy") {
+            if image.whole().starts_with("registry.k8s.io/kube-proxy") {
                 return Err(anyhow::anyhow!("Cannot run kube-proxy"));
             }
         }


### PR DESCRIPTION
This is a part of https://github.com/kubernetes/k8s.io/issues/4780 
All occurrences of `k8s.gcr.io` to `registry.k8s.io.`